### PR TITLE
chore: update all pinned dependencies to latest versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Update all pinned dependencies to latest versions** - Bring all ==pinned packages current
+  - Tier 1 (patch): psycopg2-binary 2.9.9→2.9.11, python-dateutil 2.8.2→2.9.0.post0
+  - Tier 2 (minor): pydantic 2.5→2.12.5, pydantic-settings 2.1→2.12, SQLAlchemy 2.0.23→2.0.46, click 8.1→8.3, rich 13.7→14.3, python-dotenv 1.0→1.2, alembic 1.13→1.18
+  - Tier 3 (major): python-telegram-bot 20.7→22.6, httpx 0.25→0.28, Pillow 10.1→12.1, pytest 7.4→9.0, pytest-asyncio 0.21→1.3, pytest-cov 4.1→7.0, pytest-mock 3.12→3.15
+
 - **Documentation review and accuracy audit** - Cross-referenced all docs against codebase post-v1.6.0 refactor
   - Corrected test counts, setting names, supported formats, and deploy script defaults
   - Updated code examples in security review for post-refactor handler locations

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,26 +1,26 @@
 # Core
-python-dotenv==1.0.0
-pydantic==2.5.0
-pydantic-settings==2.1.0
+python-dotenv==1.2.1
+pydantic==2.12.5
+pydantic-settings==2.12.0
 
 # Database
-sqlalchemy==2.0.23
-psycopg2-binary==2.9.9
-alembic==1.13.0
+sqlalchemy==2.0.46
+psycopg2-binary==2.9.11
+alembic==1.18.4
 
 # Telegram
-python-telegram-bot==20.7
-httpx==0.25.2
+python-telegram-bot==22.6
+httpx==0.28.1
 
 # Image Processing
-Pillow==10.1.0
+Pillow==12.1.1
 
 # CLI
-click==8.1.7
-rich==13.7.0
+click==8.3.1
+rich==14.3.2
 
 # Utilities
-python-dateutil==2.8.2
+python-dateutil==2.9.0.post0
 
 # Cloud Storage (Phase 2)
 cloudinary>=1.36.0
@@ -29,7 +29,7 @@ cloudinary>=1.36.0
 cryptography>=41.0.0
 
 # Testing
-pytest==7.4.3
-pytest-asyncio==0.21.1
-pytest-cov==4.1.0
-pytest-mock==3.12.0
+pytest==9.0.2
+pytest-asyncio==1.3.0
+pytest-cov==7.0.0
+pytest-mock==3.15.1

--- a/tests/src/services/test_health_check.py
+++ b/tests/src/services/test_health_check.py
@@ -177,7 +177,9 @@ class TestHealthCheckService:
 
     @patch("src.services.core.health_check.BaseRepository")
     @patch("src.services.core.health_check.settings")
-    def test_check_all_some_unhealthy(self, mock_settings, mock_base_repo, health_service):
+    def test_check_all_some_unhealthy(
+        self, mock_settings, mock_base_repo, health_service
+    ):
         """Test check_all returns unhealthy when any check fails."""
         # Telegram unhealthy
         mock_settings.TELEGRAM_BOT_TOKEN = ""


### PR DESCRIPTION
## Summary
- Update all 16 ==pinned packages to latest versions (some 2+ years stale)
- Tier 1 (patch): psycopg2-binary 2.9.11, python-dateutil 2.9.0.post0
- Tier 2 (minor): pydantic 2.12.5, pydantic-settings 2.12.0, SQLAlchemy 2.0.46, click 8.3.1, rich 14.3.2, python-dotenv 1.2.1, alembic 1.18.4
- Tier 3 (major): python-telegram-bot 22.6, httpx 0.28.1, Pillow 12.1.1, pytest 9.0.2, pytest-asyncio 1.3.0, pytest-cov 7.0.0, pytest-mock 3.15.1
- No code changes required -- all APIs remained backward-compatible

## Test plan
- [x] All 353 tests pass (147 skipped - pre-existing)
- [x] Ruff lint and format clean
- [x] Each tier installed and tested independently before proceeding
- [x] CHANGELOG.md updated

Phase 11 of tech debt remediation (`documentation/planning/tech_debt/full-review-feb-2026_2026-02-10/11_dependency-updates.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)