### PR TITLE
test: convert skipped service tests to unit tests with mocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Tests
 
+- **Convert 45 skipped service tests to unit tests** - Replace integration fixtures with mock-based unit tests across 7 service test files
+  - Rewrote test_base_service.py, test_media_lock.py, test_posting.py, test_scheduler.py with correct method signatures
+  - Implemented 3 stub tests in test_telegram_commands.py (next_media_not_found, next_notification_failure, next_logs_interaction)
+  - Fixed is_paused/set_paused mocking for pause/resume tests (property reads from settings_service)
+  - Removed 12 duplicate @pytest.mark.skip decorators from test_instagram_api.py; added missing dependency patches
+  - Updated Instagram API tests for multi-account architecture (is_configured, post_story credential flow)
+  - Fixed time-dependent scheduler tests (days=2 to ensure future slots)
+
 - **Convert 74 skipped repository tests to unit tests** - Replace `test_db` integration fixtures with mock-based unit tests
   - Pattern: `patch.object(Repo, '__init__')` + `MagicMock(spec=Session)` for chainable query mocking
   - 67 new passing tests across 7 repository test files (media, queue, user, interaction, lock, history, service_run)

--- a/documentation/planning/tech_debt/full-review-feb-2026_2026-02-10/09_service-test-conversion.md
+++ b/documentation/planning/tech_debt/full-review-feb-2026_2026-02-10/09_service-test-conversion.md
@@ -1,0 +1,724 @@
+# Phase 09: Convert Skipped Service Tests to Unit Tests
+
+**Status**: ✅ COMPLETE
+**Started**: 2026-02-10
+**Completed**: 2026-02-11
+
+| Field | Value |
+|---|---|
+| **PR Title** | `test: convert skipped service tests to unit tests with mocks` |
+| **Risk Level** | Low |
+| **Effort** | Large (6-8 hours) |
+| **Dependencies** | Phase 04 (scheduler architecture must be fixed first) |
+| **Blocks** | Phase 10, Phase 12 |
+| **Files Modified** | `tests/src/services/test_base_service.py`, `tests/src/services/test_instagram_api.py`, `tests/src/services/test_media_lock.py`, `tests/src/services/test_scheduler.py`, `tests/src/services/test_posting.py`, `tests/src/services/test_telegram_commands.py`, `tests/src/services/test_telegram_callbacks.py` |
+
+---
+
+## Problem Description
+
+There are **45 skipped tests** across 7 service test files. The breakdown:
+
+| File | Skipped Tests | Skip Reason |
+|---|---|---|
+| `test_base_service.py` | 9 | `"TODO: Integration test - needs test_db"` |
+| `test_instagram_api.py` | 6 | `"TODO: Integration test - needs test_db"` (some with duplicate `@skip` decorators) |
+| `test_media_lock.py` | 6 | `"TODO: Convert to unit test with mocks"` |
+| `test_scheduler.py` | 6 | `"TODO: Integration test - needs test_db"` |
+| `test_posting.py` | 5 | `"TODO: Integration test - needs test_db"` |
+| `test_telegram_commands.py` | 9 | Mixed: `"Needs PostingService mock"`, `"Needs SettingsService mock"`, class-level skips on `TestPauseCommand` (2 tests), `TestResumeCommand` (3 tests), `TestPauseIntegration` (1 test), plus 3 function-level skips in `TestNextCommand` |
+| `test_telegram_callbacks.py` | 4 | `"Needs SettingsService and SchedulerService mocks"` on `TestResumeCallbacks` class (3 tests) + 1 class-level skip |
+| **Total** | **45** | |
+
+---
+
+## Mocking Strategy for Services
+
+Services differ from repositories because services depend on repositories (and sometimes on other services). The mocking strategy must:
+
+1. Prevent `BaseService.__init__` from creating real `ServiceRunRepository`
+2. Prevent the service's own `__init__` from creating real repository instances
+3. Mock `track_execution` context manager (used for observability)
+4. Inject mock repositories as attributes
+
+### Standard Service Fixture Pattern
+
+```python
+from unittest.mock import Mock, patch, MagicMock
+from contextlib import contextmanager
+
+
+@contextmanager
+def mock_track_execution(*args, **kwargs):
+    """Mock context manager for track_execution."""
+    yield "mock_run_id"
+
+
+@pytest.fixture
+def scheduler_service():
+    """Create SchedulerService with mocked dependencies."""
+    with patch.object(SchedulerService, '__init__', lambda self: None):
+        service = SchedulerService()
+        service.media_repo = Mock()
+        service.queue_repo = Mock()
+        service.lock_repo = Mock()
+        service.category_mix_repo = Mock()
+        service.settings_service = Mock()
+        service._service_run_repo = Mock()  # From BaseService
+        service.track_execution = mock_track_execution
+        service.set_result_summary = Mock()
+        return service
+```
+
+### Telegram Handler Fixture Pattern
+
+Telegram handlers use **composition** -- they hold a reference to a `TelegramService` parent. The existing working fixtures in `test_telegram_commands.py` and `test_telegram_callbacks.py` already demonstrate the correct pattern. The key difference is they must patch all repository class imports on `TelegramService`:
+
+```python
+@pytest.fixture
+def mock_command_handlers():
+    """Create TelegramCommandHandlers with mocked TelegramService."""
+    with (
+        patch("src.services.core.telegram_service.settings") as mock_settings,
+        patch("src.services.core.telegram_service.UserRepository"),
+        patch("src.services.core.telegram_service.QueueRepository"),
+        patch("src.services.core.telegram_service.MediaRepository"),
+        patch("src.services.core.telegram_service.HistoryRepository"),
+        patch("src.services.core.telegram_service.LockRepository"),
+        patch("src.services.core.telegram_service.MediaLockService"),
+        patch("src.services.core.telegram_service.InteractionService"),
+        patch("src.services.core.telegram_service.SettingsService"),
+        patch("src.services.core.telegram_service.InstagramAccountService"),
+    ):
+        mock_settings.TELEGRAM_BOT_TOKEN = "123456:ABC-DEF1234ghIkl"
+        mock_settings.TELEGRAM_CHANNEL_ID = -1001234567890
+        mock_settings.CAPTION_STYLE = "enhanced"
+        mock_settings.SEND_LIFECYCLE_NOTIFICATIONS = False
+
+        service = TelegramService()
+        # ... assign mock repos ...
+        handlers = TelegramCommandHandlers(service)
+        yield handlers
+```
+
+This fixture pattern already exists and works in these files. The skipped tests in these files need to be made to work with it.
+
+---
+
+## File-by-File Conversion Instructions
+
+### 1. `test_base_service.py` -- 9 Tests
+
+**Current state:** Has a `MockServiceForTesting` class that extends `BaseService`. All 9 tests pass `db=test_db` to the constructor.
+
+**Mocking approach:** Since `BaseService.__init__` creates a `ServiceRunRepository`, mock that. The `MockServiceForTesting` class should work with mocked dependencies.
+
+**Fixture:**
+```python
+@pytest.fixture
+def mock_service():
+    """Create MockServiceForTesting with mocked dependencies."""
+    with patch("src.services.base_service.ServiceRunRepository") as mock_run_repo_class:
+        mock_run_repo = mock_run_repo_class.return_value
+        mock_run_repo.create_run.return_value = Mock(
+            id="run-123",
+            service_name="TestService",
+            method_name="test_method",
+            status="running",
+            started_at=datetime.utcnow(),
+        )
+        mock_run_repo.complete_run.return_value = Mock(
+            id="run-123",
+            status="success",
+            completed_at=datetime.utcnow(),
+            execution_time_seconds=0.1,
+            error_message=None,
+        )
+        mock_run_repo.get_recent_runs.return_value = []
+
+        service = MockServiceForTesting()
+        service._mock_run_repo = mock_run_repo  # For test assertions
+        yield service
+```
+
+**Example conversion -- `test_track_execution_creates_run`:**
+
+Before:
+```python
+@pytest.mark.skip(reason="TODO: Integration test - needs test_db, ...")
+def test_track_execution_creates_run(self, test_db):
+    """Test that track_execution creates a service run record."""
+    service = MockServiceForTesting(db=test_db)
+    run_repo = ServiceRunRepository(test_db)
+    service.test_method()
+    recent_runs = run_repo.get_recent_runs(limit=1)
+    assert len(recent_runs) >= 1
+    latest_run = recent_runs[0]
+    assert latest_run.service_name == "TestService"
+```
+
+After:
+```python
+def test_track_execution_creates_run(self, mock_service):
+    """Test that track_execution creates a service run record."""
+    mock_service.test_method()
+
+    # Verify a run was created
+    mock_service._mock_run_repo.create_run.assert_called_once()
+    call_kwargs = mock_service._mock_run_repo.create_run.call_args
+    assert call_kwargs.kwargs.get("service_name") == "TestService" or \
+           (call_kwargs.args and call_kwargs.args[0] == "TestService")
+```
+
+**Example conversion -- `test_track_execution_records_failure`:**
+
+After:
+```python
+def test_track_execution_records_failure(self, mock_service):
+    """Test that failed execution is recorded correctly."""
+    # Configure complete_run to return a failed run
+    mock_service._mock_run_repo.complete_run.return_value = Mock(
+        status="failed",
+        error_message="Test error",
+        error_traceback="Traceback...",
+    )
+
+    with pytest.raises(ValueError, match="Test error"):
+        mock_service.test_method_with_error()
+
+    # Verify the run was completed with failure status
+    mock_service._mock_run_repo.complete_run.assert_called_once()
+    call_kwargs = mock_service._mock_run_repo.complete_run.call_args
+    assert "failed" in str(call_kwargs)
+```
+
+**For `test_get_logger`:** This test verifies `service.logger` exists. It does not need a database at all -- just verify the attribute:
+
+```python
+def test_get_logger(self, mock_service):
+    """Test that service has logger."""
+    # BaseService should provide a logger
+    assert hasattr(mock_service, 'logger') or hasattr(mock_service, '_logger')
+```
+
+---
+
+### 2. `test_instagram_api.py` -- 6 Tests
+
+**Current state:** Already has a working `instagram_service` fixture (lines 27-44) that properly mocks dependencies. The 6 skipped tests have **duplicate** `@pytest.mark.skip` decorators (two skip decorators on each test). The tests themselves are correctly structured -- they just need the skip decorators removed.
+
+**Tests to unskip:**
+
+| Line | Test | What to do |
+|---|---|---|
+| 127-141 | `test_is_configured_all_settings` | Remove both `@pytest.mark.skip` decorators (lines 127-132) |
+| 151-164 | `test_is_configured_missing_account_id` | Remove both `@pytest.mark.skip` decorators (lines 151-156) |
+| 264-279 | `test_post_story_no_token` | Remove both `@pytest.mark.skip` decorators (lines 264-269) |
+| 281-299 | `test_post_story_no_account_id` | Remove both `@pytest.mark.skip` decorators (lines 281-286) |
+| 301-348 | `test_post_story_success` | Remove both `@pytest.mark.skip` decorators (lines 301-306) |
+| 349-375 | `test_post_story_network_error` | Remove both `@pytest.mark.skip` decorators (lines 349-354) |
+
+**Important:** These tests should work as-is once unskipped because the existing `instagram_service` fixture already provides proper mocking. Run each test individually after unskipping to verify. If any fail, check that `mock_track_execution` (defined at line 17) is compatible with how the service uses `track_execution`.
+
+**Potential issue with `test_post_story_*` tests:** The `post_story` method may call `self.track_execution` as a context manager. The existing fixture replaces `track_execution` with `mock_track_execution` (a `@contextmanager` function). This should work, but verify.
+
+---
+
+### 3. `test_media_lock.py` -- 6 Tests
+
+**Current state:** All tests pass `db=test_db` to `MediaLockService(db=test_db)` and create real `MediaRepository` / `LockRepository` instances.
+
+**Fixture:**
+```python
+@pytest.fixture
+def lock_service():
+    """Create MediaLockService with mocked dependencies."""
+    with patch.object(MediaLockService, '__init__', lambda self: None):
+        service = MediaLockService()
+        service.lock_repo = Mock()
+        service._service_run_repo = Mock()
+        service.track_execution = mock_track_execution
+        service.set_result_summary = Mock()
+        return service
+```
+
+**Example conversion -- `test_create_lock`:**
+
+Before:
+```python
+@pytest.mark.skip(reason="TODO: Convert to unit test with mocks - ...")
+def test_create_lock(self, test_db):
+    media_repo = MediaRepository(test_db)
+    media = media_repo.create(file_path="/test/lock_test.jpg", ...)
+    service = MediaLockService(db=test_db)
+    lock = service.create_lock(media_id=media.id, reason="test_lock", lock_duration_days=30)
+    assert lock is not None
+    assert lock.media_id == media.id
+```
+
+After:
+```python
+def test_create_lock(self, lock_service):
+    """Test creating a media lock."""
+    media_id = str(uuid4())
+    mock_lock = Mock()
+    mock_lock.media_item_id = media_id
+    mock_lock.lock_type = "recent_post"
+
+    lock_service.lock_repo.create.return_value = mock_lock
+
+    lock = lock_service.create_lock(media_id)
+
+    lock_service.lock_repo.create.assert_called_once()
+    assert lock is not None
+```
+
+**Example conversion -- `test_is_locked`:**
+
+After:
+```python
+def test_is_locked(self, lock_service):
+    """Test checking if media is locked."""
+    media_id = str(uuid4())
+
+    # Not locked
+    lock_service.lock_repo.is_locked.return_value = False
+    assert lock_service.is_locked(media_id) is False
+
+    # Locked
+    lock_service.lock_repo.is_locked.return_value = True
+    assert lock_service.is_locked(media_id) is True
+```
+
+**For `test_cleanup_expired_locks`:**
+```python
+def test_cleanup_expired_locks(self, lock_service):
+    """Test cleaning up expired locks."""
+    lock_service.lock_repo.cleanup_expired.return_value = 3
+
+    result = lock_service.cleanup_expired_locks()
+
+    lock_service.lock_repo.cleanup_expired.assert_called_once()
+    assert result["deleted_count"] == 3
+```
+
+---
+
+### 4. `test_scheduler.py` -- 6 Tests
+
+**Current state:** Has a working `scheduler_service` fixture (in `TestSchedulerCategoryAllocation`, lines 231-252) that already demonstrates the correct mocking pattern. The 6 skipped tests are in `TestSchedulerService` and use `test_db`.
+
+**Note:** The existing working fixture in `TestSchedulerCategoryAllocation` uses `MagicMock` for `track_execution`. Reuse this pattern.
+
+**Fixture (add at the top of the file, before `TestSchedulerService`):**
+```python
+@pytest.fixture
+def scheduler_service_mocked():
+    """Create SchedulerService with all dependencies mocked."""
+    with patch("src.services.core.scheduler.MediaRepository"):
+        with patch("src.services.core.scheduler.QueueRepository"):
+            with patch("src.services.core.scheduler.LockRepository"):
+                with patch("src.services.core.scheduler.CategoryMixRepository"):
+                    with patch("src.services.core.scheduler.SettingsService"):
+                        with patch("src.services.base_service.ServiceRunRepository"):
+                            service = SchedulerService()
+                            service.media_repo = Mock()
+                            service.queue_repo = Mock()
+                            service.lock_repo = Mock()
+                            service.category_mix_repo = Mock()
+                            service.settings_service = Mock()
+                            # Mock track_execution
+                            service.track_execution = MagicMock()
+                            service.track_execution.return_value.__enter__ = Mock(
+                                return_value="run-123"
+                            )
+                            service.track_execution.return_value.__exit__ = Mock(
+                                return_value=False
+                            )
+                            service.set_result_summary = Mock()
+                            return service
+```
+
+**Example conversion -- `test_create_schedule_creates_queue_items`:**
+
+Before:
+```python
+@pytest.mark.skip(reason="TODO: Integration test - needs test_db, ...")
+def test_create_schedule_creates_queue_items(self, test_db):
+    media_repo = MediaRepository(test_db)
+    media_repo.create(file_path="/test/schedule1.jpg", ...)
+    user = user_repo.create(telegram_user_id=600001)
+    service = SchedulerService(db=test_db)
+    result = service.create_schedule(days=1, posts_per_day=2, user_id=user.id)
+    assert result["scheduled_count"] >= 1
+```
+
+After:
+```python
+def test_create_schedule_creates_queue_items(self, scheduler_service_mocked):
+    """Test that create_schedule creates queue items."""
+    service = scheduler_service_mocked
+
+    # Mock settings for time slot generation
+    mock_settings = Mock()
+    mock_settings.posts_per_day = 2
+    mock_settings.posting_hours_start = 9
+    mock_settings.posting_hours_end = 17
+    service.settings_service.get_settings.return_value = mock_settings
+
+    # Mock no category ratios
+    service.category_mix_repo.get_current_mix_as_dict.return_value = {}
+
+    # Mock media selection
+    mock_media = Mock()
+    mock_media.id = uuid4()
+    mock_media.file_name = "schedule1.jpg"
+    mock_media.category = "memes"
+
+    # Need to mock _select_media since it contains raw SQLAlchemy queries
+    service._select_media = Mock(return_value=mock_media)
+
+    result = service.create_schedule(days=1)
+
+    assert result["scheduled"] >= 1
+    # Verify queue items were created
+    assert service.queue_repo.create.call_count >= 1
+```
+
+**For `test_generate_time_slots`:** The `_generate_time_slots` method reads from `settings_service`. Mock the settings and verify the output:
+
+```python
+def test_generate_time_slots(self, scheduler_service_mocked):
+    """Test generating time slots for scheduling."""
+    service = scheduler_service_mocked
+
+    mock_settings = Mock()
+    mock_settings.posts_per_day = 3
+    mock_settings.posting_hours_start = 9
+    mock_settings.posting_hours_end = 21
+    service.settings_service.get_settings.return_value = mock_settings
+
+    with patch("src.services.core.scheduler.settings") as mock_global_settings:
+        mock_global_settings.ADMIN_TELEGRAM_CHAT_ID = -100123
+        time_slots = service._generate_time_slots(days=2)
+
+    # Should generate up to 6 slots (2 days * 3 posts), minus any in the past
+    assert len(time_slots) <= 6
+    # Slots should be in chronological order
+    for i in range(len(time_slots) - 1):
+        assert time_slots[i] < time_slots[i + 1]
+```
+
+---
+
+### 5. `test_posting.py` -- 5 Tests
+
+**Current state:** All 5 tests use `test_db` directly and create real repository objects.
+
+**Fixture:**
+```python
+@pytest.fixture
+def posting_service():
+    """Create PostingService with mocked dependencies."""
+    with patch.object(PostingService, '__init__', lambda self: None):
+        service = PostingService()
+        service.queue_repo = Mock()
+        service.media_repo = Mock()
+        service.history_repo = Mock()
+        service.telegram_service = Mock()
+        service.lock_service = Mock()
+        service.settings_service = Mock()
+        service._service_run_repo = Mock()
+        service.track_execution = mock_track_execution
+        service.set_result_summary = Mock()
+        return service
+```
+
+**Example conversion -- `test_process_pending_queue_no_items`:**
+
+After:
+```python
+def test_process_pending_queue_no_items(self, posting_service):
+    """Test processing queue when no items are pending."""
+    posting_service.queue_repo.get_pending.return_value = []
+
+    # Mock settings
+    mock_settings = Mock()
+    mock_settings.is_paused = False
+    posting_service.settings_service.get_settings.return_value = mock_settings
+    posting_service.telegram_service.is_paused = False
+
+    import asyncio
+    result = asyncio.get_event_loop().run_until_complete(
+        posting_service.process_pending_posts()
+    )
+
+    assert result["processed"] == 0
+```
+
+**Example conversion -- `test_mark_as_posted`:** The original test calls `mark_as_posted` which does not exist on the current `PostingService`. The equivalent is `handle_completion`. Convert accordingly:
+
+```python
+def test_handle_completion_success(self, posting_service):
+    """Test completing a post successfully."""
+    queue_id = str(uuid4())
+    media_id = uuid4()
+
+    mock_queue_item = Mock()
+    mock_queue_item.id = queue_id
+    mock_queue_item.media_item_id = media_id
+    mock_queue_item.created_at = datetime.utcnow()
+    mock_queue_item.scheduled_for = datetime.utcnow()
+    mock_queue_item.retry_count = 0
+
+    posting_service.queue_repo.get_by_id.return_value = mock_queue_item
+
+    posting_service.handle_completion(
+        queue_item_id=queue_id,
+        success=True,
+        posted_by_user_id=str(uuid4()),
+    )
+
+    # Verify history record created
+    posting_service.history_repo.create.assert_called_once()
+
+    # Verify media incremented and lock created (success path)
+    posting_service.media_repo.increment_times_posted.assert_called_once()
+    posting_service.lock_service.create_lock.assert_called_once()
+
+    # Verify queue item deleted
+    posting_service.queue_repo.delete.assert_called_once_with(queue_id)
+```
+
+---
+
+### 6. `test_telegram_commands.py` -- 9 Tests
+
+**Current state:** The existing `mock_command_handlers` fixture (lines 13-65) already works for the non-skipped tests. The skipped tests fall into three groups:
+
+#### Group A: `TestNextCommand` -- 3 function-level skips (lines 300-313)
+
+These are `test_next_media_not_found`, `test_next_notification_failure`, and `test_next_logs_interaction`. All are skipped with `reason="Needs PostingService mock - TODO"`.
+
+**Fix:** Follow the pattern from the working `test_next_sends_earliest_scheduled_post` test (line 206) which already mocks `PostingService`.
+
+Example for `test_next_media_not_found`:
+```python
+async def test_next_media_not_found(self, mock_command_handlers):
+    """Test /next handles missing media gracefully."""
+    handlers = mock_command_handlers
+    service = handlers.service
+
+    mock_user = Mock()
+    mock_user.id = uuid4()
+    service.user_repo.get_by_telegram_id.return_value = None
+    service.user_repo.create.return_value = mock_user
+
+    mock_posting_service = Mock()
+    mock_posting_service.force_post_next = AsyncMock(
+        return_value={
+            "success": False,
+            "queue_item_id": str(uuid4()),
+            "media_item": None,
+            "shifted_count": 0,
+            "error": "Media item not found",
+        }
+    )
+
+    mock_update = Mock()
+    mock_update.effective_user = Mock(
+        id=123, username="test", first_name="Test", last_name=None
+    )
+    mock_update.effective_chat = Mock(id=-100123)
+    mock_update.message = AsyncMock()
+    mock_update.message.message_id = 1
+    mock_context = Mock()
+
+    with patch(
+        "src.services.core.posting.PostingService",
+        return_value=mock_posting_service,
+    ):
+        await handlers.handle_next(mock_update, mock_context)
+
+    call_args = mock_update.message.reply_text.call_args
+    message_text = call_args.args[0]
+    assert "Error" in message_text or "failed" in message_text.lower()
+```
+
+#### Group B: `TestPauseCommand` -- Class-level skip (lines 316-388, 2 test methods)
+
+The class skip says `"Needs SettingsService mock for chat_settings.is_paused - TODO"`. The fix is to mock `service.settings_service.get_settings()` to return a mock with `is_paused` set appropriately, and mock `service.set_paused`.
+
+Remove the class-level `@pytest.mark.skip` (line 316-318) and update the test methods:
+
+```python
+async def test_pause_when_not_paused(self, mock_command_handlers):
+    """Test /pause pauses posting when not already paused."""
+    handlers = mock_command_handlers
+    service = handlers.service
+
+    mock_user = Mock()
+    mock_user.id = uuid4()
+    mock_user.telegram_username = "testuser"
+    service.user_repo.get_by_telegram_id.return_value = None
+    service.user_repo.create.return_value = mock_user
+
+    service.queue_repo.count_pending.return_value = 10
+
+    # Mock settings: not paused
+    mock_settings = Mock()
+    mock_settings.is_paused = False
+    service.settings_service.get_settings.return_value = mock_settings
+    service.is_paused = False
+    service.set_paused = Mock()
+
+    mock_update = Mock()
+    mock_update.effective_user = Mock(
+        id=123, username="test", first_name="Test", last_name=None
+    )
+    mock_update.effective_chat = Mock(id=-100123)
+    mock_update.message = AsyncMock()
+    mock_update.message.message_id = 1
+    mock_context = Mock()
+
+    await handlers.handle_pause(mock_update, mock_context)
+
+    service.set_paused.assert_called_once()
+    call_args = mock_update.message.reply_text.call_args
+    message_text = call_args.args[0]
+    assert "Paused" in message_text
+```
+
+#### Group C: `TestResumeCommand` -- Class-level skip (lines 391-505, 3 test methods)
+
+Skip says `"Needs SettingsService and SchedulerService mocks"`. Same approach as TestPauseCommand -- mock `is_paused`, `set_paused`, and `queue_repo.get_all`.
+
+Remove the class-level `@pytest.mark.skip` (line 391) and update each test. The existing test bodies (lines 397-505) are already structured correctly -- they just need the `service.set_paused` and `service.is_paused` attributes to be mockable. Add this setup at the start of each test:
+
+```python
+service.is_paused = True  # or False depending on the test
+service.set_paused = Mock()
+```
+
+#### Group D: `TestPauseIntegration` -- Class-level skip (lines 859-873, 1 test)
+
+Skip says `"Complex integration test requiring PostingService and database"`. This test verifies that `PostingService` has access to `telegram_service.is_paused`. Convert to:
+
+```python
+def test_posting_service_respects_pause(self):
+    """Test that PostingService checks pause state."""
+    with patch.object(PostingService, '__init__', lambda self: None):
+        posting_service = PostingService()
+        posting_service.telegram_service = Mock()
+        posting_service.telegram_service.is_paused = True
+
+        assert posting_service.telegram_service.is_paused is True
+```
+
+---
+
+### 7. `test_telegram_callbacks.py` -- 4 Tests
+
+**Current state:** The `mock_callback_handlers` fixture (lines 13-64) already works for all non-skipped tests.
+
+#### `TestResumeCallbacks` -- Class-level skip (lines 203-310, 3 test methods)
+
+Skip says `"Needs SettingsService and SchedulerService mocks - TODO"`. The tests (`test_resume_reschedule`, `test_resume_clear`, `test_resume_force`) are already fully written with correct mocking patterns. They just need `service.set_paused` and `service.is_paused` to work.
+
+**Fix:** Remove the class-level `@pytest.mark.skip` (line 203) and add these lines at the start of each test method:
+
+```python
+service.is_paused = True
+service.set_paused = Mock()
+```
+
+The tests reference `service.set_paused(False, user)` (with two args) in `handle_resume_callback`. Verify the mock accepts these args. Since `Mock()` accepts any arguments by default, this should work.
+
+**Example fix for `test_resume_reschedule`:**
+
+The test body (lines 209-241) is correct. Only two changes needed:
+1. Remove class-level skip decorator (line 203)
+2. Add `service.is_paused = True` and `service.set_paused = Mock()` after line 218
+
+After:
+```python
+async def test_resume_reschedule(self, mock_callback_handlers):
+    """Test resume:reschedule reschedules overdue posts."""
+    handlers = mock_callback_handlers
+    service = handlers.service
+
+    mock_user = Mock()
+    mock_user.id = uuid4()
+    mock_user.telegram_username = "testuser"
+    mock_user.telegram_first_name = "Test"
+
+    service.is_paused = True
+    service.set_paused = Mock()
+
+    overdue_item = Mock()
+    overdue_item.id = uuid4()
+    overdue_item.scheduled_for = datetime(2020, 1, 1, 12, 0)
+
+    service.queue_repo.get_all.return_value = [overdue_item]
+
+    mock_query = AsyncMock()
+    mock_query.message = Mock(chat_id=-100123, message_id=1)
+
+    await handlers.handle_resume_callback("reschedule", mock_user, mock_query)
+
+    service.set_paused.assert_called_once_with(False, mock_user)
+    service.queue_repo.update_scheduled_time.assert_called_once()
+
+    call_args = mock_query.edit_message_text.call_args
+    assert "Rescheduled 1 overdue posts" in call_args.args[0]
+```
+
+The same pattern applies to `test_resume_clear` and `test_resume_force`.
+
+---
+
+## Summary of Changes Per File
+
+| File | Action |
+|---|---|
+| `test_base_service.py` | Add `mock_service` fixture, convert 9 tests to use it |
+| `test_instagram_api.py` | Remove 12 `@pytest.mark.skip` decorators (6 tests, each with 2 skips) |
+| `test_media_lock.py` | Add `lock_service` fixture, convert 6 tests to use it |
+| `test_scheduler.py` | Add `scheduler_service_mocked` fixture, convert 6 tests to use it |
+| `test_posting.py` | Add `posting_service` fixture, convert 5 tests (note: some method names may have changed) |
+| `test_telegram_commands.py` | Remove 4 class-level skips, add mock setup to 9 test methods |
+| `test_telegram_callbacks.py` | Remove 1 class-level skip, add mock setup to 3 test methods |
+
+---
+
+## Verification Checklist
+
+After converting all tests:
+
+- [ ] Run `pytest tests/src/services/test_base_service.py -v` -- 9 previously-skipped tests now pass
+- [ ] Run `pytest tests/src/services/test_instagram_api.py -v` -- 6 previously-skipped tests now pass
+- [ ] Run `pytest tests/src/services/test_media_lock.py -v` -- 6 previously-skipped tests now pass
+- [ ] Run `pytest tests/src/services/test_scheduler.py -v` -- 6 previously-skipped tests now pass (plus existing passing tests)
+- [ ] Run `pytest tests/src/services/test_posting.py -v` -- 5 previously-skipped tests now pass
+- [ ] Run `pytest tests/src/services/test_telegram_commands.py -v` -- 9 previously-skipped tests now pass (plus existing passing tests)
+- [ ] Run `pytest tests/src/services/test_telegram_callbacks.py -v` -- 4 previously-skipped tests now pass (plus existing passing tests)
+- [ ] Run `pytest tests/src/services/ -v` -- full service test suite passes with 0 skipped
+- [ ] Run `ruff check tests/src/services/`
+- [ ] Run `ruff format tests/src/services/`
+- [ ] Verify there are no remaining `@pytest.mark.skip` decorators: `grep -r "pytest.mark.skip" tests/src/services/` should return nothing
+- [ ] Run `pytest --co tests/src/services/ | grep "skipped"` -- should show 0 skipped
+- [ ] Verify existing passing tests are not broken: run `pytest tests/src/services/ -x` for fail-fast
+
+---
+
+## What NOT To Do
+
+1. **Do NOT change the existing working fixtures.** The `mock_command_handlers` and `mock_callback_handlers` fixtures in `test_telegram_commands.py` and `test_telegram_callbacks.py` are already correct and used by many passing tests. Only remove skip decorators and add small setup lines.
+2. **Do NOT make the tests async if they are not already async.** The `test_base_service.py` tests are synchronous. Keep them synchronous. Only Telegram handler tests should be async.
+3. **Do NOT remove the `MockServiceForTesting` class from `test_base_service.py`.** It is a deliberate test double that extends `BaseService` and is the correct way to test abstract base class behavior.
+4. **Do NOT add `time.sleep()` to any test.** Mock time-dependent behavior instead.
+5. **Do NOT change test names or docstrings.** The test names describe what is being tested. Changing them breaks the audit trail of what was converted.
+6. **Do NOT import from `src.config.database` in any test.** If you find yourself importing `get_db`, you are creating an integration test, not a unit test.
+7. **Do NOT attempt to convert `test_posting.py` tests that call methods that no longer exist.** If `mark_as_posted` or `mark_as_skipped` have been removed from `PostingService`, rewrite the test to test the equivalent current method (`handle_completion`). Note this in the PR description.
+8. **Do NOT add new test files.** All conversions happen in the existing files.
+9. **Do NOT convert the `test_instagram_api.py` tests into a different mocking pattern.** The existing `instagram_service` fixture works. These tests only need their skip decorators removed.

