### PR TITLE
Security hardening: XSS, CORS, input validation, auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **XSS prevention in OAuth HTML pages** - All user-supplied values (`username`, `email`, `title`, `message`) now escaped with `html.escape()` before interpolation into HTML responses (`src/api/routes/oauth.py`)
+- **Onboarding chat_id verification** - `_validate_request()` now verifies the `chat_id` from the signed `initData` matches the request's `chat_id`, preventing cross-tenant manipulation; returns 403 on mismatch
+- **CORS origin restriction** - Replaced `allow_origins=["*"]` with `OAUTH_REDIRECT_BASE_URL` (or `localhost` in development), and restricted `allow_headers` to `Content-Type`
+- **Google Drive API query injection fix** - Escaped single quotes and backslashes in `folder_name` before interpolating into Google Drive API query strings (`google_drive_provider.py`)
+- **Schedule input validation** - Added Pydantic `Field` validators: `posts_per_day` (1-50), `posting_hours_start/end` (0-23), `schedule_days` (1-30)
+- **Instagram API exception data sanitization** - Removed `response` dict from `InstagramAPIError` to prevent full API response leakage through error tracking/logging
+- **initData chat extraction** - `validate_init_data()` now extracts `chat_id` from Telegram's `chat` object when present in signed data (group chats)
+
 ### Added
 
 - **Cloud deployment guide** - Comprehensive guide for deploying to Railway + Neon

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -9,6 +9,7 @@ from fastapi.staticfiles import StaticFiles
 
 from src.api.routes.oauth import router as oauth_router
 from src.api.routes.onboarding import router as onboarding_router
+from src.config.settings import settings
 
 app = FastAPI(
     title="Storyline AI API",
@@ -16,12 +17,17 @@ app = FastAPI(
     version="0.1.0",
 )
 
-# CORS middleware (needed for browser redirects and Mini App API calls)
+# CORS middleware — restrict to our own domain in production
+_cors_origins = (
+    [settings.OAUTH_REDIRECT_BASE_URL]
+    if settings.OAUTH_REDIRECT_BASE_URL
+    else ["http://localhost:8000"]
+)
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],  # Tighten in production
+    allow_origins=_cors_origins,
     allow_methods=["GET", "POST"],
-    allow_headers=["*"],
+    allow_headers=["Content-Type"],
 )
 
 # Static files for Mini App

--- a/src/api/routes/oauth.py
+++ b/src/api/routes/oauth.py
@@ -1,5 +1,7 @@
 """OAuth redirect flow endpoints for Instagram and Google Drive."""
 
+import html
+
 from fastapi import APIRouter, HTTPException, Query
 from fastapi.responses import HTMLResponse, RedirectResponse
 
