### PR TITLE
feat: Sync Media action in Mini App dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Badge shows "Healthy"/"All Set" or issue count based on health check results
   - `GET /api/onboarding/system-status` - Aggregated health data from HealthCheckService
 
+- **Sync Media action in Mini App** - Trigger media sync directly from the dashboard (Phase 4 of Mini App Consolidation)
+  - "Sync Media" button in Quick Controls card below settings
+  - Inline result display showing new/updated/removed/error counts
+  - `POST /api/onboarding/sync-media` - Calls MediaSyncService with per-tenant config
+
 ### Fixed
 
 - **Google Drive media download in `/next` and auto-post** - Fixed "No Google Drive credentials found" error when sending notifications. The media download path was using the service account credential lookup instead of per-chat OAuth tokens. Now passes `telegram_chat_id` through `MediaSourceFactory.get_provider_for_media_item()` so Google Drive files are fetched with the correct user OAuth credentials.

--- a/documentation/planning/mini-app-consolidation_2026-02-23/00_OVERVIEW.md
+++ b/documentation/planning/mini-app-consolidation_2026-02-23/00_OVERVIEW.md
@@ -1,6 +1,6 @@
 # Mini App Consolidation — Command Cleanup & Feature Unification
 
-**Status**: 🔧 IN PROGRESS (Phase 3)
+**Status**: 🔧 IN PROGRESS (Phase 4)
 **Started**: 2026-02-23
 **Created**: 2026-02-23
 **Priority**: High
@@ -91,7 +91,7 @@ The in-channel post notification with action buttons stays exactly as-is:
 
 ## Phased Implementation Plan
 
-### Phase 1: Complete Settings in Quick Controls Card ✅ COMPLETE (PR #73)
+### Phase 1: Complete Settings in Quick Controls Card — ✅ COMPLETE (PR #73)
 **Expand the existing Quick Controls card to include all settings**
 
 The Quick Controls card already has Delivery and Dry Run toggles. This phase adds the remaining 3 toggles and numeric settings editing inline.
@@ -109,7 +109,7 @@ Backend changes (`onboarding.py`):
 
 No changes to `/settings` command in this phase.
 
-### Phase 2: Account Management in Mini App
+### Phase 2: Account Management in Mini App — ✅ COMPLETE (PR #74)
 **Move add/switch/remove accounts to Mini App**
 
 Expand the existing Instagram card to be collapsible with account management:
@@ -166,20 +166,29 @@ Backend changes (`onboarding.py`):
 
 No changes to `/status` command in this phase.
 
-### Phase 4: Quick Actions in Mini App
-**Add /next, /sync, and overdue handling equivalents**
+### Phase 4: Sync Media Action in Mini App — 🔧 IN PROGRESS
+**Add media sync trigger to Quick Controls card**
+Started: 2026-02-22
 
-Add to the existing Quick Controls card or a dedicated action area:
-- "Send Next Now" button (equivalent to `/next`) with confirmation dialog
-- "Sync Media" button (equivalent to `/sync`) with result display
+Simplified scope after challenge round:
+- **Dropped**: "Send Next Now" — stays as `/next` in Telegram (one word, instant, power-user shortcut)
+- **Dropped**: Overdue handling — rare scenario, keep in Telegram via `/resume`
+- **Kept**: "Sync Media" trigger button — natural fit alongside the Media Sync toggle
 
-Add to the Schedule card:
-- When overdue items exist, show inline options: Reschedule / Clear / Force — same as `/resume` flow but in Mini App UI
+Add to Quick Controls card body:
+- "Sync Media" trigger button below the existing settings
+- Visual divider separating settings from actions
+- Inline result display (e.g., "3 new, 1 updated" or "No changes")
+- Loading state while sync runs
+- Error handling for sync failures
 
 Backend:
