### PR TITLE
feat: Complete settings panel in Mini App Quick Controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Cards lazy-load data on first expand to keep initial load fast
   - Schedule timing info (next post, schedule end date) shown in card summaries
 
-- **Dashboard API endpoints** - Six new endpoints powering the enhanced dashboard
+- **Dashboard API endpoints** - Seven new endpoints powering the enhanced dashboard
   - `GET /api/onboarding/queue-detail` - Queue items with day summary and schedule bounds
   - `GET /api/onboarding/history-detail` - Recent posting history with media info
   - `GET /api/onboarding/media-stats` - Media library category breakdown
-  - `POST /api/onboarding/toggle-setting` - Toggle is_paused or dry_run_mode from dashboard
+  - `POST /api/onboarding/toggle-setting` - Toggle boolean settings from dashboard (all 5: is_paused, dry_run_mode, enable_instagram_api, show_verbose_notifications, media_sync_enabled)
+  - `POST /api/onboarding/update-setting` - Update numeric settings from dashboard (posts_per_day, posting_hours_start, posting_hours_end)
   - `POST /api/onboarding/extend-schedule` - Extend schedule by N days
   - `POST /api/onboarding/regenerate-schedule` - Clear queue and rebuild schedule
+
+- **Full Settings in Quick Controls card** - All settings now editable from the Mini App dashboard (Phase 1 of Mini App Consolidation)
+  - 3 new toggle switches: Instagram API, Verbose Notifications, Media Sync
+  - Stepper controls for Posts/Day (1-50) and Posting Hours (start/end with wraparound)
+  - Optimistic UI updates with automatic rollback on API failure
+  - Setup state now returns all boolean settings for dashboard hydration
 
 ### Fixed
 

