### PR TITLE
refactor: break down _do_autopost() and handle_status() long methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Extract sub-methods from long handlers** - Decomposed `_do_autopost()` and `handle_status()` into focused helpers
+  - `_do_autopost()` reduced from 353 to ~50 lines via `AutopostContext` dataclass + 7 extracted helpers (`_get_account_display`, `_upload_to_cloudinary`, `_handle_dry_run`, `_execute_instagram_post`, `_record_successful_post`, `_send_success_message`, `_handle_autopost_error`)
+  - `handle_status()` reduced from 115 to ~50 lines via 4 extracted helpers (`_get_next_post_display`, `_get_last_posted_display`, `_get_instagram_api_status`, `_get_sync_status_line`)
+  - 27 new tests covering all extracted methods
+
 - **BackfillContext dataclass for parameter reduction** - Introduced `BackfillContext` to bundle shared state across backfill call chain
   - Reduces `_backfill_feed` from 9 to 3 params, `_backfill_stories` from 8 to 2, `_process_media_item` from 8 to 3, `_process_carousel` from 7 to 2, `_download_and_index` from 7 to 6
   - Removed unused `username` parameter from `_download_and_index`

--- a/documentation/planning/tech_debt/quality-review-feb-2026_2026-02-12/00_TECH_DEBT.md
+++ b/documentation/planning/tech_debt/quality-review-feb-2026_2026-02-12/00_TECH_DEBT.md
@@ -1,0 +1,102 @@
+# Tech Debt: Post-Cloud-Media Quality Review
+
+**Status:** 📋 PENDING
+**Created:** 2026-02-12
+**Session:** `quality-review-feb-2026`
+**Trigger:** Codebase scan after completing Cloud Media Enhancements (5 phases, PRs #41-#45)
+
+## Executive Summary
+
+Scan of the 32,680-line codebase revealed **12 findings** across 3 severity levels. The codebase is structurally sound (no dead code, no unused imports, clean architecture), but the rapid 5-phase feature addition introduced complexity hotspots and test coverage gaps that should be addressed before the next feature cycle.
+
+**Key numbers:**
+- 708 tests passing, 13 skipped
+- 0% test coverage on models (12 files) and config (3 files)
+- 17 CLI tests all skipped (TODO placeholders)
+- 1 function at 315 lines with 6+ nesting levels
+- 4 functions with 7-8 parameters each
+- ~150 lines of duplicated code across Telegram handlers
+
+## Findings Inventory
+
+### HIGH Priority
+
+| ID | Finding | Location | Severity |
+|----|---------|----------|----------|
+| H1 | Monster method: 315 lines, 6+ nesting, duplicated cleanup 3x | `telegram_accounts.py:handle_add_account_message()` L167-482 | High |
+| H2 | Parameter bloat: 4 functions with 7-8 params each | `instagram_backfill.py` | High |
+| H3 | 0% test coverage on models (12) and config (3) | `src/models/`, `src/config/` | High |
+| H4 | 17 CLI tests all skipped with TODO placeholders | `tests/cli/test_user_commands.py`, `test_queue_commands.py`, `test_media_commands.py` | High |
+
+### MEDIUM Priority
+
+| ID | Finding | Location | Severity |
+|----|---------|----------|----------|
+| M1 | Long method: 152+ lines, 8 params | `telegram_autopost.py:_do_autopost()` L97 | Medium |
+| M2 | Long method: 115 lines, 5 nesting levels | `telegram_commands.py:handle_status()` L54-168 | Medium |
+| M3 | ~150 duplicated lines: keyboard building (4x), cleanup loops (3x), API error extraction (3x) | Telegram handler files | Medium |
+| M4 | 3 of 5 exception modules untested | `base.py`, `google_drive.py`, `instagram.py` | Medium |
+| M5 | 3 new CLI command modules with 0 tests | `backfill.py`, `google_drive.py`, `sync.py` | Medium |
+
+### LOW Priority
+
+| ID | Finding | Location | Severity |
+|----|---------|----------|----------|
+| L1 | Missing `__init__.py` exports for 2 repositories | `src/repositories/__init__.py` | Low |
+| L2 | Stale comment (says "unused" but is used by tests) | `service_run_repository.py` L87 | Low |
+| L3 | 9 packages with minor version bumps | `pip list --outdated` | Low |
+
+## Phased Remediation Plan
+
+### Dependency Matrix
+
+```
+Phase 01  ──┐
+             ├──► Phase 04
+Phase 03  ──┘
+
+Phase 02  (independent)
+Phase 05  (independent)
+Phase 06  (independent)
+Phase 07  (independent, naturally last)
+```
+
+### Phase Summary
+
+| Phase | Title | Findings | Risk | Effort | PR |
+|-------|-------|----------|------|--------|-----|
+| 01 | Refactor Account Add State Machine | H1 | Medium | 2-3h | #46 |
+| 02 | BackfillContext Dataclass | H2 | Low | 1-2h | #47 |
+| 03 | Extract Long Method Sub-Methods | M1, M2 | Medium | 2-3h | #48 |
+| 04 | Extract Shared Telegram Utilities | M3 | Low | 1-2h | - |
+| 05 | Convert Skipped CLI Tests | H4 | Low | 2-3h | - |
+| 06 | Model, Config, and Exception Tests | H3, M4 | Low | 3-4h | - |
+| 07 | CLI Command Tests + Cleanup | M5, L1-L3 | Low | 2-3h | - |
+
+### Parallel Execution Guide
+
+**Can run in parallel** (touch disjoint files):
+- Phase 01, 02, 05, 06 are fully independent
+- Phase 03 is independent of 01 and 02
+
+**Must be sequential:**
+- Phase 04 depends on Phase 01 + Phase 03 (extracts patterns they create)
+- Phase 07 is naturally last (cleanup)
+
+### Recommended Execution Order
+
+1. **Phase 01** — Refactor the worst complexity hotspot
+2. **Phase 02** — Quick win, independent
+3. **Phase 03** — Extract long methods (unblocks Phase 04)
+4. **Phase 04** — Deduplicate shared patterns (depends on 01 + 03)
+5. **Phase 05** — Convert skipped CLI tests (independent)
+6. **Phase 06** — Add model/config/exception tests (independent)
+7. **Phase 07** — CLI command tests + final cleanup
+
+## What's NOT in Scope
+
+- **Dead code removal** — Already clean from prior tech debt session (PRs #28-#40)
+- **Architecture changes** — The 3-layer architecture is solid
+- **Dependency upgrades** — Only minor bumps, no security issues
+- **Performance optimization** — No performance issues identified
+- **New features** — This is strictly quality improvement

--- a/documentation/planning/tech_debt/quality-review-feb-2026_2026-02-12/03_extract-long-method-submethods.md
+++ b/documentation/planning/tech_debt/quality-review-feb-2026_2026-02-12/03_extract-long-method-submethods.md
@@ -1,0 +1,349 @@
+# Phase 03: Extract Sub-Methods from Long Handlers
+
+**Status:** ✅ COMPLETE
+**Started:** 2026-02-12
+**Completed:** 2026-02-12
+**PR Title:** `refactor: break down _do_autopost() and handle_status() long methods`
+**Risk Level:** Medium
+**Estimated Effort:** 2-3 hours
+**Files Modified:**
+- `src/services/core/telegram_autopost.py` (primary)
+- `src/services/core/telegram_commands.py` (primary)
+- `tests/src/services/test_telegram_autopost.py` (add tests)
+- `tests/src/services/test_telegram_commands.py` (add tests)
+
+## Dependencies
+- None (independent)
+
+## Blocks
+- Phase 04 (shared utilities extraction)
+
+## Context
+
+Two methods exceed maintainability thresholds:
+- `_do_autopost()` in `telegram_autopost.py`: **152+ lines, 8 params**, mixes upload, posting, recording, and error handling
+- `handle_status()` in `telegram_commands.py`: **115 lines, 5 nesting levels**, queries 7+ services inline
+
+## Implementation Steps
+
+### Part A: telegram_autopost.py
+
+#### Step 1: Define `AutopostContext` dataclass
+
+Add at module level (after imports, before class). Bundles shared state that flows through the autopost call chain, avoiding parameter bloat in extracted methods. Follows the same pattern as `BackfillContext` (Phase 02).
+
+```python
+@dataclass
+class AutopostContext:
+    """Shared state passed through the autopost call chain."""
+
+    queue_id: str
+    queue_item: object  # PostingQueue model
+    media_item: object  # MediaItem model
+    user: object  # User model
+    query: object  # CallbackQuery
+    chat_id: int
+    chat_settings: object  # ChatSettings model
+    cloud_service: object  # CloudStorageService
+    instagram_service: object  # InstagramAPIService
+    cancel_flag: object = None  # threading.Event or None
+    cloud_url: str | None = None
+    cloud_public_id: str | None = None
+```
+
+#### Step 2: Extract `_get_account_display()`
+
+Extract the account info lookup into a helper (~lines 350-360).
+
+```python
+async def _get_account_display(self, ctx: AutopostContext) -> str:
+    """Get formatted account display string for messages."""
+    try:
+        account_info = await ctx.instagram_service.get_account_info(
+            telegram_chat_id=ctx.chat_id
+        )
+        return f"@{account_info.get('username', 'Unknown')}"
+    except Exception:
+        return "Unknown account"
+```
+
+#### Step 3: Extract `_upload_to_cloudinary()`
+
+Extract lines ~133-176 (the Cloudinary upload section). Sets `ctx.cloud_url` and `ctx.cloud_public_id`.
+
+```python
+async def _upload_to_cloudinary(self, ctx: AutopostContext) -> bool:
+    """Upload media to Cloudinary for Instagram posting.
+
+    Sets ctx.cloud_url and ctx.cloud_public_id.
+    Returns False if cancelled, True on success.
+    """
+    if ctx.cancel_flag and ctx.cancel_flag.is_set():
+        return False
+
+    await ctx.query.edit_message_caption(
+        caption="☁️ *Uploading to cloud...*", parse_mode="Markdown"
+    )
+
+    cloud_result = ctx.cloud_service.upload_media(ctx.media_item)
+    ctx.cloud_url = cloud_result["url"]
+    ctx.cloud_public_id = cloud_result["public_id"]
+
+    self.service.media_repo.update_cloud_info(
+        media_id=str(ctx.media_item.id),
+        cloud_url=ctx.cloud_url,
+        cloud_public_id=ctx.cloud_public_id,
+        cloud_uploaded_at=datetime.utcnow(),
+    )
+
+    return True
+```
+
+#### Step 4: Extract `_handle_dry_run()`
+
+Extract the dry-run branch (~lines 180-269).
+
+```python
+async def _handle_dry_run(self, ctx: AutopostContext) -> None:
+    """Handle dry-run mode: log what would happen, cleanup cloud, show message."""
+    # ... dry run caption building and interaction logging
+    # ... cloud cleanup
+    # ... edit message with dry run result
+```
+
+Preserve the exact caption text and interaction logging from the current code.
+
+#### Step 5: Extract `_execute_instagram_post()`
+
+Extract lines ~284-310 (the actual Instagram API call).
+
+```python
+async def _execute_instagram_post(self, ctx: AutopostContext) -> str | None:
+    """Post media to Instagram via the Graph API.
+
+    Returns:
+        Instagram story_id string, or None if cancelled.
+    """
+    if ctx.cancel_flag and ctx.cancel_flag.is_set():
+        return None
+
+    await ctx.query.edit_message_caption(
+        caption="⏳ *Posting to Instagram...*", parse_mode="Markdown"
+    )
+
+    media_type = (
+        "VIDEO" if ctx.media_item.file_path.lower().endswith((".mp4", ".mov")) else "IMAGE"
+    )
+
+    if media_type == "IMAGE":
+        story_url = ctx.cloud_service.get_story_optimized_url(ctx.cloud_url)
+    else:
+        story_url = ctx.cloud_url
+
+    post_result = await ctx.instagram_service.post_story(
+        media_url=story_url, media_type=media_type, telegram_chat_id=ctx.chat_id,
+    )
+
+    story_id = post_result.get("story_id")
+    logger.info(f"Posted to Instagram: story_id={story_id}")
+    return story_id
+```
+
+#### Step 6: Extract `_record_successful_post()`
+
+Extract lines ~316-345 (history, increment, lock, queue delete, user stats).
+
+```python
+def _record_successful_post(self, ctx: AutopostContext, story_id: str) -> None:
+    """Record a successful Instagram post in all relevant tables."""
+    self.service.history_repo.create(
+        HistoryCreateParams(
+            media_item_id=str(ctx.queue_item.media_item_id),
+            queue_item_id=ctx.queue_id,
+            queue_created_at=ctx.queue_item.created_at,
+            queue_deleted_at=datetime.utcnow(),
+            scheduled_for=ctx.queue_item.scheduled_for,
+            posted_at=datetime.utcnow(),
+            status="posted",
+            success=True,
+            posted_by_user_id=str(ctx.user.id),
+            posted_by_telegram_username=ctx.user.telegram_username,
+            posting_method="instagram_api",
+            instagram_story_id=story_id,
+        )
+    )
+    self.service.media_repo.increment_times_posted(str(ctx.queue_item.media_item_id))
+    self.service.lock_service.create_lock(str(ctx.queue_item.media_item_id))
+    self.service.queue_repo.delete(ctx.queue_id)
+    self.service.user_repo.increment_posts(str(ctx.user.id))
+```
+
+#### Step 7: Extract `_handle_autopost_error()`
+
+Extract the except block (~lines 413-449).
+
+```python
+async def _handle_autopost_error(self, ctx: AutopostContext, e: Exception) -> None:
+    """Handle auto-post failure: show error message with recovery options."""
+    error_msg = str(e)
+    logger.error(f"Auto-post failed: {error_msg}", exc_info=True)
+
+    caption = (
+        f"❌ *Auto Post Failed*\n\n"
+        f"Error: {error_msg[:200]}\n\n"
+        f"You can try again or use manual posting."
+    )
+
+    reply_markup = build_error_recovery_keyboard(
+        ctx.queue_id, enable_instagram_api=settings.ENABLE_INSTAGRAM_API
+    )
+
+    await ctx.query.edit_message_caption(
+        caption=caption, reply_markup=reply_markup, parse_mode="Markdown",
+    )
+
+    self.service.interaction_service.log_callback(
+        user_id=str(ctx.user.id), callback_name="autopost",
+        context={
+            "queue_item_id": ctx.queue_id,
+            "media_id": str(ctx.queue_item.media_item_id),
+            "media_filename": ctx.media_item.file_name,
+            "dry_run": False, "success": False, "error": error_msg[:200],
+        },
+        telegram_chat_id=ctx.query.message.chat_id,
+        telegram_message_id=ctx.query.message.message_id,
+    )
+```
+
+#### Step 8: Rewrite `_do_autopost()` as orchestrator
+
+Replace body with ~55 lines: create `AutopostContext`, then call sub-methods in sequence: safety check → upload → dry-run check → post → record → success message, with try/except calling `_handle_autopost_error`. Keep the 8-parameter signature unchanged (callers don't see `AutopostContext`).
+
+### Part B: telegram_commands.py
+
+#### Step 9: Extract `_get_next_post_display()`
+
+```python
+def _get_next_post_display(self) -> str:
+    """Get formatted display for next scheduled post time."""
+    next_items = self.service.queue_repo.get_pending(limit=1)
+    if next_items:
+        return next_items[0].scheduled_for.strftime("%H:%M UTC")
+    return "None scheduled"
+```
+
+#### Step 10: Extract `_get_last_posted_display()`
+
+```python
+def _get_last_posted_display(self, recent_posts) -> str:
+    """Get formatted display for last post time."""
+    if recent_posts:
+        time_diff = datetime.utcnow() - recent_posts[0].posted_at
+        hours = int(time_diff.total_seconds() / 3600)
+        return f"{hours}h ago" if hours > 0 else "< 1h ago"
+    return "Never"
+```
+
+#### Step 11: Extract `_get_instagram_api_status()`
+
+```python
+def _get_instagram_api_status(self) -> str:
+    """Get formatted Instagram API status string."""
+    if settings.ENABLE_INSTAGRAM_API:
+        from src.services.integrations.instagram_api import InstagramAPIService
+        with InstagramAPIService() as ig_service:
+            rate_remaining = ig_service.get_rate_limit_remaining()
+        return f"✅ Enabled ({rate_remaining}/{settings.INSTAGRAM_POSTS_PER_HOUR} remaining)"
+    return "❌ Disabled"
+```
+
+#### Step 12: Extract `_get_sync_status_line()`
+
+Extract lines 94-133 (the most deeply nested section at 5 levels).
+
+```python
+def _get_sync_status_line(self, chat_id) -> str:
+    """Get formatted media sync status (catches all exceptions internally)."""
+    try:
+        from src.services.core.media_sync import MediaSyncService
+        sync_service = MediaSyncService()
+        last_sync = sync_service.get_last_sync_info()
+        chat_settings = self.service.settings_service.get_settings(chat_id)
+
+        if not chat_settings.media_sync_enabled:
+            return "🔄 Media Sync: ❌ Disabled"
+        if not last_sync:
+            return "🔄 Media Sync: ⏳ No syncs yet"
+        if last_sync["success"]:
+            result = last_sync.get("result", {}) or {}
+            new_count = result.get("new", 0)
+            total = sum(result.get(k, 0) for k in ["new", "updated", "deactivated", "reactivated", "unchanged"])
+            return (
+                f"🔄 Media Sync: ✅ OK"
+                f"\n   └─ Last: {last_sync['started_at'][:16]} ({total} items, {new_count} new)"
+            )
+        return f"🔄 Media Sync: ⚠️ Last sync failed\n   └─ {last_sync.get('started_at', 'N/A')[:16]}"
+    except Exception:
+        return "🔄 Media Sync: ❓ Check failed"
+```
+
+#### Step 13: Rewrite `handle_status()` to compose from helpers
+
+Drops from 115 lines to ~50 lines. Max nesting drops from 5 to 2.
+
+### Part C: Add Tests
+
+#### Step 14: Add `AutopostContext` tests
+
+Add `TestAutopostContext` class verifying dataclass creation and mutable field defaults.
+
+#### Step 15: Add autopost helper tests
+
+Add tests for all 6 extracted autopost methods. Use a `make_autopost_ctx` factory fixture (similar to Phase 02's `make_ctx`).
+
+| Test Class | Methods Tested | Test Cases |
+|-----------|---------------|------------|
+| `TestAutopostContext` | dataclass | creation, default fields |
+| `TestGetAccountDisplay` | `_get_account_display` | success, exception fallback |
+| `TestUploadToCloudinary` | `_upload_to_cloudinary` | success (sets ctx fields), cancelled returns False |
+| `TestHandleDryRun` | `_handle_dry_run` | edits message with dry-run caption, cleans up cloud |
+| `TestExecuteInstagramPost` | `_execute_instagram_post` | success returns story_id, cancelled returns None, IMAGE vs VIDEO media type |
+| `TestRecordSuccessfulPost` | `_record_successful_post` | calls all 5 repo operations (history, increment, lock, delete queue, user stats) |
+| `TestHandleAutopostError` | `_handle_autopost_error` | edits message with error caption, logs interaction |
+
+Existing integration-level tests (`handle_autopost()` → `_do_autopost()`) continue to pass unchanged.
+
+#### Step 16: Add status helper tests
+
+Add tests for all 4 status helpers + end-to-end `handle_status()`.
+
+| Test Class | Methods Tested | Test Cases |
+|-----------|---------------|------------|
+| `TestGetNextPostDisplay` | `_get_next_post_display` | with pending items, empty queue |
+| `TestGetLastPostedDisplay` | `_get_last_posted_display` | recent post (hours ago), very recent (< 1h), no posts |
+| `TestGetInstagramApiStatus` | `_get_instagram_api_status` | enabled with rate limit, disabled |
+| `TestGetSyncStatusLine` | `_get_sync_status_line` | disabled, no syncs yet, successful sync, failed sync, exception |
+| `TestStatusCommand` | `handle_status` | end-to-end: sends formatted message with all sections |
+
+## Verification Checklist
+
+- [x] `AutopostContext` dataclass defined at module level in `telegram_autopost.py`
+- [x] All 7 extracted autopost methods take `ctx: AutopostContext` (not bare params)
+- [x] `ruff check src/services/core/telegram_autopost.py src/services/core/telegram_commands.py`
+- [x] `ruff format --check` passes
+- [x] `pytest tests/src/services/test_telegram_autopost.py -v` — all 20 tests pass (6 existing + 14 new)
+- [x] `pytest tests/src/services/test_telegram_commands.py -v` — all 36 tests pass (23 existing + 13 new)
+- [x] `pytest` — full suite passes (750 passed, 38 skipped)
+- [x] `_do_autopost()` is under 60 lines (~50, was 353)
+- [x] `handle_status()` is under 55 lines (~50, was 115)
+- [x] Lazy imports preserved (MediaSyncService, InstagramAPIService inside methods)
+- [x] CHANGELOG.md updated
+
+## What NOT To Do
+
+- **Do NOT change signatures of `handle_autopost()`, `_locked_autopost()`, or `_do_autopost()`**
+- **Do NOT change user-visible caption text, emoji, or Markdown formatting**
+- **Do NOT change the order of operations in `_do_autopost()`** — safety check → upload → dry-run → post → record is critical
+- **Do NOT extract the safety check** (lines 114-128) — it's only 15 lines and reads well as a guard clause
+- **Do NOT refactor other commands** (`handle_sync`, `handle_backfill`, etc.) — out of scope
+- **Do NOT create new files** — extracted methods stay as private methods on the same class


### PR DESCRIPTION
## Summary
- **`_do_autopost()`** reduced from 353 to ~50 lines via `AutopostContext` dataclass + 7 extracted helpers
- **`handle_status()`** reduced from 115 to ~50 lines via 4 extracted status helpers
- 27 new unit tests covering all extracted methods (750 passed, 38 skipped)

## Changes

### telegram_autopost.py
- Added `AutopostContext` dataclass bundling shared state across the autopost call chain
- Extracted: `_get_account_display`, `_upload_to_cloudinary`, `_handle_dry_run`, `_execute_instagram_post`, `_record_successful_post`, `_send_success_message`, `_handle_autopost_error`
- `_do_autopost()` now orchestrates: safety check → upload → dry-run check → post → record

### telegram_commands.py
- Extracted: `_get_next_post_display`, `_get_last_posted_display`, `_get_instagram_api_status`, `_get_sync_status_line`
- `handle_status()` now composes from helpers with max nesting of 2 (was 5)

### Tests
- 14 new autopost tests: AutopostContext, GetAccountDisplay, UploadToCloudinary, HandleDryRun, ExecuteInstagramPost, RecordSuccessfulPost, HandleAutopostError
- 13 new commands tests: GetNextPostDisplay, GetLastPostedDisplay, GetInstagramApiStatus, GetSyncStatusLine, StatusCommand

## Test plan
- [x] All 6 existing autopost integration tests pass (unchanged behavior)
- [x] All 23 existing command tests pass (unchanged behavior)
- [x] 27 new unit tests for extracted helpers
- [x] Full suite: 750 passed, 38 skipped
- [x] `ruff check` + `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)