### PR TITLE
fix: signed URL tokens for webapp in group chats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **WebApp buttons in group chats** - `/start` and `/settings` failed with `Button_type_invalid` because the bot's WebApp domain was not registered in BotFather. Requires Menu Button configuration via BotFather to whitelist the domain for `WebAppInfo` inline buttons.
+- **WebApp buttons in group chats** - `/start` and `/settings` failed with `Button_type_invalid` because Telegram rejects `WebAppInfo` buttons in groups. Now uses signed URL tokens for browser-based access in groups (`web_app=` in DMs, `url=` + HMAC token in groups). API accepts both `initData` and URL tokens for authentication.
 - **Telegram bot polling on Railway** - Bot was not responding to commands since migration from Pi. Fixed three issues:
   - Polling task completed immediately after starting background updater; now blocks to keep task alive
   - Added explicit `allowed_updates` and `drop_pending_updates=True` to ensure clean startup

--- a/src/api/static/onboarding/app.js
+++ b/src/api/static/onboarding/app.js
@@ -37,27 +37,26 @@ const App = {
      */
     async init() {
         const tg = window.Telegram && window.Telegram.WebApp;
-        if (!tg) {
-            this._showError('This page must be opened from Telegram.');
-            return;
-        }
 
-        tg.ready();
-        tg.expand();
-
-        // Apply Telegram theme
-        this._applyTheme(tg.themeParams);
-
-        // Get initData for API authentication
-        this.initData = tg.initData;
-        if (!this.initData) {
-            this._showError('Missing authentication data. Please reopen from Telegram.');
-            return;
-        }
-
-        // Get chat_id from URL parameter
+        // Get URL parameters (chat_id and optional token for browser access)
         const params = new URLSearchParams(window.location.search);
         this.chatId = parseInt(params.get('chat_id'), 10);
+        const urlToken = params.get('token');
+
+        if (tg && tg.initData) {
+            // Opened as Telegram Mini App — use native auth
+            tg.ready();
+            tg.expand();
+            this._applyTheme(tg.themeParams);
+            this.initData = tg.initData;
+        } else if (urlToken) {
+            // Opened via browser URL with signed token (group chats)
+            this.initData = urlToken;
+        } else {
+            this._showError('Missing authentication data. Please open from Telegram.');
+            return;
+        }
+
         if (!this.chatId) {
             this._showError('Missing chat context. Please use /start in your Telegram chat.');
             return;

--- a/tests/src/services/test_telegram_settings.py
+++ b/tests/src/services/test_telegram_settings.py
@@ -250,12 +250,22 @@ class TestBuildSettingsKeyboard:
             "active_account_name": "Not selected",
         }
 
+        # In group chats (default), uses signed URL button
         _, markup = mock_settings_handlers.build_settings_message_and_keyboard(-100123)
-
         all_buttons = [btn for row in markup.inline_keyboard for btn in row]
         mini_app_buttons = [b for b in all_buttons if "Full Settings" in b.text]
         assert len(mini_app_buttons) == 1
-        assert mini_app_buttons[0].web_app is not None
+        assert mini_app_buttons[0].url is not None
+        assert "token=" in mini_app_buttons[0].url
+
+        # In private chats, uses WebAppInfo button
+        _, markup_priv = mock_settings_handlers.build_settings_message_and_keyboard(
+            -100123, user_id=12345, is_private=True
+        )
+        all_buttons_priv = [btn for row in markup_priv.inline_keyboard for btn in row]
+        mini_app_priv = [b for b in all_buttons_priv if "Full Settings" in b.text]
+        assert len(mini_app_priv) == 1
+        assert mini_app_priv[0].web_app is not None
 
     @patch("src.services.core.telegram_settings.app_settings")
     def test_mini_app_button_absent_when_not_configured(


### PR DESCRIPTION
## Summary
- `WebAppInfo` buttons are rejected by Telegram in groups (`Button_type_invalid`)
- In groups: uses `url=` button with HMAC-signed token (chat_id + user_id + timestamp)
- In DMs: uses `web_app=WebAppInfo` (native Mini App experience)
- API now accepts both `initData` (Mini App) and URL tokens (browser) for authentication
- Frontend detects available auth method automatically

## Changes
- `webapp_auth.py`: Added `generate_url_token()` and `validate_url_token()`
- `telegram_commands.py`: Uses signed URL in groups, WebAppInfo in DMs
- `telegram_settings.py`: Same pattern for "Open Full Settings" button
- `onboarding.py`: `_validate_request()` tries initData first, falls back to URL token
- `app.js`: Reads `token` URL param when Telegram WebApp SDK not available

## Test plan
- [x] 1239 tests pass
- [ ] Deploy worker + API and test `/start` in group chat → opens webapp with auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)