### PR TITLE
feat: complete onboarding wizard - folder save, indexing, skip steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Onboarding wizard completion** - Mini App wizard now fully functional end-to-end
+  - Media folder validation saves `media_source_type`, `media_source_root`, and `media_sync_enabled` to `chat_settings`
+  - New `/api/onboarding/start-indexing` endpoint triggers media sync during wizard
+  - Enriched `/api/onboarding/init` response with `media_folder_configured`, `media_indexed`, `media_count`, and `onboarding_step`
+  - Completing onboarding auto-enables `enable_instagram_api` (if connected) and `media_sync_enabled` (if folder configured); `dry_run_mode` always stays true
+  - Onboarding step tracking: each wizard step saves progress to database for resume on reopen
+  - New "Index Media" wizard step with progress indicator and result display
+  - All wizard steps are skippable (Instagram, Google Drive, media folder, indexing, schedule)
+  - Summary step shows configuration status for all setup items
+  - Folder validation no longer auto-advances — shows results with explicit "Continue" button
 - **Per-chat media source configuration** - `media_source_type` and `media_source_root` columns on `chat_settings` table
   - Each Telegram chat can now have its own media source (local path or Google Drive folder ID)
   - `NULL` values fall back to global `MEDIA_SOURCE_TYPE` / `MEDIA_SOURCE_ROOT` env vars (backward compatible)

--- a/documentation/planning/phases/onboarding-and-setup-flow_2026-02-18/02_complete_mini_app_wizard.md
+++ b/documentation/planning/phases/onboarding-and-setup-flow_2026-02-18/02_complete_mini_app_wizard.md
@@ -1,5 +1,18 @@
 # Phase 02: Complete the Mini App Onboarding Wizard
 
+**Status:** 🔧 IN PROGRESS
+**Started:** 2026-02-19
+
+## Challenge Round Corrections
+
+1. **Step 1 (STRING_SETTINGS) — SKIP**: Phase 01 already added `TEXT_SETTINGS` with identical content. No work needed.
+2. **Step 3 media_sync changes — SKIP**: Phase 01 already added `telegram_chat_id` param to `sync()` and `_create_provider()`.
+3. **Test 5e (STRING_SETTINGS tests) — SKIP**: Phase 01 already added `TestSettingsServiceMediaSource` class.
+4. **goToStep fire-and-forget init call — REMOVED**: `/init` is read-only, doesn't save step. Backend `set_onboarding_step()` calls in Step 6 handle resume.
+5. **Empty folder button disable — REMOVED**: Over-engineering for rare case. Indexing returns `new: 0` which is self-explanatory.
+6. **`complete` redundant media_source_type — REMOVED**: Already set during folder validation. Only `enable_instagram_api` and `media_sync_enabled` needed.
+7. **`_get_setup_state` missing `onboarding_step` — ADDED**: Plan Step 4 return dict now includes `onboarding_step`.
+
 ## 1. Header
 
 | Field | Value |

--- a/src/api/static/onboarding/index.html
+++ b/src/api/static/onboarding/index.html
@@ -11,7 +11,7 @@
     <div id="app">
         <!-- Step 1: Welcome -->
         <div class="step" id="step-welcome">
-            <div class="progress-bar"><div class="progress-fill" style="width: 16%"></div></div>
+            <div class="progress-bar"><div class="progress-fill" style="width: 14%"></div></div>
             <div class="step-content">
                 <h1>Welcome to Storyline AI</h1>
                 <p class="subtitle">Let's get your Instagram posting automated in a few quick steps.</p>
@@ -19,7 +19,8 @@
                     <div class="step-item"><span class="step-num">1</span> Connect Instagram</div>
                     <div class="step-item"><span class="step-num">2</span> Connect Google Drive</div>
                     <div class="step-item"><span class="step-num">3</span> Pick media folder</div>
-                    <div class="step-item"><span class="step-num">4</span> Set your schedule</div>
+                    <div class="step-item"><span class="step-num">4</span> Index your media</div>
+                    <div class="step-item"><span class="step-num">5</span> Set your schedule</div>
                 </div>
                 <button class="btn btn-primary" onclick="App.goToStep('instagram')">Get Started</button>
             </div>
@@ -27,7 +28,7 @@
 
         <!-- Step 2: Connect Instagram -->
         <div class="step hidden" id="step-instagram">
-            <div class="progress-bar"><div class="progress-fill" style="width: 33%"></div></div>
+            <div class="progress-bar"><div class="progress-fill" style="width: 28%"></div></div>
             <div class="step-content">
                 <h2>Connect Instagram</h2>
                 <p class="subtitle">Link your Instagram Business or Creator account.</p>
@@ -50,7 +51,7 @@
 
         <!-- Step 3: Connect Google Drive -->
         <div class="step hidden" id="step-gdrive">
-            <div class="progress-bar"><div class="progress-fill" style="width: 50%"></div></div>
+            <div class="progress-bar"><div class="progress-fill" style="width: 43%"></div></div>
             <div class="step-content">
                 <h2>Connect Google Drive</h2>
                 <p class="subtitle">Access your media files stored in Google Drive.</p>
@@ -73,7 +74,7 @@
 
         <!-- Step 4: Media Folder -->
         <div class="step hidden" id="step-media-folder">
