### PR TITLE
Feature: Add category-based scheduling with configurable ratios (v1.4.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A self-hosted Instagram Story scheduling system with Telegram-based team collabo
 ## Features
 
 - 📅 **Smart Scheduling**: Intelligent posting schedule based on your preferences
+- 📁 **Category-Based Scheduling**: Organize media by folder (memes/, merch/) with configurable ratios
 - 📱 **Telegram Integration**: Team collaboration via Telegram bot with lifecycle notifications
 - 🔄 **Phased Approach**: Start with manual posting, optionally enable automation
 - 🔒 **TTL Locks**: Prevent premature reposts with 30-day locks
@@ -110,7 +111,7 @@ storyline-cli validate-image /path/to/image.jpg
 ### Queue Management
 
 ```bash
-# Create posting schedule
+# Create posting schedule (uses category ratios)
 storyline-cli create-schedule --days 7
 
 # Process pending posts
@@ -121,6 +122,19 @@ storyline-cli process-queue --force
 
 # View queue
 storyline-cli list-queue
+```
+
+### Category Management
+
+```bash
+# List categories and their posting ratios
+storyline-cli list-categories
+
+# Update category posting ratios (interactive prompts)
+storyline-cli update-category-mix
+
+# View ratio history (Type 2 SCD)
+storyline-cli category-mix-history --limit 10
 ```
 
 ### User Management
@@ -181,7 +195,14 @@ The bot responds to these commands in Telegram:
 - ✅ 3-button layout: Posted, Skip, Reject
 - ✅ 7 new bot commands: `/pause`, `/resume`, `/schedule`, `/stats`, `/history`, `/locks`, `/clear`
 - ✅ Smart overdue handling when resuming after pause
-- ✅ 173 comprehensive tests
+
+**Phase 1.6** (Category Scheduling) - ✅ COMPLETE (v1.4.0):
+- ✅ Category-based media organization (folder structure → category)
+- ✅ Configurable posting ratios per category (e.g., 70% memes, 30% merch)
+- ✅ Type 2 SCD tracking for ratio history
+- ✅ Interactive ratio configuration during indexing
+- ✅ Scheduler integration with category-aware slot allocation
+- ✅ 268 comprehensive tests
 
 **Phase 2** (Hybrid Mode - Optional):
 - 🔄 Enable Instagram API for simple stories
@@ -193,7 +214,7 @@ The bot responds to these commands in Telegram:
 
 ### Running Tests
 
-The project includes 173 comprehensive tests with automatic test database setup:
+The project includes 268 comprehensive tests with automatic test database setup:
 
 ```bash
 # Run all tests with coverage
@@ -224,6 +245,9 @@ storyline-ai/
 ├── tests/                 # Test suite
 ├── scripts/               # Database scripts
 └── media/                 # Media storage
+    └── stories/           # Instagram stories
+        ├── memes/         # Meme content
+        └── merch/         # Merchandise content
 ```
 
 ## Documentation

--- a/cli/commands/media.py
+++ b/cli/commands/media.py
@@ -2,50 +2,252 @@
 import click
 from rich.console import Console
 from rich.table import Table
+from rich.prompt import Prompt, Confirm
 from pathlib import Path
+from decimal import Decimal, InvalidOperation
 
 from src.services.core.media_ingestion import MediaIngestionService
 from src.repositories.media_repository import MediaRepository
+from src.repositories.category_mix_repository import CategoryMixRepository
 
 console = Console()
+
+
+def prompt_for_category_ratios(categories: list[str], current_ratios: dict = None) -> dict:
+    """
+    Prompt user to define ratios for each category.
+
+    Args:
+        categories: List of category names
+        current_ratios: Optional dict of existing ratios to show as defaults
+
+    Returns:
+        Dict of {category: Decimal ratio}
+    """
+    if not categories:
+        return {}
+
+    current_ratios = current_ratios or {}
+
+    cat_list = ", ".join(sorted(categories))
+    console.print(f"\n[bold]Categories based on folder structure:[/bold] [cyan]{cat_list}[/cyan]")
+    console.print("[dim]Ratios must sum to 100%[/dim]\n")
+
+    while True:
+        ratios = {}
+
+        for cat in sorted(categories):
+            default = current_ratios.get(cat)
+            default_hint = f" [dim](current: {float(default) * 100:.0f}%)[/dim]" if default else ""
+            console.print(f"What % would you like [cyan]'{cat}'[/cyan]?{default_hint}")
+
+            while True:
+                value = Prompt.ask("  ")
+
+                # Use default if empty and default exists
+                if not value and default:
+                    ratios[cat] = default
+                    break
+
+                try:
+                    pct = float(value)
+                    if pct < 0 or pct > 100:
+                        console.print("[red]  Enter a value between 0 and 100[/red]")
+                        continue
+                    ratios[cat] = Decimal(str(pct / 100))
+                    break
+                except (ValueError, InvalidOperation):
+                    console.print("[red]  Invalid number. Enter a percentage (e.g., 70)[/red]")
+
+        # Validate sum
+        total = sum(ratios.values())
+        total_pct = float(total) * 100
+
+        if abs(total_pct - 100) < 0.1:  # Allow small tolerance
+            # Normalize to exactly 1.0
+            if total != Decimal("1"):
+                # Adjust the largest ratio to make sum exactly 1.0
+                largest_cat = max(ratios, key=lambda k: ratios[k])
+                ratios[largest_cat] += Decimal("1") - total
+
+            console.print(f"\n[green]✓ Ratios sum to 100%[/green]")
+            return ratios
+        else:
+            console.print(f"\n[red]✗ Ratios sum to {total_pct:.1f}%, must equal 100%[/red]")
+            if not Confirm.ask("Try again?", default=True):
+                raise click.Abort()
+
+
+def display_current_mix(mix_repo: CategoryMixRepository, media_repo: MediaRepository):
+    """Display the current category mix with media counts."""
+    current_mix = mix_repo.get_current_mix()
+
+    if not current_mix:
+        console.print("[yellow]No category mix configured yet[/yellow]")
+        return False
+
+    table = Table(title="Current Category Mix")
+    table.add_column("Category", style="cyan")
+    table.add_column("Ratio", justify="right")
+    table.add_column("Media Count", justify="right", style="dim")
+
+    for mix in current_mix:
+        count = len(media_repo.get_all(category=mix.category))
+        table.add_row(
+            mix.category,
+            f"{float(mix.ratio) * 100:.0f}%",
+            str(count),
+        )
+
+    console.print(table)
+    return True
 
 
 @click.command(name="index-media")
 @click.argument("directory", type=click.Path(exists=True))
 @click.option("--recursive/--no-recursive", default=True, help="Scan subdirectories")
-def index(directory, recursive):
-    """Index media files from a directory."""
+@click.option(
+    "--extract-category/--no-extract-category",
+    default=True,
+    help="Extract category from subfolder names",
+)
+def index(directory, recursive, extract_category):
+    """Index media files from a directory.
+
+    Categories are automatically extracted from immediate subdirectory names.
+    For example, media/stories/memes/image.jpg will have category "memes".
+
+    After indexing, you'll be prompted to define posting ratios for each category.
+    """
     console.print(f"[bold blue]Indexing media from:[/bold blue] {directory}")
+    if extract_category:
+        console.print("[dim]Category extraction enabled (from subfolder names)[/dim]")
 
     service = MediaIngestionService()
+    media_repo = MediaRepository()
+    mix_repo = CategoryMixRepository()
 
     try:
-        result = service.scan_directory(directory, recursive=recursive)
+        result = service.scan_directory(
+            directory, recursive=recursive, extract_category=extract_category
+        )
 
         console.print(f"\n[bold green]✓ Indexing complete![/bold green]")
         console.print(f"  Indexed: {result['indexed']}")
         console.print(f"  Skipped: {result['skipped']}")
         console.print(f"  Errors: {result['errors']}")
 
+        discovered_categories = result.get("categories", [])
+        if discovered_categories:
+            console.print(f"  Categories: {', '.join(discovered_categories)}")
+
+        # Get all categories in the database (might include previously indexed ones)
+        all_categories = media_repo.get_categories()
+
+        if not all_categories:
+            console.print("\n[yellow]No categories found in media library[/yellow]")
+            return
+
+        # Check if mix already exists
+        has_mix = mix_repo.has_current_mix()
+        current_ratios = mix_repo.get_current_mix_as_dict() if has_mix else {}
+
+        # Check for new categories without ratios
+        new_categories = mix_repo.get_categories_without_ratio(all_categories)
+
+        if has_mix and not new_categories:
+            # Existing mix covers all categories
+            console.print("\n[bold]Current category mix:[/bold]")
+            display_current_mix(mix_repo, media_repo)
+
+            if Confirm.ask("\nKeep current ratios?", default=True):
+                console.print("[green]✓ Keeping existing ratios[/green]")
+                return
+            # Fall through to redefine
+
+        elif new_categories:
+            console.print(f"\n[yellow]New categories detected: {', '.join(new_categories)}[/yellow]")
+            if has_mix:
+                console.print("[dim]Current ratios will need to be updated[/dim]")
+
+        # Prompt for ratios
+        ratios = prompt_for_category_ratios(all_categories, current_ratios)
+
+        # Save the new mix
+        mix_repo.set_mix(ratios)
+
+        console.print("\n[bold green]✓ Category mix saved![/bold green]")
+        display_current_mix(mix_repo, media_repo)
+
     except Exception as e:
         console.print(f"[bold red]✗ Error:[/bold red] {str(e)}")
         raise click.Abort()
 
 
+@click.command(name="update-category-mix")
+def update_category_mix():
+    """Update the posting ratio mix for categories.
+
+    Opens a workflow to redefine what percentage of posts
+    should come from each category.
+    """
+    media_repo = MediaRepository()
+    mix_repo = CategoryMixRepository()
+
+    categories = media_repo.get_categories()
+
+    if not categories:
+        console.print("[yellow]No categories found. Run index-media first.[/yellow]")
+        return
+
+    console.print("[bold blue]Update Category Mix[/bold blue]")
+    console.print(f"Categories in library: {', '.join(sorted(categories))}\n")
+
+    # Show current mix
+    has_mix = display_current_mix(mix_repo, media_repo)
+
+    if has_mix:
+        if not Confirm.ask("\nRedefine ratios?", default=True):
+            return
+
+    current_ratios = mix_repo.get_current_mix_as_dict()
+    ratios = prompt_for_category_ratios(categories, current_ratios)
+
+    # Save
+    mix_repo.set_mix(ratios)
+
+    console.print("\n[bold green]✓ Category mix updated![/bold green]")
+    display_current_mix(mix_repo, media_repo)
+
+
 @click.command(name="list-media")
 @click.option("--limit", default=20, help="Number of items to show")
 @click.option("--active-only", is_flag=True, help="Show only active media")
-def list_media(limit, active_only):
+@click.option("--category", "-c", help="Filter by category (e.g., 'memes' or 'merch')")
+def list_media(limit, active_only, category):
     """List indexed media items."""
     repo = MediaRepository()
-    items = repo.get_all(is_active=True if active_only else None, limit=limit)
+    items = repo.get_all(
+        is_active=True if active_only else None,
+        category=category,
+        limit=limit,
+    )
 
     if not items:
-        console.print("[yellow]No media items found[/yellow]")
+        msg = "[yellow]No media items found"
+        if category:
+            msg += f" in category '{category}'"
+        msg += "[/yellow]"
+        console.print(msg)
         return
 
-    table = Table(title=f"Media Items (showing {len(items)})")
+    title = f"Media Items (showing {len(items)})"
+    if category:
+        title += f" - Category: {category}"
+
+    table = Table(title=title)
     table.add_column("File Name", style="cyan")
+    table.add_column("Category", style="magenta")
     table.add_column("Times Posted", justify="right")
     table.add_column("Last Posted", justify="right")
     table.add_column("Active", justify="center")
@@ -53,8 +255,75 @@ def list_media(limit, active_only):
     for item in items:
         last_posted = item.last_posted_at.strftime("%Y-%m-%d") if item.last_posted_at else "Never"
         active = "✓" if item.is_active else "✗"
+        cat = item.category or "-"
 
-        table.add_row(item.file_name[:40], str(item.times_posted), last_posted, active)
+        table.add_row(item.file_name[:40], cat, str(item.times_posted), last_posted, active)
+
+    console.print(table)
+
+
+@click.command(name="list-categories")
+def list_categories():
+    """List all media categories with their posting ratios."""
+    media_repo = MediaRepository()
+    mix_repo = CategoryMixRepository()
+
+    categories = media_repo.get_categories()
+
+    if not categories:
+        console.print("[yellow]No categories found[/yellow]")
+        return
+
+    current_mix = mix_repo.get_current_mix_as_dict()
+
+    table = Table(title="Media Categories")
+    table.add_column("Category", style="cyan")
+    table.add_column("Media Count", justify="right")
+    table.add_column("Post Ratio", justify="right", style="magenta")
+
+    for cat in sorted(categories):
+        count = len(media_repo.get_all(category=cat))
+        ratio = current_mix.get(cat)
+        ratio_str = f"{float(ratio) * 100:.0f}%" if ratio else "[dim]not set[/dim]"
+        table.add_row(cat, str(count), ratio_str)
+
+    console.print(table)
+
+    if not current_mix:
+        console.print("\n[yellow]Tip: Run 'update-category-mix' to set posting ratios[/yellow]")
+
+
+@click.command(name="category-mix-history")
+@click.option("--category", "-c", help="Filter by specific category")
+def category_mix_history(category):
+    """Show history of category mix changes (Type 2 SCD)."""
+    mix_repo = CategoryMixRepository()
+
+    history = mix_repo.get_history(category=category)
+
+    if not history:
+        console.print("[yellow]No category mix history found[/yellow]")
+        return
+
+    table = Table(title="Category Mix History")
+    table.add_column("Category", style="cyan")
+    table.add_column("Ratio", justify="right")
+    table.add_column("Effective From", justify="right")
+    table.add_column("Effective To", justify="right")
+    table.add_column("Status", justify="center")
+
+    for record in history:
+        eff_from = record.effective_from.strftime("%Y-%m-%d %H:%M")
+        eff_to = record.effective_to.strftime("%Y-%m-%d %H:%M") if record.effective_to else "-"
+        status = "[green]current[/green]" if record.is_current else "[dim]expired[/dim]"
+
+        table.add_row(
+            record.category,
+            f"{float(record.ratio) * 100:.0f}%",
+            eff_from,
+            eff_to,
+            status,
+        )
 
     console.print(table)
 

--- a/cli/main.py
+++ b/cli/main.py
@@ -13,7 +13,14 @@ def cli():
 
 
 # Import commands
-from cli.commands.media import index, list_media, validate
+from cli.commands.media import (
+    index,
+    list_media,
+    validate,
+    list_categories,
+    update_category_mix,
+    category_mix_history,
+)
 from cli.commands.queue import create_schedule, process_queue, list_queue
 from cli.commands.users import list_users, promote_user
 from cli.commands.health import check_health
@@ -21,6 +28,9 @@ from cli.commands.health import check_health
 # Add commands to CLI
 cli.add_command(index)
 cli.add_command(list_media)
+cli.add_command(list_categories)
+cli.add_command(update_category_mix)
+cli.add_command(category_mix_history)
 cli.add_command(validate)
 cli.add_command(create_schedule)
 cli.add_command(process_queue)

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -93,6 +93,13 @@ Coming soon:
 
 ## 🔄 Project Updates
 
+### Feature Updates
+**[2026-01-10-category-scheduling.md](updates/2026-01-10-category-scheduling.md)**
+- Category-based media organization (folder → category extraction)
+- Configurable posting ratios per category (Type 2 SCD)
+- Scheduler integration with category-aware slot allocation
+- New CLI commands: `list-categories`, `update-category-mix`, `category-mix-history`
+
 ### Bug Fixes & Patches
 **[2026-01-04-bugfixes.md](updates/2026-01-04-bugfixes.md)**
 - 4 critical bugs fixed (service run metadata, scheduler date mutation, health check, lock creation)
@@ -186,9 +193,10 @@ Current documentation status:
 
 | Area | Coverage | Files |
 |------|----------|-------|
-| **Planning** | ✅ Complete | 2 files |
+| **Planning** | ✅ Complete | 3 files |
 | **Getting Started** | ✅ Complete | 3 guides |
 | **Testing** | ✅ Complete | 2 guides |
+| **Updates** | ✅ Current | 2 files |
 | **Operations** | 🚧 Planned | 0 files |
 | **API Docs** | ⏳ Phase 5 | 0 files |
 
@@ -203,4 +211,4 @@ Current documentation status:
 
 ---
 
-*Last updated: 2026-01-06*
+*Last updated: 2026-01-10*

--- a/documentation/updates/2026-01-10-category-scheduling.md
+++ b/documentation/updates/2026-01-10-category-scheduling.md
@@ -1,0 +1,275 @@
+# Category-Based Scheduling Feature
+
+**Date**: 2026-01-10
+**Version**: 1.4.0
+**Phase**: 1.6
+
+## Overview
+
+This update introduces category-based media organization and configurable posting ratios. Media is now organized into categories based on folder structure (e.g., `memes/`, `merch/`), and the scheduler allocates posting slots according to configured ratios.
+
+## Features Added
+
+### 1. Category Extraction from Folder Structure
+
+Media files are now automatically categorized based on their folder location during indexing.
+
+**Folder Structure:**
+```
+media/stories/
+├── memes/        → category: "memes"
+│   ├── image1.jpg
+│   └── image2.png
+└── merch/        → category: "merch"
+    ├── product1.jpg
+    └── product2.png
+```
+
+**How it works:**
+- During `index-media`, the first-level subfolder becomes the category
+- Files directly in the base directory get `category: NULL`
+- Category is stored in the `media_items.category` column
+
+### 2. Posting Ratios (Type 2 SCD)
+
+Configure what percentage of posts should come from each category.
+
+**Example Configuration:**
+- memes: 70%
+- merch: 30%
+
+**Database Design:**
+The `category_post_case_mix` table uses Type 2 Slowly Changing Dimension design:
+- Maintains full history of ratio changes
+- `is_current = true` for active ratios
+- `effective_from` / `effective_to` for temporal queries
+- Supports auditing and analytics
+
+**Validation:**
+- All active ratios must sum to 100% (1.0)
+- Ratios stored as decimals (0.70 = 70%)
+- Validation occurs before saving
+
+### 3. Scheduler Integration
+
+The scheduler now allocates slots based on configured ratios.
+
+**Algorithm:**
+1. Generate time slots for the scheduling period
+2. Allocate slots to categories based on ratios (deterministic)
+3. Shuffle allocation for variety
+4. Select media from each category
+5. Fall back to any category if target is exhausted
+
+**Example:**
+With 21 total slots and 70/30 ratio:
+- 15 slots allocated to memes (70% × 21 ≈ 15)
+- 6 slots allocated to merch (30% × 21 ≈ 6)
+- Slots are shuffled so posts alternate between categories
+
+### 4. New CLI Commands
+
+#### `list-categories`
+Show all categories with media counts and posting ratios.
+
+```bash
+storyline-cli list-categories
+```
+
+Output:
+```
+Categories (2 found):
+  Category    Items    Ratio
+  memes       1287     70.00%
+  merch       45       30.00%
+```
+
+#### `update-category-mix`
+Interactively update posting ratios.
+
+```bash
+storyline-cli update-category-mix
+```
+
+Prompts:
+```
+What % would you like 'memes'? 70
+What % would you like 'merch'? 30
+✓ Category mix updated!
+```
+
+#### `category-mix-history`
+View history of ratio changes (Type 2 SCD).
+
+```bash
+storyline-cli category-mix-history --limit 10
+```
+
+### 5. Enhanced Existing Commands
+
+#### `index-media`
+- Now extracts categories from folder structure
+- Prompts for ratio configuration after indexing new categories
+
+#### `create-schedule`
+- Shows category breakdown in output
+- Logs allocation summary
+
+#### `list-queue`
+- Added category column to queue display
+
+## Database Changes
+
+### New Column: `media_items.category`
+```sql
+ALTER TABLE media_items ADD COLUMN category TEXT;
+CREATE INDEX idx_media_items_category ON media_items(category);
+```
+
+### New Table: `category_post_case_mix`
+```sql
+CREATE TABLE category_post_case_mix (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    category VARCHAR(100) NOT NULL,
+    ratio NUMERIC(5, 4) NOT NULL,
+    effective_from TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    effective_to TIMESTAMP,  -- NULL = currently active
+    is_current BOOLEAN DEFAULT TRUE,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    created_by_user_id UUID REFERENCES users(id),
+    CONSTRAINT check_ratio_range CHECK (ratio >= 0 AND ratio <= 1)
+);
+```
+
+## Migration
+
+### For Existing Installations
+
+Run the migration scripts:
+
+```bash
+# Add category column
+psql -d storyline_ai -f scripts/migrations/001_add_category_column.sql
+
+# Create ratio table
+psql -d storyline_ai -f scripts/migrations/002_add_category_post_case_mix.sql
+```
+
+### For Fresh Installations
+
+The `scripts/setup_database.sql` has been updated to include all new schema elements.
+
+```bash
+make reset-db
+```
+
+## New Components
+
+### Models
+- `src/models/category_mix.py` - CategoryPostCaseMix SQLAlchemy model
+
+### Repositories
+- `src/repositories/category_mix_repository.py` - Type 2 SCD operations
+  - `get_current_mix()` - Get active ratios
+  - `get_current_mix_as_dict()` - Get as {category: ratio} dict
+  - `set_mix()` - Set new ratios (creates SCD records)
+  - `get_history()` - Get all historical records
+
+### Services
+- `SchedulerService` - Enhanced with category-aware allocation
+  - `_allocate_slots_to_categories()` - Ratio-based slot allocation
+  - `_select_media_from_pool()` - Category-filtered selection
+  - `_select_media()` - Category with fallback logic
+
+### CLI
+- `cli/commands/media.py` - New category commands and prompts
+
+## Testing
+
+34 new tests added:
+
+- **Category extraction** (7 tests)
+  - Extract from folder structure
+  - Handle nested folders
+  - Handle files in root directory
+
+- **CategoryMixRepository** (18 tests)
+  - CRUD operations
+  - Ratio validation
+  - Type 2 SCD behavior
+  - History tracking
+
+- **Scheduler category allocation** (9 tests)
+  - Slot allocation by ratio
+  - Rounding handling
+  - Fallback when exhausted
+  - Empty ratio handling
+
+**Total test count: 173 → 268**
+
+## Usage Example
+
+### Complete Workflow
+
+1. **Organize media into folders:**
+   ```
+   media/stories/
+   ├── memes/    (your meme content)
+   └── merch/    (product photos)
+   ```
+
+2. **Index media with category extraction:**
+   ```bash
+   storyline-cli index-media /path/to/media/stories
+   ```
+
+3. **Configure posting ratios when prompted:**
+   ```
+   What % would you like 'memes'? 70
+   What % would you like 'merch'? 30
+   ✓ Category mix updated!
+   ```
+
+4. **Create schedule (uses ratios automatically):**
+   ```bash
+   storyline-cli create-schedule --days 7
+
+   ✓ Schedule created!
+     Scheduled: 21
+     Category breakdown:
+       • memes: 15 (71%)
+       • merch: 6 (29%)
+   ```
+
+5. **View queue with categories:**
+   ```bash
+   storyline-cli list-queue
+   ```
+
+## Technical Notes
+
+### Rounding Behavior
+When allocating slots, the last category receives remaining slots to ensure the total matches. For example, with 21 slots and 70/30:
+- memes: round(0.7 × 21) = 15
+- merch: remaining = 21 - 15 = 6
+
+### Fallback Behavior
+If a category is exhausted (all media locked/queued), the scheduler falls back to any available media from other categories. This ensures schedules are always filled.
+
+### SCD Benefits
+Type 2 SCD design enables:
+- Auditing: "Who changed the ratios and when?"
+- Analytics: "What was the ratio when this post was scheduled?"
+- Rollback: Easy to see previous configurations
+
+## Known Limitations
+
+1. **Single-level categories**: Only first-level subfolders become categories. Nested folders like `memes/funny/` still map to `memes`.
+
+2. **No ratio scheduling by time**: Ratios are static across the schedule. Future enhancement could support different ratios for different times/days.
+
+3. **Manual ratio updates**: Ratios must be set via CLI. Future Telegram bot command could be added.
+
+---
+
+*For the complete CHANGELOG entry, see [CHANGELOG.md](../../CHANGELOG.md)*

--- a/scripts/migrations/001_add_category_column.sql
+++ b/scripts/migrations/001_add_category_column.sql
@@ -1,0 +1,23 @@
+-- Migration: Add category column to media_items
+-- Description: Stores the category extracted from folder structure during indexing
+-- Date: 2026-01-10
+
+-- Add the category column
+ALTER TABLE media_items
+ADD COLUMN IF NOT EXISTS category TEXT;
+
+-- Create index for efficient category queries
+CREATE INDEX IF NOT EXISTS idx_media_items_category ON media_items(category);
+
+-- Record migration in schema_version if table exists
+-- (Create the table if it doesn't exist)
+CREATE TABLE IF NOT EXISTS schema_version (
+    version INTEGER PRIMARY KEY,
+    description TEXT NOT NULL,
+    applied_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Record this migration
+INSERT INTO schema_version (version, description)
+VALUES (1, 'Add category column to media_items')
+ON CONFLICT (version) DO NOTHING;

--- a/scripts/migrations/002_add_category_post_case_mix.sql
+++ b/scripts/migrations/002_add_category_post_case_mix.sql
@@ -1,0 +1,41 @@
+-- Migration: Create category_post_case_mix table (Type 2 SCD)
+-- Description: Tracks posting ratio configuration per category with full history
+-- Date: 2026-01-10
+
+-- Create the category_post_case_mix table
+CREATE TABLE IF NOT EXISTS category_post_case_mix (
+    id UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+
+    -- Category name (matches media_items.category)
+    category VARCHAR(100) NOT NULL,
+
+    -- Ratio as decimal (0.70 = 70%)
+    ratio NUMERIC(5, 4) NOT NULL,
+
+    -- Type 2 SCD fields
+    effective_from TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    effective_to TIMESTAMP,  -- NULL = currently active
+    is_current BOOLEAN DEFAULT TRUE,
+
+    -- Audit fields
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    created_by_user_id UUID REFERENCES users(id),
+
+    -- Constraints
+    CONSTRAINT check_ratio_range CHECK (ratio >= 0 AND ratio <= 1)
+);
+
+-- Indexes for efficient queries
+CREATE INDEX IF NOT EXISTS idx_category_mix_category ON category_post_case_mix(category);
+CREATE INDEX IF NOT EXISTS idx_category_mix_is_current ON category_post_case_mix(is_current);
+CREATE INDEX IF NOT EXISTS idx_category_mix_effective_dates ON category_post_case_mix(effective_from, effective_to);
+
+-- Record migration
+INSERT INTO schema_version (version, description)
+VALUES (2, 'Add category_post_case_mix table (Type 2 SCD)')
+ON CONFLICT (version) DO NOTHING;
+
+-- Comment on table
+COMMENT ON TABLE category_post_case_mix IS 'Type 2 SCD table tracking posting ratio configuration per category. All current ratios must sum to 1.0.';
+COMMENT ON COLUMN category_post_case_mix.ratio IS 'Posting ratio as decimal (0.70 = 70% of posts will be from this category)';
+COMMENT ON COLUMN category_post_case_mix.is_current IS 'TRUE if this is the currently active ratio for this category';

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -6,6 +6,7 @@ from src.models.posting_history import PostingHistory
 from src.models.media_lock import MediaPostingLock
 from src.models.service_run import ServiceRun
 from src.models.user_interaction import UserInteraction
+from src.models.category_mix import CategoryPostCaseMix
 
 __all__ = [
     "User",
@@ -15,4 +16,5 @@ __all__ = [
     "MediaPostingLock",
     "ServiceRun",
     "UserInteraction",
+    "CategoryPostCaseMix",
 ]

--- a/src/models/category_mix.py
+++ b/src/models/category_mix.py
@@ -1,0 +1,47 @@
+"""Category post case mix model - Type 2 SCD for tracking posting ratio history."""
+from sqlalchemy import Column, String, Boolean, DateTime, Numeric, ForeignKey, CheckConstraint
+from sqlalchemy.dialects.postgresql import UUID
+from datetime import datetime
+import uuid
+
+from src.config.database import Base
+
+
+class CategoryPostCaseMix(Base):
+    """
+    Category posting ratio configuration with Type 2 SCD.
+
+    Tracks the desired posting ratio for each category over time.
+    When ratios change, old records are expired (effective_to set)
+    and new records are created, preserving full history.
+
+    All current (is_current=TRUE) ratios must sum to 1.0.
+    """
+
+    __tablename__ = "category_post_case_mix"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+
+    # Category name (matches media_items.category)
+    category = Column(String(100), nullable=False, index=True)
+
+    # Ratio as decimal (0.70 = 70%), precision 5 scale 4 allows 0.0000 to 9.9999
+    ratio = Column(Numeric(5, 4), nullable=False)
+
+    # Type 2 SCD fields
+    effective_from = Column(DateTime, nullable=False, default=datetime.utcnow)
+    effective_to = Column(DateTime, nullable=True)  # NULL = currently active
+    is_current = Column(Boolean, default=True, index=True)
+
+    # Audit fields
+    created_at = Column(DateTime, default=datetime.utcnow)
+    created_by_user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"))
+
+    # Constraints
+    __table_args__ = (
+        CheckConstraint("ratio >= 0 AND ratio <= 1", name="check_ratio_range"),
+    )
+
+    def __repr__(self):
+        status = "current" if self.is_current else f"expired {self.effective_to}"
+        return f"<CategoryPostCaseMix {self.category}={float(self.ratio)*100:.1f}% ({status})>"

--- a/src/models/media_item.py
+++ b/src/models/media_item.py
@@ -29,6 +29,9 @@ class MediaItem(Base):
     # Routing logic: determines auto vs manual posting
     requires_interaction = Column(Boolean, default=False)  # TRUE = send to Telegram, FALSE = auto-post
 
+    # Category: extracted from parent folder during indexing (e.g., "memes", "merch")
+    category = Column(Text, index=True)
+
     # Optional metadata (flexible for any use case)
     title = Column(Text)  # General purpose title (product name, meme title, etc.)
     link_url = Column(Text)  # Link for sticker (if requires_interaction = TRUE)

--- a/src/repositories/__init__.py
+++ b/src/repositories/__init__.py
@@ -6,6 +6,7 @@ from src.repositories.history_repository import HistoryRepository
 from src.repositories.lock_repository import LockRepository
 from src.repositories.service_run_repository import ServiceRunRepository
 from src.repositories.interaction_repository import InteractionRepository
+from src.repositories.category_mix_repository import CategoryMixRepository
 
 __all__ = [
     "UserRepository",
@@ -15,4 +16,5 @@ __all__ = [
     "LockRepository",
     "ServiceRunRepository",
     "InteractionRepository",
+    "CategoryMixRepository",
 ]

--- a/src/repositories/category_mix_repository.py
+++ b/src/repositories/category_mix_repository.py
@@ -1,0 +1,169 @@
+"""Category post case mix repository - CRUD with Type 2 SCD logic."""
+from typing import Optional, List, Dict
+from datetime import datetime
+from decimal import Decimal
+from sqlalchemy.orm import Session
+from sqlalchemy import func
+
+from src.config.database import get_db
+from src.models.category_mix import CategoryPostCaseMix
+
+
+class CategoryMixRepository:
+    """Repository for CategoryPostCaseMix with Type 2 SCD operations."""
+
+    def __init__(self):
+        self.db: Session = next(get_db())
+
+    def get_current_mix(self) -> List[CategoryPostCaseMix]:
+        """Get all current (active) category ratios."""
+        return (
+            self.db.query(CategoryPostCaseMix)
+            .filter(CategoryPostCaseMix.is_current == True)
+            .order_by(CategoryPostCaseMix.category)
+            .all()
+        )
+
+    def get_current_mix_as_dict(self) -> Dict[str, Decimal]:
+        """Get current mix as {category: ratio} dictionary."""
+        current = self.get_current_mix()
+        return {mix.category: mix.ratio for mix in current}
+
+    def get_category_ratio(self, category: str) -> Optional[Decimal]:
+        """Get current ratio for a specific category."""
+        mix = (
+            self.db.query(CategoryPostCaseMix)
+            .filter(
+                CategoryPostCaseMix.category == category,
+                CategoryPostCaseMix.is_current == True,
+            )
+            .first()
+        )
+        return mix.ratio if mix else None
+
+    def get_history(self, category: Optional[str] = None) -> List[CategoryPostCaseMix]:
+        """Get full history, optionally filtered by category."""
+        query = self.db.query(CategoryPostCaseMix)
+
+        if category:
+            query = query.filter(CategoryPostCaseMix.category == category)
+
+        return query.order_by(
+            CategoryPostCaseMix.category,
+            CategoryPostCaseMix.effective_from.desc(),
+        ).all()
+
+    def get_mix_at_date(self, target_date: datetime) -> List[CategoryPostCaseMix]:
+        """Get the mix that was active at a specific date (for historical analysis)."""
+        return (
+            self.db.query(CategoryPostCaseMix)
+            .filter(
+                CategoryPostCaseMix.effective_from <= target_date,
+                (CategoryPostCaseMix.effective_to.is_(None))
+                | (CategoryPostCaseMix.effective_to > target_date),
+            )
+            .order_by(CategoryPostCaseMix.category)
+            .all()
+        )
+
+    def set_mix(
+        self,
+        ratios: Dict[str, Decimal],
+        user_id: Optional[str] = None,
+    ) -> List[CategoryPostCaseMix]:
+        """
+        Set new category mix ratios (Type 2 SCD update).
+
+        This expires all current ratios and creates new ones.
+        Validates that ratios sum to 1.0 (100%).
+
+        Args:
+            ratios: Dict of {category: ratio} where ratios sum to 1.0
+            user_id: User making the change
+
+        Returns:
+            List of newly created CategoryPostCaseMix records
+
+        Raises:
+            ValueError: If ratios don't sum to 1.0 or are invalid
+        """
+        # Validate ratios
+        self._validate_ratios(ratios)
+
+        now = datetime.utcnow()
+
+        # Expire all current records
+        current_records = self.get_current_mix()
+        for record in current_records:
+            record.effective_to = now
+            record.is_current = False
+
+        # Create new records
+        new_records = []
+        for category, ratio in ratios.items():
+            new_record = CategoryPostCaseMix(
+                category=category,
+                ratio=ratio,
+                effective_from=now,
+                effective_to=None,
+                is_current=True,
+                created_by_user_id=user_id,
+            )
+            self.db.add(new_record)
+            new_records.append(new_record)
+
+        self.db.commit()
+
+        # Refresh to get IDs
+        for record in new_records:
+            self.db.refresh(record)
+
+        return new_records
+
+    def has_current_mix(self) -> bool:
+        """Check if any current mix ratios exist."""
+        count = (
+            self.db.query(func.count(CategoryPostCaseMix.id))
+            .filter(CategoryPostCaseMix.is_current == True)
+            .scalar()
+        )
+        return count > 0
+
+    def get_categories_without_ratio(self, categories: List[str]) -> List[str]:
+        """Find categories that don't have a current ratio defined."""
+        current_mix = self.get_current_mix_as_dict()
+        return [cat for cat in categories if cat not in current_mix]
+
+    def _validate_ratios(self, ratios: Dict[str, Decimal]) -> None:
+        """
+        Validate that ratios are valid.
+
+        Raises:
+            ValueError: If validation fails
+        """
+        if not ratios:
+            raise ValueError("At least one category ratio must be provided")
+
+        # Check each ratio is valid
+        for category, ratio in ratios.items():
+            if not category or not category.strip():
+                raise ValueError("Category name cannot be empty")
+
+            ratio_decimal = Decimal(str(ratio))
+
+            if ratio_decimal < 0:
+                raise ValueError(f"Ratio for '{category}' cannot be negative: {ratio}")
+
+            if ratio_decimal > 1:
+                raise ValueError(
+                    f"Ratio for '{category}' cannot exceed 1.0: {ratio}"
+                )
+
+        # Check sum equals 1.0 (with small tolerance for floating point)
+        total = sum(Decimal(str(r)) for r in ratios.values())
+        tolerance = Decimal("0.0001")
+
+        if abs(total - Decimal("1.0")) > tolerance:
+            raise ValueError(
+                f"Ratios must sum to 1.0 (100%). Current sum: {total:.4f}"
+            )

--- a/src/repositories/media_repository.py
+++ b/src/repositories/media_repository.py
@@ -27,7 +27,11 @@ class MediaRepository:
         return self.db.query(MediaItem).filter(MediaItem.file_hash == file_hash).all()
 
     def get_all(
-        self, is_active: Optional[bool] = None, requires_interaction: Optional[bool] = None, limit: Optional[int] = None
+        self,
+        is_active: Optional[bool] = None,
+        requires_interaction: Optional[bool] = None,
+        category: Optional[str] = None,
+        limit: Optional[int] = None,
     ) -> List[MediaItem]:
         """Get all media items with optional filters."""
         query = self.db.query(MediaItem)
@@ -38,12 +42,25 @@ class MediaRepository:
         if requires_interaction is not None:
             query = query.filter(MediaItem.requires_interaction == requires_interaction)
 
+        if category is not None:
+            query = query.filter(MediaItem.category == category)
+
         query = query.order_by(MediaItem.created_at.desc())
 
         if limit:
             query = query.limit(limit)
 
         return query.all()
+
+    def get_categories(self) -> List[str]:
+        """Get all unique categories."""
+        result = (
+            self.db.query(MediaItem.category)
+            .filter(MediaItem.category.isnot(None))
+            .distinct()
+            .all()
+        )
+        return [r[0] for r in result]
 
     def create(
         self,
@@ -53,6 +70,7 @@ class MediaRepository:
         file_size_bytes: int,
         mime_type: Optional[str] = None,
         requires_interaction: bool = False,
+        category: Optional[str] = None,
         title: Optional[str] = None,
         link_url: Optional[str] = None,
         caption: Optional[str] = None,
@@ -68,6 +86,7 @@ class MediaRepository:
             file_size=file_size_bytes,
             mime_type=mime_type,
             requires_interaction=requires_interaction,
+            category=category,
             title=title,
             link_url=link_url,
             caption=caption,

--- a/src/services/core/scheduler.py
+++ b/src/services/core/scheduler.py
@@ -1,12 +1,14 @@
 """Scheduler service - create and manage posting schedule."""
 from datetime import datetime, timedelta
-from typing import Optional
+from typing import Optional, List, Dict
+from decimal import Decimal
 import random
 
 from src.services.base_service import BaseService
 from src.repositories.media_repository import MediaRepository
 from src.repositories.queue_repository import QueueRepository
 from src.repositories.lock_repository import LockRepository
+from src.repositories.category_mix_repository import CategoryMixRepository
 from src.config.settings import settings
 from src.utils.logger import logger
 
@@ -19,17 +21,23 @@ class SchedulerService(BaseService):
         self.media_repo = MediaRepository()
         self.queue_repo = QueueRepository()
         self.lock_repo = LockRepository()
+        self.category_mix_repo = CategoryMixRepository()
 
     def create_schedule(self, days: int = 7, user_id: Optional[str] = None) -> dict:
         """
         Generate posting schedule for the next N days.
+
+        Uses category ratios to allocate slots across categories.
+        For example, with 70% memes / 30% merch and 21 total slots:
+        - ~15 slots allocated to memes
+        - ~6 slots allocated to merch
 
         Args:
             days: Number of days to schedule
             user_id: User who triggered scheduling
 
         Returns:
-            Dict with results: {scheduled: 21, skipped: 5, error: "..."}
+            Dict with results: {scheduled: 21, skipped: 5, category_breakdown: {...}}
         """
         with self.track_execution(
             method_name="create_schedule",
@@ -40,19 +48,27 @@ class SchedulerService(BaseService):
             scheduled_count = 0
             skipped_count = 0
             error_message = None
+            category_breakdown = {}
 
             try:
-                # Calculate total posts needed
-                total_posts = days * settings.POSTS_PER_DAY
-
                 # Generate time slots
                 time_slots = self._generate_time_slots(days)
+                total_slots = len(time_slots)
 
-                logger.info(f"Generating schedule for {days} days ({total_posts} posts)")
+                logger.info(f"Generating schedule for {days} days ({total_slots} slots)")
 
-                for scheduled_time in time_slots:
+                # Allocate slots to categories based on ratios
+                slot_categories = self._allocate_slots_to_categories(total_slots)
+
+                if slot_categories:
+                    logger.info(f"Category allocation: {self._summarize_allocation(slot_categories)}")
+
+                for i, scheduled_time in enumerate(time_slots):
+                    # Get target category for this slot (if ratios are configured)
+                    target_category = slot_categories[i] if slot_categories else None
+
                     # Select media for this slot
-                    media_item = self._select_media()
+                    media_item = self._select_media(category=target_category)
 
                     if not media_item:
                         logger.warning(f"No eligible media found for slot {scheduled_time}")
@@ -62,14 +78,23 @@ class SchedulerService(BaseService):
                     # Add to queue
                     self.queue_repo.create(media_item_id=str(media_item.id), scheduled_for=scheduled_time)
 
-                    logger.info(f"Scheduled {media_item.file_name} for {scheduled_time}")
+                    # Track category breakdown
+                    item_category = media_item.category or "uncategorized"
+                    category_breakdown[item_category] = category_breakdown.get(item_category, 0) + 1
+
+                    logger.info(f"Scheduled {media_item.file_name} [{item_category}] for {scheduled_time}")
                     scheduled_count += 1
 
             except Exception as e:
                 error_message = str(e)
                 logger.error(f"Error during scheduling: {e}")
 
-            result = {"scheduled": scheduled_count, "skipped": skipped_count, "total_slots": len(time_slots)}
+            result = {
+                "scheduled": scheduled_count,
+                "skipped": skipped_count,
+                "total_slots": len(time_slots),
+                "category_breakdown": category_breakdown,
+            }
 
             if error_message:
                 result["error"] = error_message
@@ -77,6 +102,51 @@ class SchedulerService(BaseService):
             self.set_result_summary(run_id, result)
 
             return result
+
+    def _allocate_slots_to_categories(self, total_slots: int) -> List[Optional[str]]:
+        """
+        Allocate slots to categories based on configured ratios.
+
+        Args:
+            total_slots: Total number of slots to allocate
+
+        Returns:
+            List of category names (shuffled), or empty list if no ratios configured
+        """
+        current_mix = self.category_mix_repo.get_current_mix_as_dict()
+
+        if not current_mix:
+            logger.info("No category mix configured, using default selection")
+            return []
+
+        # Calculate slots per category
+        slot_allocation = []
+        remaining_slots = total_slots
+
+        # Sort categories by ratio descending to handle rounding better
+        sorted_categories = sorted(current_mix.items(), key=lambda x: x[1], reverse=True)
+
+        for i, (category, ratio) in enumerate(sorted_categories):
+            if i == len(sorted_categories) - 1:
+                # Last category gets all remaining slots (handles rounding)
+                slots_for_category = remaining_slots
+            else:
+                slots_for_category = round(float(ratio) * total_slots)
+                remaining_slots -= slots_for_category
+
+            slot_allocation.extend([category] * slots_for_category)
+
+        # Shuffle for variety (so it's not all memes first, then all merch)
+        random.shuffle(slot_allocation)
+
+        return slot_allocation
+
+    def _summarize_allocation(self, slot_categories: List[str]) -> str:
+        """Summarize slot allocation for logging."""
+        summary = {}
+        for cat in slot_categories:
+            summary[cat] = summary.get(cat, 0) + 1
+        return ", ".join(f"{cat}: {count}" for cat, count in sorted(summary.items()))
 
     def _generate_time_slots(self, days: int) -> list[datetime]:
         """
@@ -125,25 +195,54 @@ class SchedulerService(BaseService):
 
         return sorted(time_slots)
 
-    def _select_media(self):
+    def _select_media(self, category: Optional[str] = None):
         """
         Select next media item to post using intelligent selection logic.
 
         Selection priority:
-        1. Never posted items first (last_posted_at IS NULL)
-        2. Least posted items (times_posted ASC)
-        3. Random from eligible items (variety)
+        1. Filter by category (if specified)
+        2. Never posted items first (last_posted_at IS NULL)
+        3. Least posted items (times_posted ASC)
+        4. Random from eligible items (variety)
+
+        If category is specified but exhausted, falls back to any available media.
+
+        Args:
+            category: Target category to select from (optional)
 
         Returns:
             MediaItem or None if no eligible media
         """
-        # Get all active media not currently queued or locked
+        # Try to select from target category first
+        media_item = self._select_media_from_pool(category=category)
+
+        # Fallback to any category if target category is exhausted
+        if not media_item and category:
+            logger.warning(f"Category '{category}' exhausted, falling back to any available media")
+            media_item = self._select_media_from_pool(category=None)
+
+        return media_item
+
+    def _select_media_from_pool(self, category: Optional[str] = None):
+        """
+        Select media from a specific pool (category or all).
+
+        Args:
+            category: Filter by category, or None for all
+
+        Returns:
+            MediaItem or None
+        """
         from sqlalchemy import and_, exists, select
         from src.models.media_item import MediaItem
         from src.models.posting_queue import PostingQueue
         from src.models.media_lock import MediaPostingLock
 
         query = self.media_repo.db.query(MediaItem).filter(MediaItem.is_active == True)
+
+        # Filter by category if specified
+        if category:
+            query = query.filter(MediaItem.category == category)
 
         # Exclude already queued items
         queued_subquery = exists(select(PostingQueue.id).where(PostingQueue.media_item_id == MediaItem.id))

--- a/tests/src/repositories/test_category_mix_repository.py
+++ b/tests/src/repositories/test_category_mix_repository.py
@@ -1,0 +1,220 @@
+"""Tests for CategoryMixRepository."""
+import pytest
+from unittest.mock import Mock, MagicMock, patch
+from decimal import Decimal
+from datetime import datetime, timedelta
+
+from src.repositories.category_mix_repository import CategoryMixRepository
+from src.models.category_mix import CategoryPostCaseMix
+
+
+@pytest.mark.unit
+class TestCategoryMixRepository:
+    """Test suite for CategoryMixRepository."""
+
+    @pytest.fixture
+    def mock_db(self):
+        """Create a mock database session."""
+        return MagicMock()
+
+    @pytest.fixture
+    def mix_repo(self, mock_db):
+        """Create CategoryMixRepository with mocked database."""
+        with patch("src.repositories.category_mix_repository.get_db") as mock_get_db:
+            mock_get_db.return_value = iter([mock_db])
+            repo = CategoryMixRepository()
+            repo.db = mock_db
+            return repo
+
+    def test_validate_ratios_success(self, mix_repo):
+        """Test that valid ratios pass validation."""
+        ratios = {
+            "memes": Decimal("0.7"),
+            "merch": Decimal("0.3"),
+        }
+        # Should not raise
+        mix_repo._validate_ratios(ratios)
+
+    def test_validate_ratios_empty_raises(self, mix_repo):
+        """Test that empty ratios raise ValueError."""
+        with pytest.raises(ValueError, match="At least one category"):
+            mix_repo._validate_ratios({})
+
+    def test_validate_ratios_negative_raises(self, mix_repo):
+        """Test that negative ratios raise ValueError."""
+        ratios = {"memes": Decimal("-0.1")}
+        with pytest.raises(ValueError, match="cannot be negative"):
+            mix_repo._validate_ratios(ratios)
+
+    def test_validate_ratios_over_one_raises(self, mix_repo):
+        """Test that ratios over 1.0 raise ValueError."""
+        ratios = {"memes": Decimal("1.5")}
+        with pytest.raises(ValueError, match="cannot exceed 1.0"):
+            mix_repo._validate_ratios(ratios)
+
+    def test_validate_ratios_sum_not_one_raises(self, mix_repo):
+        """Test that ratios not summing to 1.0 raise ValueError."""
+        ratios = {
+            "memes": Decimal("0.5"),
+            "merch": Decimal("0.3"),
+        }  # Sum = 0.8
+        with pytest.raises(ValueError, match="must sum to 1.0"):
+            mix_repo._validate_ratios(ratios)
+
+    def test_validate_ratios_empty_category_raises(self, mix_repo):
+        """Test that empty category name raises ValueError."""
+        ratios = {"": Decimal("1.0")}
+        with pytest.raises(ValueError, match="cannot be empty"):
+            mix_repo._validate_ratios(ratios)
+
+    def test_validate_ratios_tolerance(self, mix_repo):
+        """Test that small floating point errors are tolerated."""
+        # These might not sum to exactly 1.0 due to floating point
+        ratios = {
+            "cat1": Decimal("0.3333"),
+            "cat2": Decimal("0.3333"),
+            "cat3": Decimal("0.3334"),
+        }
+        # Should not raise (sum is close enough to 1.0)
+        mix_repo._validate_ratios(ratios)
+
+    def test_get_current_mix(self, mix_repo, mock_db):
+        """Test getting current mix records."""
+        mock_records = [
+            Mock(category="memes", ratio=Decimal("0.7"), is_current=True),
+            Mock(category="merch", ratio=Decimal("0.3"), is_current=True),
+        ]
+        mock_db.query.return_value.filter.return_value.order_by.return_value.all.return_value = (
+            mock_records
+        )
+
+        result = mix_repo.get_current_mix()
+
+        assert len(result) == 2
+        mock_db.query.assert_called_once()
+
+    def test_get_current_mix_as_dict(self, mix_repo, mock_db):
+        """Test getting current mix as dictionary."""
+        mock_records = [
+            Mock(category="memes", ratio=Decimal("0.7"), is_current=True),
+            Mock(category="merch", ratio=Decimal("0.3"), is_current=True),
+        ]
+        mock_db.query.return_value.filter.return_value.order_by.return_value.all.return_value = (
+            mock_records
+        )
+
+        result = mix_repo.get_current_mix_as_dict()
+
+        assert result == {"memes": Decimal("0.7"), "merch": Decimal("0.3")}
+
+    def test_has_current_mix_true(self, mix_repo, mock_db):
+        """Test has_current_mix returns True when mix exists."""
+        mock_db.query.return_value.filter.return_value.scalar.return_value = 2
+
+        result = mix_repo.has_current_mix()
+
+        assert result is True
+
+    def test_has_current_mix_false(self, mix_repo, mock_db):
+        """Test has_current_mix returns False when no mix exists."""
+        mock_db.query.return_value.filter.return_value.scalar.return_value = 0
+
+        result = mix_repo.has_current_mix()
+
+        assert result is False
+
+    def test_get_categories_without_ratio(self, mix_repo, mock_db):
+        """Test finding categories without defined ratios."""
+        # Current mix only has "memes"
+        mock_records = [Mock(category="memes", ratio=Decimal("1.0"))]
+        mock_db.query.return_value.filter.return_value.order_by.return_value.all.return_value = (
+            mock_records
+        )
+
+        result = mix_repo.get_categories_without_ratio(["memes", "merch", "misc"])
+
+        assert "merch" in result
+        assert "misc" in result
+        assert "memes" not in result
+
+    def test_set_mix_creates_new_records(self, mix_repo, mock_db):
+        """Test that set_mix creates new records."""
+        # No existing records
+        mock_db.query.return_value.filter.return_value.order_by.return_value.all.return_value = []
+
+        ratios = {
+            "memes": Decimal("0.7"),
+            "merch": Decimal("0.3"),
+        }
+
+        mix_repo.set_mix(ratios)
+
+        # Should add 2 new records
+        assert mock_db.add.call_count == 2
+        mock_db.commit.assert_called_once()
+
+    def test_set_mix_expires_old_records(self, mix_repo, mock_db):
+        """Test that set_mix expires existing records."""
+        # Existing records
+        old_record = Mock(is_current=True, effective_to=None)
+        mock_db.query.return_value.filter.return_value.order_by.return_value.all.return_value = [
+            old_record
+        ]
+
+        ratios = {"memes": Decimal("1.0")}
+
+        mix_repo.set_mix(ratios)
+
+        # Old record should be expired
+        assert old_record.is_current is False
+        assert old_record.effective_to is not None
+
+    def test_get_category_ratio(self, mix_repo, mock_db):
+        """Test getting ratio for specific category."""
+        mock_record = Mock(ratio=Decimal("0.7"))
+        mock_db.query.return_value.filter.return_value.first.return_value = mock_record
+
+        result = mix_repo.get_category_ratio("memes")
+
+        assert result == Decimal("0.7")
+
+    def test_get_category_ratio_not_found(self, mix_repo, mock_db):
+        """Test getting ratio for non-existent category."""
+        mock_db.query.return_value.filter.return_value.first.return_value = None
+
+        result = mix_repo.get_category_ratio("unknown")
+
+        assert result is None
+
+
+@pytest.mark.unit
+class TestCategoryPostCaseMixModel:
+    """Test suite for CategoryPostCaseMix model."""
+
+    def test_model_repr(self):
+        """Test model string representation."""
+        mix = CategoryPostCaseMix(
+            category="memes",
+            ratio=Decimal("0.7"),
+            is_current=True,
+        )
+
+        repr_str = repr(mix)
+
+        assert "memes" in repr_str
+        assert "70" in repr_str
+        assert "current" in repr_str
+
+    def test_model_repr_expired(self):
+        """Test model string representation for expired record."""
+        mix = CategoryPostCaseMix(
+            category="merch",
+            ratio=Decimal("0.3"),
+            is_current=False,
+            effective_to=datetime(2024, 1, 15),
+        )
+
+        repr_str = repr(mix)
+
+        assert "merch" in repr_str
+        assert "expired" in repr_str

--- a/tests/src/services/test_scheduler.py
+++ b/tests/src/services/test_scheduler.py
@@ -1,7 +1,8 @@
 """Tests for SchedulerService."""
 import pytest
 from datetime import datetime, timedelta
-from unittest.mock import Mock, patch
+from decimal import Decimal
+from unittest.mock import Mock, patch, MagicMock
 
 from src.services.core.scheduler import SchedulerService
 from src.repositories.media_repository import MediaRepository
@@ -203,3 +204,155 @@ class TestSchedulerService:
             hour = item.scheduled_time.hour
             # Allow for jitter, but should be roughly within bounds
             assert 0 <= hour <= 23  # Basic sanity check
+
+
+@pytest.mark.unit
+class TestSchedulerCategoryAllocation:
+    """Test suite for category-based slot allocation."""
+
+    @pytest.fixture
+    def scheduler_service(self):
+        """Create SchedulerService with mocked dependencies."""
+        with patch("src.services.core.scheduler.MediaRepository"):
+            with patch("src.services.core.scheduler.QueueRepository"):
+                with patch("src.services.core.scheduler.LockRepository"):
+                    with patch("src.services.core.scheduler.CategoryMixRepository"):
+                        with patch("src.services.base_service.ServiceRunRepository"):
+                            service = SchedulerService()
+                            service.media_repo = Mock()
+                            service.queue_repo = Mock()
+                            service.lock_repo = Mock()
+                            service.category_mix_repo = Mock()
+                            # Mock track_execution
+                            service.track_execution = MagicMock()
+                            service.track_execution.return_value.__enter__ = Mock(return_value="run-123")
+                            service.track_execution.return_value.__exit__ = Mock(return_value=False)
+                            service.set_result_summary = Mock()
+                            return service
+
+    def test_allocate_slots_with_ratios(self, scheduler_service):
+        """Test that slots are allocated according to category ratios."""
+        scheduler_service.category_mix_repo.get_current_mix_as_dict.return_value = {
+            "memes": Decimal("0.7"),
+            "merch": Decimal("0.3"),
+        }
+
+        allocation = scheduler_service._allocate_slots_to_categories(10)
+
+        # Should have 10 slots total
+        assert len(allocation) == 10
+
+        # Count per category
+        memes_count = allocation.count("memes")
+        merch_count = allocation.count("merch")
+
+        # 70% of 10 = 7 memes, 30% of 10 = 3 merch
+        assert memes_count == 7
+        assert merch_count == 3
+
+    def test_allocate_slots_with_rounding(self, scheduler_service):
+        """Test that slot allocation handles rounding correctly."""
+        scheduler_service.category_mix_repo.get_current_mix_as_dict.return_value = {
+            "memes": Decimal("0.7"),
+            "merch": Decimal("0.3"),
+        }
+
+        # 21 slots: 70% = 14.7 -> 15, 30% = 6.3 -> 6
+        allocation = scheduler_service._allocate_slots_to_categories(21)
+
+        assert len(allocation) == 21
+
+        memes_count = allocation.count("memes")
+        merch_count = allocation.count("merch")
+
+        # Should sum to 21
+        assert memes_count + merch_count == 21
+        # Roughly 70/30 split
+        assert memes_count >= 14 and memes_count <= 15
+        assert merch_count >= 6 and merch_count <= 7
+
+    def test_allocate_slots_no_ratios_configured(self, scheduler_service):
+        """Test that empty list is returned when no ratios configured."""
+        scheduler_service.category_mix_repo.get_current_mix_as_dict.return_value = {}
+
+        allocation = scheduler_service._allocate_slots_to_categories(10)
+
+        assert allocation == []
+
+    def test_allocate_slots_single_category(self, scheduler_service):
+        """Test allocation with single category at 100%."""
+        scheduler_service.category_mix_repo.get_current_mix_as_dict.return_value = {
+            "memes": Decimal("1.0"),
+        }
+
+        allocation = scheduler_service._allocate_slots_to_categories(10)
+
+        assert len(allocation) == 10
+        assert all(cat == "memes" for cat in allocation)
+
+    def test_allocate_slots_three_categories(self, scheduler_service):
+        """Test allocation with three categories."""
+        scheduler_service.category_mix_repo.get_current_mix_as_dict.return_value = {
+            "memes": Decimal("0.5"),
+            "merch": Decimal("0.3"),
+            "misc": Decimal("0.2"),
+        }
+
+        allocation = scheduler_service._allocate_slots_to_categories(10)
+
+        assert len(allocation) == 10
+
+        memes = allocation.count("memes")
+        merch = allocation.count("merch")
+        misc = allocation.count("misc")
+
+        assert memes == 5  # 50%
+        assert merch == 3  # 30%
+        assert misc == 2   # 20%
+
+    def test_summarize_allocation(self, scheduler_service):
+        """Test allocation summary string."""
+        allocation = ["memes", "memes", "merch", "memes", "merch"]
+
+        summary = scheduler_service._summarize_allocation(allocation)
+
+        assert "memes: 3" in summary
+        assert "merch: 2" in summary
+
+    def test_select_media_with_category(self, scheduler_service):
+        """Test that _select_media passes category to pool selection."""
+        mock_media = Mock(category="memes", file_name="test.jpg")
+        scheduler_service._select_media_from_pool = Mock(return_value=mock_media)
+
+        result = scheduler_service._select_media(category="memes")
+
+        scheduler_service._select_media_from_pool.assert_called_with(category="memes")
+        assert result == mock_media
+
+    def test_select_media_fallback_when_category_exhausted(self, scheduler_service):
+        """Test fallback to any category when target is exhausted."""
+        mock_media = Mock(category="merch", file_name="fallback.jpg")
+
+        # First call (with category) returns None, second call (without) returns media
+        scheduler_service._select_media_from_pool = Mock(side_effect=[None, mock_media])
+
+        result = scheduler_service._select_media(category="memes")
+
+        # Should have been called twice
+        assert scheduler_service._select_media_from_pool.call_count == 2
+        # First with category, then without
+        calls = scheduler_service._select_media_from_pool.call_args_list
+        assert calls[0][1]["category"] == "memes"
+        assert calls[1][1]["category"] is None
+        # Should return fallback media
+        assert result == mock_media
+
+    def test_select_media_no_fallback_when_no_category(self, scheduler_service):
+        """Test that no fallback occurs when no category specified."""
+        scheduler_service._select_media_from_pool = Mock(return_value=None)
+
+        result = scheduler_service._select_media(category=None)
+
+        # Should only be called once (no fallback)
+        scheduler_service._select_media_from_pool.assert_called_once_with(category=None)
+        assert result is None


### PR DESCRIPTION
- Extract category from folder structure during media indexing
- Add category_post_case_mix table (Type 2 SCD) for ratio tracking
- Integrate category ratios into scheduler slot allocation
- Add CLI commands: list-categories, update-category-mix, category-mix-history
- Update documentation and tests (173 → 268 tests)