--- a/documentation/planning/mini-app-consolidation_2026-02-23/00_OVERVIEW.md
+++ b/documentation/planning/mini-app-consolidation_2026-02-23/00_OVERVIEW.md
@@ -1,0 +1,292 @@
+# Mini App Consolidation — Command Cleanup & Feature Unification
+
+**Status**: 🔧 IN PROGRESS (Phase 1)
+**Started**: 2026-02-23
+**Created**: 2026-02-23
+**Priority**: High
+
+## Problem Statement
+
+The bot has grown organically into two parallel interfaces:
+
+1. **Telegram Commands** (11 active) — text-heavy, multi-step conversation flows, settings menus with 10+ inline buttons
+2. **Mini App** (webapp) — visual dashboard with collapsible cards, toggles, lazy-loaded data
+
+These overlap significantly. Users must context-switch between typing `/settings` for account management, opening the Mini App for schedule actions, and using `/status` for health checks. The experience is fragmented.
+
+### Current Command Inventory
+
+| Command | What It Does | Mini App Overlap |
+|---------|-------------|------------------|
+| `/start` | Opens Mini App (or shows fallback) | **Full** — IS the Mini App |
+| `/status` | 25-line health report + setup status tree | **Partial** — dashboard shows counts but not health/setup checks |
+| `/queue` | Lists next 10 queue items | **Full** — Queue card does this |
+| `/next` | Force-send next post immediately | **None** — action command, not info |
+| `/pause` | Pause delivery | **Full** — Quick Controls toggle |
+| `/resume` | Resume + handle overdue items | **Partial** — toggle exists, but overdue flow is Telegram-only |
+| `/history N` | Recent post list (scrollable) | **Full** — Recent Activity card |
+| `/settings` | 10-button settings menu + multi-step conversations | **Partial** — only 2 toggles in Mini App |
+| `/help` | Command reference | **None** — reference material |
+| `/sync` | Trigger media sync | **None** — action command |
+| `/cleanup` | Delete bot messages | **None** — utility |
+
+### What the Mini App Already Has
+
+The Enhanced Dashboard (shipped Feb 2026) already provides:
+
+- **8 collapsible cards**: Instagram, Google Drive, Quick Controls, Schedule, Queue, Recent Activity, Media Library
+- **Quick Controls card**: Delivery ON/OFF and Dry Run ON/OFF toggles
+- **Schedule card**: Day summary, +7 Days extend, Regenerate (with confirmation), Edit Settings link
+- **Queue card**: Lazy-loaded next 10 pending posts with scheduled times
+- **Recent Activity card**: Lazy-loaded last 10 posts with status and posting method
+- **Media Library card**: Category breakdown with percentage bars
+- **Edit mode**: Jump to any wizard step from home, "Save & Return" navigation
+- **API endpoints**: `/toggle-setting`, `/queue-detail`, `/history-detail`, `/media-stats`, `/extend-schedule`, `/regenerate-schedule`
+
+### Remaining Gaps in Mini App
+
+1. **Incomplete settings** — Quick Controls only has 2 of 5 toggles; missing Instagram API, Verbose, Media Sync. No Posts/Day or Posting Hours editing from dashboard.
+2. **No account management** — can't add/switch/remove Instagram accounts
+3. **No /next equivalent** — can't force-send from dashboard
+4. **No /sync equivalent** — can't trigger sync from dashboard
+5. **No overdue handling** — /resume's reschedule/clear/force flow has no Mini App equivalent
+6. **No status/health view** — no system health or setup completion reporting
+
+---
+
+## Design Philosophy
+
+### Keep In Telegram (Quick Actions)
+Commands that are **fast, contextual, action-oriented** and benefit from being typed in-chat:
+
+- **`/next`** — Force-send. One word, immediate result. This is a power-user shortcut.
+- **`/cleanup`** — Channel housekeeping. Must operate on Telegram messages.
+- **`/help`** — Reference card. Quick text dump, no UI needed.
+
+### Slim Down In Telegram (Deferred to Phase 5)
+Commands that currently display **rich UI** in Telegram will become **thin redirects** with one-line status + a "Open Dashboard" button — but only after the Mini App has full feature parity:
+
+- **`/status`** → One-line summary + button to Mini App status view
+- **`/settings`** → One-line current config + button to Mini App settings
+
+### Move to Mini App (Full Experience)
+Everything that involves **browsing data, editing settings, or multi-step workflows**:
+
+- Account management (add/switch/remove)
+- Full settings panel (all toggles + numeric inputs)
+- Queue browsing + schedule management (already done)
+- History browsing (already done)
+- Media library browsing (already done)
+- System health / setup status
+- Media sync trigger
+- Overdue post handling
+
+### Post Notifications (Unchanged)
+The in-channel post notification with action buttons stays exactly as-is:
+- Auto Post / Posted / Skip / Reject buttons
+- Inline account selector (switch account per-post)
+- These are contextual actions on a specific post and belong in the channel
+
+---
+
+## Phased Implementation Plan
+
+### Phase 1: Complete Settings in Quick Controls Card
+**Expand the existing Quick Controls card to include all settings**
+
+The Quick Controls card already has Delivery and Dry Run toggles. This phase adds the remaining 3 toggles and numeric settings editing inline.
+
+Frontend changes (`index.html` + `app.js` + `style.css`):
+- Add 3 toggle rows to Quick Controls card body: Instagram API, Verbose Notifications, Media Sync
+- Add Posts/Day display with edit control (number input or stepper)
+- Add Posting Hours display with edit controls (start/end hour selectors)
+- Reuse existing `toggleSetting()` method (already handles POST to `/toggle-setting`)
+- Add `updateSetting(name, value)` method for numeric settings (POST to existing `/schedule` endpoint pattern)
+
+Backend changes (`onboarding.py`):
+- Expand `/toggle-setting` endpoint's `allowed_settings` from `{"is_paused", "dry_run_mode"}` to include `"enable_instagram_api"`, `"show_verbose_notifications"`, `"media_sync_enabled"` — the `SettingsService.toggle_setting()` already supports all 5
+- Add `POST /api/onboarding/update-setting` for numeric settings — calls existing `SettingsService.update_setting()` which already validates `posts_per_day` (1-50), `posting_hours_start` (0-23), `posting_hours_end` (0-23)
+
+No changes to `/settings` command in this phase.
+
+### Phase 2: Account Management in Mini App
+**Move add/switch/remove accounts to Mini App**
+
+Expand the existing Instagram card to be collapsible with account management:
+- List of all connected accounts (active marked with checkmark)
+- "Switch" button per account
+- "Add Account" button → opens OAuth flow (reuse existing `connectOAuth('instagram')` pattern)
+- "Remove" button per account (with confirmation)
+- Active account badge on card header
+
+Backend:
+- `GET /api/onboarding/accounts` — list all accounts for this chat (uses `InstagramAccountService.list_accounts()`)
+- `POST /api/onboarding/switch-account` — switch active account (uses `InstagramAccountService.switch_account()`)
+- `POST /api/onboarding/remove-account` — deactivate account (uses `InstagramAccountService.deactivate_account()`)
+- Reuse existing OAuth flow for adding accounts
+
+Note: **In-channel post account selector stays unchanged** — switching account on a specific post notification is a contextual action that belongs in the channel.
+
+### Phase 3: Status & Health in Mini App
+**Move /status reporting to Mini App**
+
+Add a new collapsible **System Status card** to the dashboard showing:
+- Delivery mode (active/paused/dry-run)
+- Instagram API status (enabled/disabled, token health)
+- Media sync status (last sync time, source type)
+- Setup completion checklist (5 items with checkmarks)
+- Queue health (pending count, locked count, next post time)
+
+Backend:
+- `GET /api/onboarding/system-status` — aggregated health data
+- Reuses existing logic from `TelegramCommandHandlers._get_setup_status()` and `HealthCheckService.check_all()`
+
+No changes to `/status` command in this phase.
+
+### Phase 4: Quick Actions in Mini App
+**Add /next, /sync, and overdue handling equivalents**
+
+Add to the existing Quick Controls card or a dedicated action area:
+- "Send Next Now" button (equivalent to `/next`) with confirmation dialog
+- "Sync Media" button (equivalent to `/sync`) with result display
+
+Add to the Schedule card:
+- When overdue items exist, show inline options: Reschedule / Clear / Force — same as `/resume` flow but in Mini App UI
+
+Backend:
+- `POST /api/onboarding/force-next` — calls existing `PostingService.force_post_next()`
+- `POST /api/onboarding/sync-media` — calls existing `MediaSyncService.sync()`
+- `POST /api/onboarding/handle-overdue` — calls existing reschedule/clear logic from `TelegramCommandHandlers.handle_resume()`
+
+### Phase 5: Command Cleanup
+**Retire redundant commands, slim remaining ones**
+
+After Phases 1-4, the Mini App has full feature parity. Now slim down Telegram:
+
+Slim down `/status`:
+```
+📊 Status: ✅ Healthy · 210 queued · Next in 2h · Last 4d ago
+[Open Dashboard ↗]
+```
+One-line summary + button to Mini App.
+
+Slim down `/settings`:
+```
+⚙️ Settings: 15/day · 12pm-4am · Delivery ON · Dry Run OFF
+[Open Settings ↗]
+```
+One line of current config + button to Mini App.
+
+**Retire** (add redirect messages):
+- `/queue` → "View your queue in the dashboard" + button
+- `/pause` → "Use Quick Controls in the dashboard" + button
+- `/resume` → "Use Quick Controls in the dashboard" + button
+- `/history` → "View recent activity in the dashboard" + button
+- `/sync` → "Sync from the dashboard" + button
+
+The command structure becomes:
+
+| Command | Behavior | Purpose |
+|---------|----------|---------|
+| `/start` | Opens Mini App | **Primary entry point** |
+| `/status` | One-line summary + "Open Dashboard" button | **Quick glance** |
+| `/settings` | One-line config + "Open Settings" button | **Quick glance** |
+| `/next` | Force-send (unchanged) | **Power-user shortcut** |
+| `/help` | Slim command reference | **Reference** |
+| `/cleanup` | Delete bot messages (unchanged) | **Utility** |
+
+This takes us from **11 active commands** down to **6** (with 5 joining the 7 already-retired commands as redirects).
+
+### Phase 6: Menu Button
+**Configure BotFather menu button to always open Mini App**
+
+Instead of the hamburger menu showing a command list, the main menu button opens the Mini App directly. This makes the Mini App the default interface.
+
+---
+
+## Command Consolidation Summary
+
+### Before (11 commands)
+```
+/start    /status    /queue     /next      /pause
+/resume   /history   /settings  /help      /sync
+/cleanup
+```
+
+### After (6 commands)
+```
+/start     → Opens Mini App (primary interface)
+/status    → One-line summary + [Open Dashboard] button
+/settings  → One-line config + [Open Settings] button
+/next      → Force-send next post (power-user action)
+/help      → Slim reference card
+/cleanup   → Delete bot messages (utility)
+```
+
+### Retired → Redirect (12 total, 5 new + 7 existing)
+```
+/queue /pause /resume /history /sync          ← NEW redirects
+/schedule /stats /locks /reset /dryrun        ← Existing redirects
+/backfill /connect                            ← Existing redirects
+```
+
+---
+
+## What Stays in Telegram (Unchanged)
+
+**Post notifications** with full button set:
+- Auto Post to Instagram
+- Posted / Skip / Reject
+- Account selector (switch per-post)
+- Open Instagram link
+
+These are contextual actions on specific posts and MUST stay in the channel. The Mini App cannot interact with individual Telegram messages.
+
+---
+
+## Files Affected (Estimated)
+
+| Phase | Files | Scope |
+|-------|-------|-------|
+| 1 | `onboarding.py`, `index.html`, `app.js`, `style.css`, tests | Expand Quick Controls |
+| 2 | `onboarding.py`, `index.html`, `app.js`, `style.css`, tests | Account management |
+| 3 | `onboarding.py`, `index.html`, `app.js`, `style.css`, tests | Status/health card |
+| 4 | `onboarding.py`, `index.html`, `app.js`, `style.css`, tests | Quick actions + overdue |
+| 5 | `telegram_commands.py`, `telegram_settings.py`, tests | Command slimming + retirements |
+| 6 | BotFather config (manual) | Menu button |
+
+## Existing Code to Reuse (NOT Duplicate)
+
+| What | Where It Already Lives | Reuse Pattern |
+|------|----------------------|---------------|
+| Toggle 5 boolean settings | `SettingsService.toggle_setting()` | Widen `allowed_settings` in endpoint |
+| Update numeric settings | `SettingsService.update_setting()` | New thin endpoint, same service call |
+| Schedule extend/regenerate | `/extend-schedule`, `/regenerate-schedule` endpoints | Already in Mini App |
+| Queue detail + day summary | `/queue-detail` endpoint | Already in Mini App |
+| History detail | `/history-detail` endpoint | Already in Mini App |
+| Media stats | `/media-stats` endpoint | Already in Mini App |
+| Account CRUD | `InstagramAccountService` | New endpoints call existing service |
+| Health checks | `HealthCheckService.check_all()` | New endpoint wraps existing service |
+| Setup status checks | `TelegramCommandHandlers._get_setup_status()` | Extract logic to shared helper |
+| Force post next | `PostingService.force_post_next()` | New endpoint calls existing service |
+| Media sync | `MediaSyncService.sync()` | New endpoint calls existing service |
+| Overdue handling | `TelegramCommandHandlers.handle_resume()` | Extract logic to shared helper |
+| OAuth flow | `connectOAuth()` in app.js | Reuse for account additions |
+| Collapsible card pattern | Existing cards in index.html/app.js | Follow established pattern |
+| Lazy-load on expand | `toggleCard()` + `_loadCardData()` | Follow established pattern |
+
+## Dependencies
+
+- Phase 1 is independent (no blockers)
+- Phase 2 is independent (no blockers)
+- Phase 3 is independent (no blockers)
+- Phase 4 is independent (no blockers)
+- Phase 5 depends on Phases 1-4 (can't retire until Mini App has the features)
+- Phase 6 depends on Phase 5 (menu button change is the final step)
+- Phases 1-4 can be done in any order, but suggested order maximizes user value
+
+## Risk & Rollback
+
+- All retired commands get redirect messages (never a dead end)
+- Mini App features are additive (don't remove Telegram functionality until Mini App equivalent is verified)
+- Phase 5 (retirements) is the only destructive phase and should be the last step

--- a/src/api/static/onboarding/index.html
+++ b/src/api/static/onboarding/index.html
@@ -66,6 +66,52 @@
                                 <span class="toggle-slider"></span>
                             </label>
                         </div>
+                        <div class="toggle-row-compact">
+                            <span>Instagram API</span>
+                            <label class="toggle toggle-sm">
+                                <input type="checkbox" id="toggle-instagram-api" onchange="App.toggleSetting('enable_instagram_api')">
+                                <span class="toggle-slider"></span>
+                            </label>
+                        </div>
+                        <div class="toggle-row-compact">
+                            <span>Verbose Notifications</span>
+                            <label class="toggle toggle-sm">
+                                <input type="checkbox" id="toggle-verbose" onchange="App.toggleSetting('show_verbose_notifications')">
+                                <span class="toggle-slider"></span>
+                            </label>
+                        </div>
+                        <div class="toggle-row-compact">
+                            <span>Media Sync</span>
+                            <label class="toggle toggle-sm">
+                                <input type="checkbox" id="toggle-media-sync" onchange="App.toggleSetting('media_sync_enabled')">
+                                <span class="toggle-slider"></span>
+                            </label>
+                        </div>
+                        <div class="settings-divider"></div>
+                        <div class="setting-row-numeric">
+                            <span>Posts / Day</span>
+                            <div class="stepper">
+                                <button class="stepper-btn" onclick="App.adjustSetting('posts_per_day', -1)">&#x2212;</button>
+                                <span class="stepper-value" id="setting-posts-per-day">3</span>
+                                <button class="stepper-btn" onclick="App.adjustSetting('posts_per_day', 1)">+</button>
+                            </div>
+                        </div>
+                        <div class="setting-row-numeric">
+                            <span>Hours Start</span>
+                            <div class="stepper">
+                                <button class="stepper-btn" onclick="App.adjustSetting('posting_hours_start', -1)">&#x2212;</button>
+                                <span class="stepper-value" id="setting-posting-hours-start">2pm</span>
+                                <button class="stepper-btn" onclick="App.adjustSetting('posting_hours_start', 1)">+</button>
+                            </div>
+                        </div>
+                        <div class="setting-row-numeric">
+                            <span>Hours End</span>
+                            <div class="stepper">
+                                <button class="stepper-btn" onclick="App.adjustSetting('posting_hours_end', -1)">&#x2212;</button>
+                                <span class="stepper-value" id="setting-posting-hours-end">2am</span>
+                                <button class="stepper-btn" onclick="App.adjustSetting('posting_hours_end', 1)">+</button>
+                            </div>
+                        </div>
                     </div>
                 </div>
 

--- a/src/api/static/onboarding/style.css
+++ b/src/api/static/onboarding/style.css
@@ -608,6 +608,59 @@ h2 {
     transform: translateX(16px);
 }
 
+/* ==================== Settings Numeric Controls ==================== */
+
+.settings-divider {
+    height: 1px;
+    background: rgba(0, 0, 0, 0.06);
+    margin: 8px 0;
+}
+
+.setting-row-numeric {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px 0;
+    font-size: 14px;
+}
+
+.stepper {
+    display: flex;
+    align-items: center;
+    gap: 0;
+    background: var(--tg-theme-bg-color);
+    border-radius: 8px;
+    overflow: hidden;
+    border: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.stepper-btn {
+    width: 32px;
+    height: 32px;
+    border: none;
+    background: none;
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--tg-theme-button-color);
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    -webkit-tap-highlight-color: transparent;
+}
+
+.stepper-btn:active {
+    background: var(--tg-theme-secondary-bg-color);
+}
+
+.stepper-value {
+    min-width: 36px;
+    text-align: center;
+    font-size: 14px;
+    font-weight: 600;
+    padding: 0 2px;
+}
+
 /* ==================== Queue / History Items ==================== */
 
 .queue-item-row, .history-item-row {

--- a/src/services/media_sources/factory.py
+++ b/src/services/media_sources/factory.py
@@ -69,9 +69,7 @@ class MediaSourceFactory:
             return provider_class(base_path=base_path)
 
         if source_type == "google_drive":
-            root_folder_id = kwargs.get(
-                "root_folder_id", settings.MEDIA_SOURCE_ROOT
-            )
+            root_folder_id = kwargs.get("root_folder_id", settings.MEDIA_SOURCE_ROOT)
             service_account_info = kwargs.get("service_account_info")
             oauth_credentials = kwargs.get("oauth_credentials")
             telegram_chat_id = kwargs.get("telegram_chat_id")

--- a/tests/src/api/test_onboarding_routes.py
+++ b/tests/src/api/test_onboarding_routes.py
@@ -44,6 +44,9 @@ def _mock_settings_obj(**overrides):
         media_source_type=None,
         is_paused=False,
         dry_run_mode=True,
+        enable_instagram_api=False,
+        show_verbose_notifications=False,
+        media_sync_enabled=False,
     )
     defaults.update(overrides)
     return Mock(**defaults)


### PR DESCRIPTION
## Summary
- Expand Quick Controls card to include all 5 boolean toggles (was 2) and numeric settings editing
- Add `POST /api/onboarding/update-setting` endpoint for posts_per_day and posting hours
- Widen `/toggle-setting` to accept all 5 boolean settings (enable_instagram_api, show_verbose_notifications, media_sync_enabled)
- Return all boolean settings from `_get_setup_state()` for dashboard hydration
- Phase 1 of Mini App Consolidation plan (see `documentation/planning/mini-app-consolidation_2026-02-23/`)

## Changes
| File | Change |
|------|--------|
| `src/api/routes/onboarding.py` | Widen toggle endpoint, add update-setting endpoint, return 3 new fields from setup state |
| `src/api/static/onboarding/index.html` | 3 new toggle rows + stepper controls for numeric settings |
| `src/api/static/onboarding/app.js` | `adjustSetting()`, `_updateSettingDisplay()`, `_updateControlsSummary()` methods |
| `src/api/static/onboarding/style.css` | Stepper and settings divider styles |
| `tests/src/api/test_onboarding_dashboard.py` | 10 new tests for expanded toggles + update-setting |
| `tests/src/api/test_onboarding_routes.py` | Updated mock to include new settings fields |

## Test plan
- [x] All 1266 tests pass (10 new)
- [x] `ruff check` clean
- [x] `ruff format` clean
- [ ] Deploy and verify toggles work from Mini App dashboard
- [ ] Verify stepper controls persist values correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)