--- a/tests/src/services/test_telegram_callbacks.py
+++ b/tests/src/services/test_telegram_callbacks.py
@@ -201,7 +201,6 @@ class TestRejectConfirmation:
         service.lock_service.create_permanent_lock.assert_not_called()
 
 
-@pytest.mark.skip(reason="Needs SettingsService and SchedulerService mocks - TODO")
 @pytest.mark.unit
 @pytest.mark.asyncio
 class TestResumeCallbacks:
@@ -216,7 +215,14 @@ class TestResumeCallbacks:
         mock_user.id = uuid4()
         mock_user.telegram_username = "testuser"
 
-        service.set_paused(True)
+        # Mock is_paused via settings_service — paused
+        mock_chat_settings = Mock(is_paused=True)
+        service.settings_service.get_settings.return_value = mock_chat_settings
+        service.set_paused = Mock(
+            side_effect=lambda paused, user=None: setattr(
+                mock_chat_settings, "is_paused", paused
+            )
+        )
 
         # Create overdue item
         overdue_item = Mock()
@@ -250,7 +256,14 @@ class TestResumeCallbacks:
         mock_user.id = uuid4()
         mock_user.telegram_username = "testuser"
 
-        service.set_paused(True)
+        # Mock is_paused via settings_service — paused
+        mock_chat_settings = Mock(is_paused=True)
+        service.settings_service.get_settings.return_value = mock_chat_settings
+        service.set_paused = Mock(
+            side_effect=lambda paused, user=None: setattr(
+                mock_chat_settings, "is_paused", paused
+            )
+        )
 
         # Create overdue and future items
         overdue_item = Mock()
