### PR TITLE
fix: revert to WebAppInfo buttons for Mini App auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **WebApp buttons in group chats** - `/start` and `/settings` failed with `Button_type_invalid` because Telegram `WebAppInfo` buttons only work in private chats. Now uses regular URL buttons in groups/supergroups, falling back to `web_app=` only in DMs.
+- **WebApp buttons in group chats** - `/start` and `/settings` failed with `Button_type_invalid` because the bot's WebApp domain was not registered in BotFather. Requires Menu Button configuration via BotFather to whitelist the domain for `WebAppInfo` inline buttons.
 - **Telegram bot polling on Railway** - Bot was not responding to commands since migration from Pi. Fixed three issues:
   - Polling task completed immediately after starting background updater; now blocks to keep task alive
   - Added explicit `allowed_updates` and `drop_pending_updates=True` to ensure clean startup

--- a/src/services/core/telegram_commands.py
+++ b/src/services/core/telegram_commands.py
@@ -68,21 +68,16 @@ class TelegramCommandHandlers:
                     "connect your accounts and configure your posting schedule\\."
                 )
 
-            # WebAppInfo buttons only work in private chats;
-            # use a regular URL button in groups/supergroups.
-            is_private = update.effective_chat.type == "private"
-            if is_private:
-                button = InlineKeyboardButton(
-                    button_text,
-                    web_app=WebAppInfo(url=webapp_url),
-                )
-            else:
-                button = InlineKeyboardButton(
-                    button_text,
-                    url=webapp_url,
-                )
-
-            keyboard = InlineKeyboardMarkup([[button]])
+            keyboard = InlineKeyboardMarkup(
+                [
+                    [
+                        InlineKeyboardButton(
+                            button_text,
+                            web_app=WebAppInfo(url=webapp_url),
+                        )
+                    ]
+                ]
+            )
             await update.message.reply_text(
                 message_text,
                 parse_mode="MarkdownV2",

--- a/src/services/core/telegram_settings.py
+++ b/src/services/core/telegram_settings.py
@@ -31,18 +31,11 @@ class TelegramSettingsHandlers:
     def __init__(self, service: TelegramService):
         self.service = service
 
-    def build_settings_message_and_keyboard(
-        self, chat_id: int, is_private: bool = False
-    ):
+    def build_settings_message_and_keyboard(self, chat_id: int):
         """Build the settings message text and inline keyboard.
 
         Returns (message, reply_markup) tuple. Used by handle_settings,
         refresh_settings_message, and send_settings_message_by_chat_id.
-
-        Args:
-            chat_id: Telegram chat ID.
-            is_private: True when called from a private (DM) chat.
-                WebAppInfo buttons only work in private chats.
         """
         settings_data = self.service.settings_service.get_settings_display(chat_id)
         account_data = self.service.ig_account_service.get_accounts_for_display(chat_id)
@@ -124,19 +117,14 @@ class TelegramSettingsHandlers:
                 f"{app_settings.OAUTH_REDIRECT_BASE_URL}/webapp/onboarding"
                 f"?chat_id={chat_id}"
             )
-            # WebAppInfo buttons only work in private chats;
-            # use a regular URL button in groups/supergroups.
-            if is_private:
-                settings_button = InlineKeyboardButton(
-                    "🔧 Open Full Settings",
-                    web_app=WebAppInfo(url=webapp_url),
-                )
-            else:
-                settings_button = InlineKeyboardButton(
-                    "🔧 Open Full Settings",
-                    url=webapp_url,
-                )
-            keyboard.append([settings_button])
+            keyboard.append(
+                [
+                    InlineKeyboardButton(
+                        "🔧 Open Full Settings",
+                        web_app=WebAppInfo(url=webapp_url),
+                    )
+                ]
+            )
 
         keyboard.append(
             [InlineKeyboardButton("❌ Close", callback_data="settings_close")]
@@ -160,10 +148,7 @@ class TelegramSettingsHandlers:
             telegram_message_id=update.message.message_id,
         )
 
-        is_private = update.effective_chat.type == "private"
-        message, reply_markup = self.build_settings_message_and_keyboard(
-            chat_id, is_private=is_private
-        )
+        message, reply_markup = self.build_settings_message_and_keyboard(chat_id)
 
         await update.message.reply_text(
             message, parse_mode="Markdown", reply_markup=reply_markup
@@ -196,10 +181,7 @@ class TelegramSettingsHandlers:
     async def refresh_settings_message(self, query, show_answer: bool = True):
         """Refresh the settings message with current values."""
         chat_id = query.message.chat_id
-        is_private = query.message.chat.type == "private"
-        message, reply_markup = self.build_settings_message_and_keyboard(
-            chat_id, is_private=is_private
-        )
+        message, reply_markup = self.build_settings_message_and_keyboard(chat_id)
 
         await query.edit_message_text(
             text=message,

--- a/tests/src/services/test_telegram_settings.py
+++ b/tests/src/services/test_telegram_settings.py
@@ -250,25 +250,12 @@ class TestBuildSettingsKeyboard:
             "active_account_name": "Not selected",
         }
 
-        # In group chats (is_private=False), should use url= instead of web_app=
         _, markup = mock_settings_handlers.build_settings_message_and_keyboard(-100123)
+
         all_buttons = [btn for row in markup.inline_keyboard for btn in row]
         mini_app_buttons = [b for b in all_buttons if "Full Settings" in b.text]
         assert len(mini_app_buttons) == 1
-        assert mini_app_buttons[0].url is not None
-
-        # In private chats (is_private=True), should use web_app=
-        _, markup_private = mock_settings_handlers.build_settings_message_and_keyboard(
-            -100123, is_private=True
-        )
-        all_buttons_private = [
-            btn for row in markup_private.inline_keyboard for btn in row
-        ]
-        mini_app_private = [
-            b for b in all_buttons_private if "Full Settings" in b.text
-        ]
-        assert len(mini_app_private) == 1
-        assert mini_app_private[0].web_app is not None
+        assert mini_app_buttons[0].web_app is not None
 
     @patch("src.services.core.telegram_settings.app_settings")
     def test_mini_app_button_absent_when_not_configured(


### PR DESCRIPTION
## Summary
- Reverts the `url=` fallback from PR #70 — it broke Mini App auth (`initData` missing)
- `WebAppInfo` buttons work in groups once the bot's Menu Button domain is registered in BotFather
- User needs: BotFather → Bot Settings → Menu Button → set webapp URL

## Test plan
- [x] 1239 tests pass
- [ ] Configure BotFather Menu Button, then test `/start` and `/settings` in group

🤖 Generated with [Claude Code](https://claude.com/claude-code)