### PR TITLE
feat: Instagram account management in Mini App

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Optimistic UI updates with automatic rollback on API failure
   - Setup state now returns all boolean settings for dashboard hydration
 
+- **Account Management in Mini App** - Manage Instagram accounts directly from the dashboard (Phase 2 of Mini App Consolidation)
+  - Instagram card is now expandable with full account list
+  - Switch active account with one tap
+  - Add new accounts via OAuth flow (reuses existing `connectOAuth` pattern)
+  - Remove accounts with inline confirmation dialog (soft-delete, can be re-added later)
+  - Active account highlighted with badge; summary shows `@username`
+  - `GET /api/onboarding/accounts` - List all active accounts with active marker for current chat
+  - `POST /api/onboarding/switch-account` - Switch active Instagram account
+  - `POST /api/onboarding/remove-account` - Deactivate (soft-delete) an account
+
 ### Fixed
 
 - **Google Drive media download in `/next` and auto-post** - Fixed "No Google Drive credentials found" error when sending notifications. The media download path was using the service account credential lookup instead of per-chat OAuth tokens. Now passes `telegram_chat_id` through `MediaSourceFactory.get_provider_for_media_item()` so Google Drive files are fetched with the correct user OAuth credentials.

--- a/src/api/static/onboarding/index.html
+++ b/src/api/static/onboarding/index.html
@@ -15,17 +15,35 @@
                 <h1>Storyline AI</h1>
                 <p class="subtitle">Your posting dashboard</p>
 
-                <!-- Instagram (static, not expandable) -->
-                <div class="home-card" id="home-card-instagram">
-                    <div class="home-card-header">
+                <!-- Instagram (expandable with account management) -->
+                <div class="home-card home-card-expandable" id="home-card-instagram">
+                    <div class="home-card-header" onclick="App.toggleCard('instagram')">
                         <div class="home-card-title">
                             <span class="home-card-icon">&#x1F4F8;</span>
                             <span>Instagram</span>
                         </div>
-                        <span class="home-card-badge" id="home-badge-instagram"></span>
+                        <div class="home-card-header-right">
+                            <span class="home-card-badge" id="home-badge-instagram"></span>
+                            <span class="home-card-chevron">&#x25B8;</span>
+                        </div>
                     </div>
                     <div class="home-card-detail" id="home-detail-instagram"></div>
-                    <button class="btn btn-card-edit" onclick="App.editSection('instagram')">Edit</button>
+                    <div class="home-card-body" id="home-body-instagram">
+                        <div class="card-body-loading hidden" id="instagram-account-loading">
+                            <div class="spinner"></div>
+                        </div>
+                        <div id="instagram-account-list"></div>
+                        <div class="confirm-dialog hidden" id="remove-account-confirm">
+                            <p>Remove this account? It can be re-added later.</p>
+                            <div class="confirm-actions">
+                                <button class="btn btn-action-sm btn-action-danger" id="btn-confirm-remove" onclick="App.executeRemoveAccount()">Yes, Remove</button>
+                                <button class="btn btn-action-sm" onclick="App.cancelRemoveAccount()">Cancel</button>
+                            </div>
+                        </div>
+                        <div class="card-body-actions" id="instagram-account-actions">
+                            <button class="btn btn-action-sm" onclick="App.connectOAuth('instagram')">Add Account</button>
+                        </div>
+                    </div>
                 </div>
 
                 <!-- Google Drive (static, not expandable) -->

--- a/src/api/static/onboarding/style.css
+++ b/src/api/static/onboarding/style.css
@@ -661,6 +661,77 @@ h2 {
     padding: 0 2px;
 }
 
+/* ==================== Account Management ==================== */
+
+.account-row {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px 0;
+    font-size: 14px;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.04);
+}
+
+.account-row:last-child {
+    border-bottom: none;
+}
+
+.account-info {
+    flex: 1;
+    min-width: 0;
+}
+
+.account-name {
+    font-weight: 500;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.account-username {
+    font-size: 12px;
+    color: var(--tg-theme-hint-color);
+    margin-top: 1px;
+}
+
+.account-actions {
+    display: flex;
+    gap: 6px;
+    flex-shrink: 0;
+    margin-left: 8px;
+}
+
+.account-active-badge {
+    font-size: 12px;
+    color: #16a34a;
+    font-weight: 500;
+    padding: 4px 8px;
+}
+
+.btn-account-action {
+    padding: 4px 10px;
+    font-size: 12px;
+    font-weight: 500;
+    border-radius: 6px;
+    border: none;
+    cursor: pointer;
+    -webkit-tap-highlight-color: transparent;
+}
+
+.btn-account-action:active {
+    opacity: 0.7;
+}
+
+.btn-account-switch {
+    background: var(--tg-theme-button-color);
+    color: var(--tg-theme-button-text-color);
+}
+
+.btn-account-remove {
+    background: rgba(239, 68, 68, 0.1);
+    color: #dc2626;
+}
+
 /* ==================== Queue / History Items ==================== */
 
 .queue-item-row, .history-item-row {


### PR DESCRIPTION
## Summary
- **Phase 2 of Mini App Consolidation** — Move Instagram account management from Telegram-only to the Mini App dashboard
- Instagram card is now expandable with full account list (switch, add via OAuth, remove with confirmation)
- Three new API endpoints: `GET /accounts`, `POST /switch-account`, `POST /remove-account`
- All backend logic reuses existing `InstagramAccountService` methods — no new business logic

## Changes

### Backend (`src/api/routes/onboarding.py`)
- `GET /api/onboarding/accounts` — Lists all active accounts, marks which is active for this chat
- `POST /api/onboarding/switch-account` — Switches active account via `InstagramAccountService.switch_account()`
- `POST /api/onboarding/remove-account` — Soft-deletes via `InstagramAccountService.deactivate_account()`
- Added `SwitchAccountRequest` and `RemoveAccountRequest` Pydantic models

### Frontend
- **HTML**: Instagram card converted from static to expandable with account list, confirmation dialog, and "Add Account" button
- **JS**: Added `_loadAccounts()`, `switchAccount()`, `confirmRemoveAccount()`, `executeRemoveAccount()`, `_renderAccounts()`. OAuth polling updated for home mode (refreshes dashboard instead of navigating wizard)
- **CSS**: Account row styles with switch/remove buttons, active badge

### Tests (9 new)
- `TestAccounts`: list, empty, unauthorized
- `TestSwitchAccount`: success, not found, unauthorized
- `TestRemoveAccount`: success, not found, unauthorized

## Test plan
- [x] All 1275 tests pass (9 new)
- [x] `ruff check` clean
- [x] `ruff format` clean
- [ ] Deploy and verify Instagram card expands with account list
- [ ] Test switch account from dashboard
- [ ] Test add account via OAuth from dashboard
- [ ] Test remove account with confirmation

🤖 Generated with [Claude Code](https://claude.com/claude-code)