### PR TITLE
deploy: cloud-ready ConfigValidator and env var reference

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,12 +12,23 @@ ENABLE_INSTAGRAM_API=false
 # ============================================
 # Database Configuration
 # ============================================
+# Option 1: Full connection URL (recommended for cloud — overrides DB_* vars)
+# DATABASE_URL=postgresql://user:pass@ep-xxx.neon.tech/storyline_ai?sslmode=require
+
+# Option 2: Individual components (for local development)
 DB_HOST=localhost
 DB_PORT=5432
 DB_NAME=storyline_ai
 DB_USER=storyline_user
 # DB_PASSWORD is optional for local PostgreSQL (leave blank if not needed)
 DB_PASSWORD=
+
+# SSL mode (set to "require" for Neon/cloud databases)
+# DB_SSLMODE=require
+
+# Connection pool sizing (reduce for Neon free tier: pool=3, overflow=2)
+# DB_POOL_SIZE=10
+# DB_MAX_OVERFLOW=20
 
 # Test database (optional)
 TEST_DB_NAME=storyline_ai_test
@@ -52,11 +63,22 @@ REPOST_TTL_DAYS=30
 # Media Configuration
 # ============================================
 # Path to media directory (absolute path required)
+# Auto-created at startup if it doesn't exist (e.g., /tmp/media on Railway)
 # Examples:
 #   macOS/Linux development: /Users/yourname/Projects/storyline-ai/media/stories
 #   Raspberry Pi production: /home/pi/media/stories
-#   Windows: C:/Users/yourname/Projects/storyline-ai/media/stories
+#   Cloud (Railway): /tmp/media
 MEDIA_DIR=/home/pi/media/stories
+
+# Media source type: "local" (filesystem) or "google_drive" (cloud)
+# MEDIA_SOURCE_TYPE=local
+
+# Google Drive folder ID (when MEDIA_SOURCE_TYPE=google_drive)
+# MEDIA_SOURCE_ROOT=
+
+# Enable periodic media sync from cloud provider
+# MEDIA_SYNC_ENABLED=false
+# MEDIA_SYNC_INTERVAL_SECONDS=300
 
 # ============================================
 # Backup Configuration
@@ -73,8 +95,18 @@ INSTAGRAM_ACCESS_TOKEN=
 FACEBOOK_APP_ID=
 FACEBOOK_APP_SECRET=
 
+# OAuth redirect base URL (required for cloud — your Railway web domain)
+# OAUTH_REDIRECT_BASE_URL=https://your-app.up.railway.app
+
 # Rate limit for Instagram API (Meta allows ~25/hour for Stories)
 INSTAGRAM_POSTS_PER_HOUR=25
+
+# ============================================
+# Google Drive OAuth (Cloud Media Source)
+# ============================================
+# Required when using MEDIA_SOURCE_TYPE=google_drive
+# GOOGLE_CLIENT_ID=
+# GOOGLE_CLIENT_SECRET=
 
 # ============================================
 # Cloudinary Configuration (Phase 2 Only)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **ConfigValidator cloud deployment support** - Relaxed startup validation for cloud environments
+  - `MEDIA_DIR` is now auto-created if it doesn't exist (needed for Railway's `/tmp/media`)
+  - Removed `INSTAGRAM_ACCESS_TOKEN` and `INSTAGRAM_ACCOUNT_ID` env var requirements — tokens are managed via OAuth and stored in the database in multi-tenant mode
+  - Cloudinary config check retained when `ENABLE_INSTAGRAM_API=true`
+
+- **`.env.example` cloud variables** - Added cloud deployment configuration reference
+  - `DATABASE_URL` full connection string option for PaaS platforms
+  - `DB_SSLMODE`, `DB_POOL_SIZE`, `DB_MAX_OVERFLOW` for Neon tuning
+  - `OAUTH_REDIRECT_BASE_URL` for Railway HTTPS domain
+  - `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` for Google Drive OAuth
+  - `MEDIA_SOURCE_TYPE`, `MEDIA_SOURCE_ROOT`, `MEDIA_SYNC_ENABLED` for cloud media
+
 ### Security
 
 - **XSS prevention in OAuth HTML pages** - All user-supplied values (`username`, `email`, `title`, `message`) now escaped with `html.escape()` before interpolation into HTML responses (`src/api/routes/oauth.py`)

--- a/src/utils/validators.py
+++ b/src/utils/validators.py
@@ -46,16 +46,6 @@ class ConfigValidator:
 
         # Validate Instagram config (if API enabled)
         if settings.ENABLE_INSTAGRAM_API:
-            if not settings.INSTAGRAM_ACCOUNT_ID:
-                errors.append(
-                    "INSTAGRAM_ACCOUNT_ID required when ENABLE_INSTAGRAM_API=true"
-                )
-
-            if not settings.INSTAGRAM_ACCESS_TOKEN:
-                errors.append(
-                    "INSTAGRAM_ACCESS_TOKEN required when ENABLE_INSTAGRAM_API=true"
-                )
-
             if not settings.CLOUDINARY_CLOUD_NAME:
                 errors.append(
                     "Cloudinary config required when ENABLE_INSTAGRAM_API=true"
@@ -65,10 +55,16 @@ class ConfigValidator:
         if not settings.DB_NAME:
             errors.append("DB_NAME is required")
 
-        # Validate paths
+        # Validate paths — auto-create MEDIA_DIR for cloud deployments
         media_dir = Path(settings.MEDIA_DIR)
         if not media_dir.exists():
-            errors.append(f"MEDIA_DIR does not exist: {settings.MEDIA_DIR}")
+            try:
+                media_dir.mkdir(parents=True, exist_ok=True)
+            except OSError as e:
+                errors.append(
+                    f"MEDIA_DIR does not exist and could not be created: "
+                    f"{settings.MEDIA_DIR} ({e})"
+                )
 
         is_valid = len(errors) == 0
         return is_valid, errors


### PR DESCRIPTION
## Summary
- Relax startup validation for Railway + Neon cloud deployment
- Auto-create `MEDIA_DIR` if it doesn't exist (needed for `/tmp/media` on Railway)
- Remove `INSTAGRAM_ACCESS_TOKEN` and `INSTAGRAM_ACCOUNT_ID` env var requirements (tokens managed via OAuth in DB)
- Add cloud deployment configuration reference to `.env.example`

## Test plan
- [x] All 1187 tests pass
- [x] Ruff lint + format clean
- [x] New test: `test_validate_all_media_dir_auto_created` verifies auto-creation
- [x] Updated test: `test_validate_all_media_dir_not_exists_and_cannot_create` verifies error on permission denied
- [x] Updated test: `test_validate_all_instagram_api_missing_cloudinary` reflects relaxed validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)