### PR TITLE
fix: resolve Telegram bot polling on Railway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Telegram bot polling on Railway** - Bot was not responding to commands since migration from Pi. Fixed three issues:
+  - Polling task completed immediately after starting background updater; now blocks to keep task alive
+  - Added explicit `allowed_updates` and `drop_pending_updates=True` to ensure clean startup
+  - Added application-level error handler so handler exceptions are logged instead of silently swallowed
+  - Routed `telegram`/`httpx` library logs through app logger so internal errors appear in Railway logs
 - **Multi-tenant media sync** - Sync loop now iterates all tenants with `media_sync_enabled=true` instead of relying on global env var. New tenants completing onboarding will have their media synced automatically.
 
 ### Changed

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -89,3 +89,12 @@ def get_logger(name: str = "storyline-ai") -> logging.Logger:
 
 # Default logger instance
 logger = setup_logger()
+
+# Route python-telegram-bot and httpx logs through our logger's handlers
+# so they appear in Railway logs (otherwise they go to root logger / stderr)
+for _lib_logger_name in ("telegram", "telegram.ext", "httpx"):
+    _lib_logger = logging.getLogger(_lib_logger_name)
+    _lib_logger.setLevel(logging.WARNING)
+    for _handler in logger.handlers:
+        _lib_logger.addHandler(_handler)
+    _lib_logger.propagate = False


### PR DESCRIPTION
## Summary
- Bot has not responded to Telegram commands since migrating from Pi to Railway (last interaction: Jan 17)
- Polling task completed immediately after starting background updater, potentially causing internal update processing to not persist
- python-telegram-bot library errors were invisible (routed to root logger, not captured by Railway)

## Changes
- **`start_polling()`**: Block forever with `asyncio.Event().wait()` to keep task alive, add explicit `allowed_updates`, `drop_pending_updates=True`, and application error handler
- **`logger.py`**: Route `telegram`, `telegram.ext`, `httpx` logs through app logger handlers

## Test plan
- [x] All 1239 tests pass
- [x] Ruff lint + format clean
- [ ] Deploy to Railway and verify bot responds to `/status` in Telegram

🤖 Generated with [Claude Code](https://claude.com/claude-code)