### PR TITLE
Fix multi-tenant media sync loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Multi-tenant media sync** - Sync loop now iterates all tenants with `media_sync_enabled=true` instead of relying on global env var. New tenants completing onboarding will have their media synced automatically.
+
 ### Changed
 
 - **Telegram command cleanup** - Consolidated bot commands from 18 to 11 for a cleaner daily experience

--- a/src/repositories/chat_settings_repository.py
+++ b/src/repositories/chat_settings_repository.py
@@ -117,6 +117,25 @@ class ChatSettingsRepository(BaseRepository):
         self.end_read_transaction()
         return result
 
+    def get_all_sync_enabled(self) -> List[ChatSettings]:
+        """Get all chat settings with media sync enabled.
+
+        Used by the media sync loop to iterate over tenants
+        that should have their media synced from cloud providers.
+
+        Returns:
+            List of ChatSettings where media_sync_enabled=True,
+            ordered by created_at
+        """
+        result = (
+            self.db.query(ChatSettings)
+            .filter(ChatSettings.media_sync_enabled == True)  # noqa: E712
+            .order_by(ChatSettings.created_at.asc())
+            .all()
+        )
+        self.end_read_transaction()
+        return result
+
     def get_all_paused(self) -> List[ChatSettings]:
         """Get all paused chat settings records.
 

--- a/src/services/core/settings_service.py
+++ b/src/services/core/settings_service.py
@@ -252,6 +252,17 @@ class SettingsService(BaseService):
         """
         return self.settings_repo.get_all_active()
 