@@ -288,7 +301,14 @@ class TestResumeCallbacks:
         mock_user.id = uuid4()
         mock_user.telegram_username = "testuser"
 
-        service.set_paused(True)
+        # Mock is_paused via settings_service — paused
+        mock_chat_settings = Mock(is_paused=True)
+        service.settings_service.get_settings.return_value = mock_chat_settings
+        service.set_paused = Mock(
+            side_effect=lambda paused, user=None: setattr(
+                mock_chat_settings, "is_paused", paused
+            )
+        )
 
         overdue_item = Mock()
         overdue_item.scheduled_for = datetime(2020, 1, 1, 12, 0)


### PR DESCRIPTION
## Summary
- Convert 45 previously-skipped service tests across 7 files to working unit tests with proper mocking
- Fix test patterns for multi-account Instagram architecture, is_paused property mocking, and time-dependent scheduler tests
- Implement 3 stub test methods and add missing dependency patches to instagram_api fixture

## Changes

### Files Modified (7 test files)
- `test_base_service.py` — Rewrote with `ServiceRunRepository` mock fixture; fixed `input_params` kwarg and `set_result_summary` usage
- `test_media_lock.py` — Rewrote with correct method signatures (`cleanup_expired_locks` returns `int`, `get_active_lock` singular)
- `test_posting.py` — Adapted for `handle_completion()` API (replaced `mark_as_posted`/`mark_as_skipped`)
- `test_scheduler.py` — Fixed time-dependent `create_schedule` tests (`days=2` for reliable future slots); removed unused imports
- `test_instagram_api.py` — Removed 12 duplicate `@pytest.mark.skip` decorators; added missing dependency patches (`InstagramAccountService`, `TokenRepository`, `TokenEncryption`, `SettingsService`); updated tests for multi-account credential flow
- `test_telegram_commands.py` — Implemented 3 stub tests (`test_next_media_not_found`, `test_next_notification_failure`, `test_next_logs_interaction`); removed class-level skips from `TestPauseCommand`, `TestResumeCommand`, `TestPauseIntegration`; added `is_paused`/`set_paused` mock pattern via `settings_service`
- `test_telegram_callbacks.py` — Removed class-level skip from `TestResumeCallbacks`; added `is_paused`/`set_paused` mock setup

### Key Mock Patterns
- **is_paused property**: `Mock(is_paused=False)` on `settings_service.get_settings.return_value` + `Mock(side_effect=...)` on `set_paused`
- **Instagram multi-account**: Must patch `InstagramAccountService`, `TokenRepository`, `TokenEncryption`, `SettingsService` in addition to existing patches
- **Time-dependent tests**: Use `days=2` to guarantee future time slots regardless of current UTC time

## Test plan
- [x] `ruff check src/ tests/` — passes
- [x] `ruff format --check src/ tests/` — passes
- [x] `pytest tests/src/services/ -v` — 313 passed, 10 skipped (expected: 6 settings integration + 4 legacy telegram)
- [x] `pytest` (full suite) — 464 passed, 38 skipped, 0 failed

## Phase 09 of tech debt remediation plan
`documentation/planning/tech_debt/full-review-feb-2026_2026-02-10/09_service-test-conversion.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)