-            <div class="progress-bar"><div class="progress-fill" style="width: 66%"></div></div>
+            <div class="progress-bar"><div class="progress-fill" style="width: 57%"></div></div>
             <div class="step-content">
                 <h2>Media Folder</h2>
                 <p class="subtitle">Paste the URL of the Google Drive folder with your media files.</p>
@@ -86,6 +87,7 @@
                         <div class="result-row"><strong>Files found:</strong> <span id="folder-file-count"></span></div>
                         <div class="result-row"><strong>Categories:</strong> <span id="folder-categories"></span></div>
                     </div>
+                    <button class="btn btn-primary" onclick="App.goToStep('indexing')">Continue</button>
                 </div>
                 <div id="folder-error" class="error-text hidden"></div>
                 <div class="step-nav">
@@ -94,9 +96,48 @@
             </div>
         </div>
 
+        <!-- Step 4b: Indexing -->
+        <div class="step hidden" id="step-indexing">
+            <div class="progress-bar"><div class="progress-fill" style="width: 71%"></div></div>
+            <div class="step-content">
+                <h2>Index Media</h2>
+                <p class="subtitle">Import your media files into Storyline so they can be scheduled.</p>
+
+                <div id="indexing-preview" class="result-card">
+                    <div class="result-row"><strong>Files found:</strong> <span id="indexing-file-count">0</span></div>
+                    <div class="result-row"><strong>Categories:</strong> <span id="indexing-categories">-</span></div>
+                </div>
+
+                <button class="btn btn-primary" id="btn-start-indexing" onclick="App.startIndexing()">
+                    Index Files Now
+                </button>
+
+                <div id="indexing-progress" class="polling-indicator hidden">
+                    <div class="spinner"></div>
+                    <span>Indexing media files...</span>
+                </div>
+
+                <div id="indexing-result" class="hidden">
+                    <div class="result-card result-success">
+                        <div class="result-row"><strong>New files indexed:</strong> <span id="indexing-new-count">0</span></div>
+                        <div class="result-row"><strong>Total processed:</strong> <span id="indexing-total-count">0</span></div>
+                        <div id="indexing-errors" class="hidden">
+                            <div class="result-row error-text"><strong>Errors:</strong> <span id="indexing-error-count">0</span></div>
+                        </div>
+                    </div>
+                </div>
+
+                <div id="indexing-error" class="error-text hidden"></div>
+
+                <div class="step-nav">
+                    <button class="btn btn-text" onclick="App.goToStep('schedule')">Skip, I'll index later</button>
+                </div>
+            </div>
+        </div>
+
         <!-- Step 5: Schedule -->
         <div class="step hidden" id="step-schedule">
-            <div class="progress-bar"><div class="progress-fill" style="width: 83%"></div></div>
+            <div class="progress-bar"><div class="progress-fill" style="width: 86%"></div></div>
             <div class="step-content">
                 <h2>Posting Schedule</h2>
                 <p class="subtitle">How often and when should Storyline post?</p>
@@ -122,6 +163,9 @@
                 </div>
 
                 <button class="btn btn-primary" onclick="App.saveSchedule()">Continue</button>
+                <div class="step-nav">
+                    <button class="btn btn-text" onclick="App.goToStep('summary')">Skip for now</button>
+                </div>
             </div>
         </div>
 
@@ -140,6 +184,14 @@
                     <div class="summary-row">
                         <span class="summary-label">Google Drive</span>
                         <span class="summary-value" id="summary-gdrive">Not connected</span>
+                    </div>
+                    <div class="summary-row">
+                        <span class="summary-label">Media Folder</span>
+                        <span class="summary-value" id="summary-media-folder">Not configured</span>
+                    </div>
+                    <div class="summary-row">
+                        <span class="summary-label">Media Indexed</span>
+                        <span class="summary-value" id="summary-media-indexed">No</span>
                     </div>
                     <div class="summary-row">
                         <span class="summary-label">Schedule</span>

--- a/src/api/static/onboarding/style.css
+++ b/src/api/static/onboarding/style.css
@@ -395,6 +395,11 @@ h2 {
     margin-top: 12px;
 }
 
+/* Indexing result success indicator */
+.result-success {
+    border-left: 3px solid #22c55e;
+}
+
 .hidden {
     display: none !important;
 }


### PR DESCRIPTION
## Summary
- **Media folder persistence**: Wizard now saves Google Drive folder ID to `chat_settings` and enables `media_sync_enabled`
- **Media indexing endpoint**: New `/api/onboarding/start-indexing` triggers media sync during wizard with progress UI
- **Auto-configuration on complete**: Enables `enable_instagram_api` (if connected) and `media_sync_enabled` (if folder configured); `dry_run_mode` always stays true
- **Onboarding step tracking**: Each wizard step saves progress to DB, enabling resume on Mini App reopen
- **Enriched init response**: Returns `media_folder_configured`, `media_indexed`, `media_count`, `onboarding_step`
- **Frontend**: New indexing step, all steps skippable, folder validation shows "Continue" button, summary shows all config status

## Plan Document
`documentation/planning/phases/onboarding-and-setup-flow_2026-02-18/02_complete_mini_app_wizard.md`

## Test plan
- [x] 31 onboarding tests passing (8 new)
- [x] 1207 total tests passing
- [x] ruff check + format clean
- [x] "What NOT To Do" items verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)