+    def get_all_sync_enabled_chats(self) -> List[ChatSettings]:
+        """Get all chat settings with media sync enabled.
+
+        Used by the media sync loop to iterate over tenants
+        that need media synced from cloud providers.
+
+        Returns:
+            List of ChatSettings where media_sync_enabled=True
+        """
+        return self.settings_repo.get_all_sync_enabled()
+
     def get_all_paused_chats(self) -> List[ChatSettings]:
         """Get all paused chat settings.
 

--- a/tests/src/repositories/test_chat_settings_repository.py
+++ b/tests/src/repositories/test_chat_settings_repository.py
@@ -158,3 +158,26 @@ class TestChatSettingsRepository:
         result = settings_repo.get_all_active()
 
         assert result == []
+
+    def test_get_all_sync_enabled_returns_sync_chats(self, settings_repo, mock_db):
+        """get_all_sync_enabled returns only chats with media_sync_enabled=True."""
+        mock_chat1 = Mock(spec=ChatSettings, media_sync_enabled=True)
+        mock_query = mock_db.query.return_value
+        mock_query.filter.return_value.order_by.return_value.all.return_value = [
+            mock_chat1,
+        ]
+
+        result = settings_repo.get_all_sync_enabled()
+
+        assert len(result) == 1
+        mock_db.query.assert_called_with(ChatSettings)
+        mock_db.commit.assert_called_once()  # end_read_transaction
+
+    def test_get_all_sync_enabled_returns_empty_when_none(self, settings_repo, mock_db):
+        """get_all_sync_enabled returns empty list when no chats have sync enabled."""
+        mock_query = mock_db.query.return_value
+        mock_query.filter.return_value.order_by.return_value.all.return_value = []
+
+        result = settings_repo.get_all_sync_enabled()
+
+        assert result == []

--- a/tests/src/services/test_settings_service.py
+++ b/tests/src/services/test_settings_service.py
@@ -282,6 +282,30 @@ class TestSettingsServiceUnit:
 
         assert result == []
 
+    def test_get_all_sync_enabled_chats_delegates_to_repository(self):
+        """get_all_sync_enabled_chats delegates to settings_repo.get_all_sync_enabled."""
+        service = SettingsService()
+        mock_repo = Mock()
+        mock_chat = Mock(spec=ChatSettings)
+        mock_repo.get_all_sync_enabled.return_value = [mock_chat]
+        service.settings_repo = mock_repo
+
+        result = service.get_all_sync_enabled_chats()
+
+        assert len(result) == 1
+        mock_repo.get_all_sync_enabled.assert_called_once()
+
+    def test_get_all_sync_enabled_chats_returns_empty_list(self):
+        """get_all_sync_enabled_chats returns empty list when none enabled."""
+        service = SettingsService()
+        mock_repo = Mock()
+        mock_repo.get_all_sync_enabled.return_value = []
+        service.settings_repo = mock_repo
+
+        result = service.get_all_sync_enabled_chats()
+
+        assert result == []
+
 
 # =============================================================================
 # ARCHITECTURE VALIDATION TESTS

--- a/tests/src/test_main_scheduler_loop.py
+++ b/tests/src/test_main_scheduler_loop.py
@@ -1,9 +1,9 @@
-"""Tests for the per-tenant scheduler loop in main.py."""
+"""Tests for the per-tenant scheduler and media sync loops in main.py."""
 
 import pytest
 from unittest.mock import AsyncMock, Mock, patch
 
-from src.main import run_scheduler_loop
+from src.main import run_scheduler_loop, media_sync_loop
 
 
 @pytest.mark.unit
@@ -104,3 +104,103 @@ class TestSchedulerLoop:
 
         # Both chats should have been attempted despite chat1 failing
         assert posting_service.process_pending_posts.call_count == 2
+
+
+@pytest.mark.unit
+class TestMediaSyncLoop:
+    """Tests for media_sync_loop multi-tenant behavior."""
+
+    @pytest.mark.asyncio
+    async def test_sync_loop_iterates_sync_enabled_chats(self):
+        """Sync loop syncs each tenant with media_sync_enabled=True."""
+        sync_service = Mock()
+        result = Mock(total_processed=0, errors=0, new=0)
+        sync_service.sync.return_value = result
+        sync_service.cleanup_transactions = Mock()
+
+        chat1 = Mock(telegram_chat_id=-100111)
+        chat2 = Mock(telegram_chat_id=-100222)
+        settings_service = Mock()
+        settings_service.get_all_sync_enabled_chats.return_value = [chat1, chat2]
+        settings_service.cleanup_transactions = Mock()
+
+        with patch("src.main.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            mock_sleep.side_effect = StopAsyncIteration
+            try:
+                await media_sync_loop(sync_service, settings_service=settings_service)
+            except StopAsyncIteration:
+                pass
+
+        assert sync_service.sync.call_count == 2
+        sync_service.sync.assert_any_call(
+            telegram_chat_id=-100111, triggered_by="scheduler"
+        )
+        sync_service.sync.assert_any_call(
+            telegram_chat_id=-100222, triggered_by="scheduler"
+        )
+
+    @pytest.mark.asyncio
+    async def test_sync_loop_falls_back_when_no_sync_enabled_chats(self):
+        """Sync loop uses global env vars when no chats have sync enabled."""
+        sync_service = Mock()
+        result = Mock(total_processed=0, errors=0, new=0)
+        sync_service.sync.return_value = result
+        sync_service.cleanup_transactions = Mock()
+
+        settings_service = Mock()
+        settings_service.get_all_sync_enabled_chats.return_value = []
+        settings_service.cleanup_transactions = Mock()
+
+        with patch("src.main.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            mock_sleep.side_effect = StopAsyncIteration
+            try:
+                await media_sync_loop(sync_service, settings_service=settings_service)
+            except StopAsyncIteration:
+                pass
+
+        # Should fall back to global (no telegram_chat_id)
+        sync_service.sync.assert_called_once_with(triggered_by="scheduler")
+
+    @pytest.mark.asyncio
+    async def test_sync_loop_falls_back_when_no_settings_service(self):
+        """Sync loop uses global env vars when settings_service is None."""
+        sync_service = Mock()
+        result = Mock(total_processed=0, errors=0, new=0)
+        sync_service.sync.return_value = result
+        sync_service.cleanup_transactions = Mock()
+
+        with patch("src.main.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            mock_sleep.side_effect = StopAsyncIteration
+            try:
+                await media_sync_loop(sync_service)
+            except StopAsyncIteration:
+                pass
+
+        sync_service.sync.assert_called_once_with(triggered_by="scheduler")
+
+    @pytest.mark.asyncio
+    async def test_sync_loop_skips_failed_tenant(self):
+        """One tenant's sync error does not block other tenants."""
+        sync_service = Mock()
+        result_ok = Mock(total_processed=0, errors=0, new=0)
+        sync_service.sync.side_effect = [
+            Exception("Chat 1 failed"),
+            result_ok,
+        ]
+        sync_service.cleanup_transactions = Mock()
+
+        chat1 = Mock(telegram_chat_id=-100111)
+        chat2 = Mock(telegram_chat_id=-100222)
+        settings_service = Mock()
+        settings_service.get_all_sync_enabled_chats.return_value = [chat1, chat2]
+        settings_service.cleanup_transactions = Mock()
+
+        with patch("src.main.asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            mock_sleep.side_effect = StopAsyncIteration
+            try:
+                await media_sync_loop(sync_service, settings_service=settings_service)
+            except StopAsyncIteration:
+                pass
+
+        # Both should have been attempted
+        assert sync_service.sync.call_count == 2


### PR DESCRIPTION
## Summary
- Media sync loop now iterates all tenants with `media_sync_enabled=true` instead of relying on global `MEDIA_SYNC_ENABLED` env var
- New tenants completing onboarding will have their media synced automatically without manual DB intervention
- Keeps legacy single-tenant fallback when no sync-enabled chats exist

## Test plan
- [x] New repo tests: `get_all_sync_enabled()` returns sync-enabled chats
- [x] New service tests: `get_all_sync_enabled_chats()` delegates correctly
- [x] New sync loop tests: iterates tenants, falls back to global, isolates errors
- [x] Full test suite: 1,239 passed, 21 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)