### PR TITLE
Fix: Account selector stays in menu after switching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Account Selector UX** - Clicking an account in the posting workflow now stays in the account selection menu to show the updated checkmark, rather than immediately returning to the posting workflow. This provides visual confirmation that the account was switched. User can then click "Back to Post" to return.
+
 ### Added - Inline Account Selector (Phase 1.7)
 
 #### Posting Workflow Enhancements

--- a/src/services/core/telegram_service.py
+++ b/src/services/core/telegram_service.py
@@ -3103,8 +3103,9 @@ class TelegramService(BaseService):
             # Show success toast (friendly name)
             await query.answer(f"✅ Switched to {switched_account.display_name}")
 
-            # Rebuild posting workflow with new account
-            await self._rebuild_posting_workflow(str(queue_item.id), query)
+            # Stay in account selection menu to show updated checkmark
+            # User can click "Back to Post" to return to posting workflow
+            await self._handle_post_account_selector(str(queue_item.id), user, query)
 
         except ValueError as e:
             await query.answer(f"Error: {e}", show_alert=True)

--- a/tests/src/services/test_telegram_service.py
+++ b/tests/src/services/test_telegram_service.py
@@ -1964,3 +1964,67 @@ class TestAccountSelectorCallbacks:
 
         # Should call edit_message_caption to rebuild the posting workflow
         mock_query.edit_message_caption.assert_called()
+
+    async def test_handle_post_account_switch_stays_in_selector(
+        self, mock_telegram_service
+    ):
+        """Test that switching account stays in selector menu to show updated checkmark."""
+        queue_id = str(uuid4())
+        account_id = str(uuid4())
+        short_queue_id = queue_id[:8]
+        short_account_id = account_id[:8]
+        chat_id = -100123
+
+        # Mock queue item
+        mock_queue_item = Mock()
+        mock_queue_item.id = queue_id
+        mock_telegram_service.queue_repo.get_by_id_prefix.return_value = mock_queue_item
+        mock_telegram_service.queue_repo.get_by_id.return_value = mock_queue_item
+
+        # Mock account
+        mock_account = Mock()
+        mock_account.id = account_id
+        mock_account.display_name = "Test Account"
+        mock_account.instagram_username = "testaccount"
+        mock_telegram_service.ig_account_service = Mock()
+        mock_telegram_service.ig_account_service.get_account_by_id_prefix.return_value = (
+            mock_account
+        )
+        mock_telegram_service.ig_account_service.switch_account.return_value = (
+            mock_account
+        )
+        mock_telegram_service.ig_account_service.get_accounts_for_display.return_value = {
+            "accounts": [
+                {
+                    "id": account_id,
+                    "display_name": "Test Account",
+                    "username": "testaccount",
+                }
+            ],
+            "active_account_id": account_id,
+        }
+
+        mock_user = Mock()
+        mock_user.id = uuid4()
+
+        mock_query = AsyncMock()
+        mock_query.message = Mock(chat_id=chat_id, message_id=1)
+
+        # Call the handler
+        data = f"{short_queue_id}:{short_account_id}"
+        await mock_telegram_service._handle_post_account_switch(
+            data, mock_user, mock_query
+        )
+
+        # Verify switch_account was called
+        mock_telegram_service.ig_account_service.switch_account.assert_called_once_with(
+            chat_id, account_id, mock_user
+        )
+
+        # Verify success toast was shown
+        mock_query.answer.assert_called_once_with("✅ Switched to Test Account")
+
+        # Verify edit_message_caption was called (account selector menu rebuilt)
+        mock_query.edit_message_caption.assert_called_once()
+        call_args = mock_query.edit_message_caption.call_args
+        assert "Select Instagram Account" in call_args.kwargs["caption"]


### PR DESCRIPTION
## Problem

When clicking an account in the posting workflow selector, it would switch the account but immediately return to the posting workflow. This made it unclear whether the account actually switched, as users couldn't see the checkmark update.

## Solution

After switching accounts, stay in the account selection menu to show the updated checkmark. User can then click "Back to Post" to return to the posting workflow. This provides clear visual feedback that the account was successfully switched.

## Changes

- ✅ Modified `_handle_post_account_switch` to call `_handle_post_account_selector` instead of `_rebuild_posting_workflow` after switching
- ✅ Added test `test_handle_post_account_switch_stays_in_selector` to verify behavior
- ✅ Updated CHANGELOG with fix

## Testing

```bash
pytest tests/src/services/test_telegram_service.py::TestAccountSelectorCallbacks -v
# All 3 tests pass
```

## User Experience

### Before:
1. User clicks account button → sees selector
2. User clicks different account → immediately returns to posting workflow
3. User confused: "Did it switch? I don't see any change"

### After:
1. User clicks account button → sees selector with checkmark on current account
2. User clicks different account → toast shows "✅ Switched to X", menu refreshes with checkmark on new account
3. User sees visual confirmation, can click another account or "Back to Post"

## Related

Part of Phase 1.7 inline account selector improvements.

🤖 Generated with [Claude Code](https://claude.com/claude-code)