@@ -205,6 +207,7 @@ async def google_drive_oauth_callback(
 
 def _gdrive_success_html_page(email: str) -> HTMLResponse:
     """Return a simple HTML success page for Google Drive."""
+    safe_email = html.escape(email)
     return HTMLResponse(
         content=f"""
         <!DOCTYPE html>
@@ -222,7 +225,7 @@ def _gdrive_success_html_page(email: str) -> HTMLResponse:
         <body>
         <div class="card">
             <h1>Google Drive Connected!</h1>
-            <p>Your Google Drive (<strong>{email}</strong>) has been
+            <p>Your Google Drive (<strong>{safe_email}</strong>) has been
             connected to Storyline AI.</p>
             <p>You can close this window and return to Telegram.</p>
         </div>
@@ -234,6 +237,7 @@ def _gdrive_success_html_page(email: str) -> HTMLResponse:
 
 def _success_html_page(username: str) -> HTMLResponse:
     """Return a simple HTML success page."""
+    safe_username = html.escape(username)
     return HTMLResponse(
         content=f"""
         <!DOCTYPE html>
@@ -251,7 +255,7 @@ def _success_html_page(username: str) -> HTMLResponse:
         <body>
         <div class="card">
             <h1>Connected!</h1>
-            <p>Instagram account <strong>@{username}</strong> has been
+            <p>Instagram account <strong>@{safe_username}</strong> has been
             connected to Storyline AI.</p>
             <p>You can close this window and return to Telegram.</p>
         </div>
@@ -263,11 +267,13 @@ def _success_html_page(username: str) -> HTMLResponse:
 
 def _error_html_page(title: str, message: str) -> HTMLResponse:
     """Return a simple HTML error page."""
+    safe_title = html.escape(title)
+    safe_message = html.escape(message)
     return HTMLResponse(
         content=f"""
         <!DOCTYPE html>
         <html>
-        <head><title>Storyline AI - {title}</title>
+        <head><title>Storyline AI - {safe_title}</title>
         <style>
             body {{ font-family: -apple-system, sans-serif; text-align: center;
                    padding: 60px 20px; background: #f5f5f5; }}
@@ -279,8 +285,8 @@ def _error_html_page(title: str, message: str) -> HTMLResponse:
         </style></head>
         <body>
         <div class="card">
-            <h1>{title}</h1>
-            <p>{message}</p>
+            <h1>{safe_title}</h1>
+            <p>{safe_message}</p>
         </div>
         </body></html>
         """,

--- a/src/exceptions/instagram.py
+++ b/src/exceptions/instagram.py
@@ -15,7 +15,6 @@ class InstagramAPIError(StorylineError):
         message: Human-readable error description
         error_code: Instagram/Meta error code (e.g., 'OAuthException')
         error_subcode: More specific error subcode from Meta
-        response: Full response dict from the API (for debugging)
     """
 
     def __init__(
@@ -23,12 +22,10 @@ class InstagramAPIError(StorylineError):
         message: str,
         error_code: Optional[str] = None,
         error_subcode: Optional[int] = None,
-        response: Optional[dict] = None,
     ):
         super().__init__(message)
         self.error_code = error_code
         self.error_subcode = error_subcode
-        self.response = response
 
     def __str__(self) -> str:
         base = super().__str__()

--- a/src/services/integrations/instagram_api.py
+++ b/src/services/integrations/instagram_api.py
@@ -260,7 +260,6 @@ class InstagramAPIService(BaseService):
             if not container_id:
                 raise InstagramAPIError(
                     "No container ID in response",
-                    response=data,
                 )
 
             return container_id
@@ -294,7 +293,6 @@ class InstagramAPIService(BaseService):
                     raise InstagramAPIError(
                         f"Media container failed: {error_msg}",
                         error_code=status_code,
-                        response=data,
                     )
 
                 if status_code == "EXPIRED":
@@ -337,7 +335,6 @@ class InstagramAPIService(BaseService):
             if not story_id:
                 raise InstagramAPIError(
                     "No story ID in publish response",
-                    response=data,
                 )
 
             return story_id
@@ -387,7 +384,6 @@ class InstagramAPIService(BaseService):
             error_message,
             error_code=str(error_code) if error_code else None,
             error_subcode=error_subcode,
-            response=data,
         )
 
     def get_rate_limit_remaining(self) -> int:

--- a/src/services/media_sources/google_drive_provider.py
+++ b/src/services/media_sources/google_drive_provider.py
@@ -294,9 +294,10 @@ class GoogleDriveProvider(MediaSourceProvider):
             if fname == folder_name:
                 return fid
 
+        safe_name = folder_name.replace("\\", "\\\\").replace("'", "\\'")
         query = (
             f"'{self.root_folder_id}' in parents "
-            f"and name='{folder_name}' "
+            f"and name='{safe_name}' "
             f"and mimeType='application/vnd.google-apps.folder' "
             f"and trashed=false"
         )

--- a/src/utils/webapp_auth.py
+++ b/src/utils/webapp_auth.py
@@ -60,7 +60,15 @@ def validate_init_data(init_data: str) -> dict:
     user_json = parsed.get("user", ["{}"])[0]
     user_data = json.loads(user_json)
 
-    return {
+    result = {
         "user_id": user_data.get("id"),
         "first_name": user_data.get("first_name"),
     }
+
+    # Extract chat_id if present (available when opened from a group chat)
+    chat_json = parsed.get("chat", [None])[0]
+    if chat_json:
+        chat_data = json.loads(chat_json)
+        result["chat_id"] = chat_data.get("id")
+
+    return result

--- a/tests/src/exceptions/test_instagram_exceptions.py
+++ b/tests/src/exceptions/test_instagram_exceptions.py
@@ -38,9 +38,10 @@ class TestInstagramAPIError:
         err = InstagramAPIError("msg", error_subcode=463)
         assert err.error_subcode == 463
 
-    def test_response_attribute(self):
-        err = InstagramAPIError("msg", response={"error": "bad"})
-        assert err.response == {"error": "bad"}
+    def test_no_response_attribute(self):
+        """Response dict removed to prevent sensitive API data leakage."""
+        err = InstagramAPIError("msg")
+        assert not hasattr(err, "response")
 
     def test_str_includes_error_code(self):
         err = InstagramAPIError("msg", error_code="OAuthException")

--- a/tests/src/utils/test_webapp_auth.py
+++ b/tests/src/utils/test_webapp_auth.py
@@ -141,3 +141,24 @@ class TestValidateInitData:
         result = validate_init_data(init_data)
 
         assert result["user_id"] == 12345
+
+    @patch("src.utils.webapp_auth.settings")
+    def test_chat_id_extracted_when_present(self, mock_settings):
+        """When initData contains a chat object, chat_id is extracted."""
+        mock_settings.TELEGRAM_BOT_TOKEN = "test-bot-token"
+
+        chat_data = json.dumps({"id": -1001234567890, "type": "supergroup"})
+        init_data = _build_init_data(extra_params={"chat": chat_data})
+        result = validate_init_data(init_data)
+
+        assert result["chat_id"] == -1001234567890
+
+    @patch("src.utils.webapp_auth.settings")
+    def test_no_chat_id_when_absent(self, mock_settings):
+        """When initData has no chat object, chat_id is not in result."""
+        mock_settings.TELEGRAM_BOT_TOKEN = "test-bot-token"
+
+        init_data = _build_init_data()
+        result = validate_init_data(init_data)
+
+        assert "chat_id" not in result


### PR DESCRIPTION
## Summary
- **XSS prevention**: `html.escape()` on all user-supplied values in OAuth HTML pages (username, email, title, message)
- **Auth hardening**: Onboarding endpoints now verify `chat_id` from signed initData matches request body — returns 403 on mismatch
- **CORS restriction**: Replaced `allow_origins=["*"]` with `OAUTH_REDIRECT_BASE_URL` origin
- **Query injection fix**: Escape single quotes in Google Drive API folder name queries
- **Input validation**: Pydantic `Field` bounds on schedule inputs (`posts_per_day` 1-50, `posting_hours` 0-23, `schedule_days` 1-30)
- **Data leak prevention**: Removed full API response dict from `InstagramAPIError` exception class

## Files changed (13)
- `src/api/app.py` — CORS origin restriction
- `src/api/routes/oauth.py` — html.escape() on all HTML interpolations
- `src/api/routes/onboarding.py` — chat_id verification, Pydantic Field validators
- `src/utils/webapp_auth.py` — extract chat_id from initData when present
- `src/exceptions/instagram.py` — remove `response` parameter
- `src/services/integrations/instagram_api.py` — remove `response=data` from all callers
- `src/services/media_sources/google_drive_provider.py` — escape folder_name in query
- `documentation/SECURITY_REVIEW.md` — updated with findings and fixes
- 5 test files updated/extended (11 new tests, 1186 total passing)

## Test plan
- [x] All 1186 tests pass
- [x] Ruff lint + format clean
- [x] XSS tests verify `<script>` tags are escaped to `&lt;script&gt;`
- [x] Chat ID mismatch test verifies 403 response
- [x] Input validation tests verify 422 on out-of-range values
- [x] Exception test verifies `response` attribute removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)