### PR TITLE
Flatten nesting and extract helpers in PostingService

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Posting service complexity reduction** — Flattened nesting in `force_post_next()` and `process_pending_posts()`, extracted helper methods (`_build_force_post_result`, `_execute_force_post`, `_process_single_pending`), moved `db.commit()` from service to new `QueueRepository.reschedule_items()` method
+
 ### Removed
 - **Dead code in PostingService** — Removed ~258 lines of unreachable code from `posting.py`: `handle_completion()`, `_post_via_instagram()`, `_cleanup_cloud_media()`, `process_next_immediate()`, and related lazy-load properties for Instagram/cloud services. All posting now routes through Telegram; Instagram API posting happens via callback handler, not `PostingService`.
 


### PR DESCRIPTION
## Summary
- Fixed BaseService pattern violation: moved `db.commit()` from `PostingService` to new `QueueRepository.reschedule_items()` method
- Flattened `force_post_next()` nesting using early returns and extracted `_execute_force_post()` helper
- Extracted `_process_single_pending()` from `process_pending_posts()` to reduce nesting
- Added `_build_force_post_result()` for consistent result dict construction

## Test plan
- [x] All existing posting service tests pass (updated 2 tests for new repo delegation)
- [x] New tests for `_build_force_post_result` (6 tests), `_process_single_pending` (2 tests), `reschedule_items` (4 tests)
- [x] No `db.commit()` calls in posting.py (verified with grep)
- [x] Full pytest suite passes (1287 passed, pre-existing instagram_account_service failures unchanged)
- [x] ruff check and format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)