-- `POST /api/onboarding/force-next` — calls existing `PostingService.force_post_next()`
-- `POST /api/onboarding/sync-media` — calls existing `MediaSyncService.sync()`
-- `POST /api/onboarding/handle-overdue` — calls existing reschedule/clear logic from `TelegramCommandHandlers.handle_resume()`
+- `POST /api/onboarding/sync-media` — calls existing `MediaSyncService.sync(telegram_chat_id=chat_id)`
+
+Tests:
+- `test_sync_media_success` — verify endpoint calls service and returns result
+- `test_sync_media_unauthorized` — verify auth check
+- `test_sync_media_error` — verify error handling
 
 ### Phase 5: Command Cleanup
 **Retire redundant commands, slim remaining ones**
@@ -274,7 +283,7 @@ These are contextual actions on specific posts and MUST stay in the channel. The
 | 1 | `onboarding.py`, `index.html`, `app.js`, `style.css`, tests | Expand Quick Controls |
 | 2 | `onboarding.py`, `index.html`, `app.js`, `style.css`, tests | Account management |
 | 3 | `onboarding.py`, `index.html`, `app.js`, `style.css`, tests | Status/health card |
-| 4 | `onboarding.py`, `index.html`, `app.js`, `style.css`, tests | Quick actions + overdue |
+| 4 | `onboarding.py`, `index.html`, `app.js`, `style.css`, tests | Sync Media trigger button |
 | 5 | `telegram_commands.py`, `telegram_settings.py`, tests | Command slimming + retirements |
 | 6 | BotFather config (manual) | Menu button |
 

--- a/src/api/static/onboarding/index.html
+++ b/src/api/static/onboarding/index.html
@@ -130,6 +130,11 @@
                                 <button class="stepper-btn" onclick="App.adjustSetting('posting_hours_end', 1)">+</button>
                             </div>
                         </div>
+                        <div class="settings-divider"></div>
+                        <div class="card-body-actions">
+                            <button class="btn btn-action-sm" id="btn-sync-media" onclick="App.syncMedia()">Sync Media</button>
+                        </div>
+                        <div class="sync-result hidden" id="sync-result"></div>
                     </div>
                 </div>
 

--- a/src/api/static/onboarding/style.css
+++ b/src/api/static/onboarding/style.css
@@ -661,6 +661,26 @@ h2 {
     padding: 0 2px;
 }
 
+/* ==================== Sync Result ==================== */
+
+.sync-result {
+    margin-top: 8px;
+    padding: 8px 12px;
+    font-size: 13px;
+    border-radius: 6px;
+    background: rgba(34, 197, 94, 0.1);
+    color: #16a34a;
+}
+
+.sync-result-warning {
+    background: rgba(245, 158, 11, 0.1);
+    color: #d97706;
+}
+
+.sync-result.hidden {
+    display: none;
+}
+
 /* ==================== Account Management ==================== */
 
 .account-row {


### PR DESCRIPTION
## Summary
- Adds "Sync Media" trigger button to the Quick Controls card in the Mini App dashboard
- New `POST /api/onboarding/sync-media` endpoint calls `MediaSyncService.sync()` with per-tenant config
- Inline result display shows new/updated/removed/error counts after sync completes
- Phase 4 of Mini App Consolidation (simplified scope: dropped /next and overdue handling after challenge round)

## Changes
- `src/api/routes/onboarding.py` — New `/sync-media` endpoint
- `src/api/static/onboarding/index.html` — Sync Media button + result area in Quick Controls
- `src/api/static/onboarding/app.js` — `syncMedia()` method with loading/error states
- `src/api/static/onboarding/style.css` — `.sync-result` styles
- `tests/src/api/test_onboarding_dashboard.py` — 4 new tests (success, no folder, error, unauthorized)

## Verification
- [x] All 1282 tests pass (4 new)
- [x] ruff check + format clean
- [x] CHANGELOG.md updated

## Test plan
- [ ] Deploy to Railway
- [ ] Open Mini App → Quick Controls → verify Sync Media button appears below settings
- [ ] Tap Sync Media → verify loading overlay, then inline result message
- [ ] Verify result shows correct counts (new/updated/removed)
- [ ] Test with no media folder configured → verify error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)