### PR TITLE
Fix Google Drive token expiry error handling with reconnect prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Google Drive token expiry error handling** — When Google Drive OAuth token expires or is revoked, `/next` now shows a "Reconnect Google Drive" button instead of a generic "Failed to send. Check logs for details." error. `GoogleDriveAuthError` propagates from `send_notification()` instead of being swallowed, with automatic detection of `google.auth.RefreshError` in the exception chain. `PostingService` catches the error in `_execute_force_post`, `_post_via_telegram`, and `process_pending_posts`, sending a rate-limited (1/hr) proactive alert to Telegram when scheduled posting fails due to auth issues.
+- **Stale Google Drive token detection** — `/status` now shows "Needs Reconnection" instead of "Connected" when the access token expired more than 7 days ago. Dashboard API returns `gdrive_needs_reconnect` flag for the same condition.
+
 ### Changed
 - **Telegram service split** — Extracted `TelegramNotificationService` (~280 lines) from `telegram_service.py` (795 -> 533 lines), isolating notification sending, caption building, keyboard construction, and header emoji logic into a dedicated module. `TelegramService` keeps thin delegation methods for backward compatibility.
 - **Repository query builder** — Added `_tenant_query()` helper to BaseRepository, refactored 34 instances across 5 repository files to eliminate repeated tenant filtering boilerplate


### PR DESCRIPTION
## Summary
- **GoogleDriveAuthError now propagates** from `send_notification()` instead of being swallowed by the generic `except` — added `_is_google_auth_error()` helper to detect `google.auth.RefreshError` in the exception cause chain
- **PostingService catches auth errors** at 3 levels: `_execute_force_post` returns `google_drive_auth_expired` error code, `_post_via_telegram` rolls back queue status + re-raises, `process_pending_posts` sends a rate-limited (1/hr) proactive Telegram alert with reconnect button and breaks the batch
- **/next shows reconnect button** instead of generic "Failed to send. Check logs for details." when the Drive token is expired
- **/status detects stale tokens** — shows "Needs Reconnection" when access token expired >7 days ago
- **Dashboard API** returns `gdrive_needs_reconnect` flag for frontend to display reconnect prompts

## Files Changed
| File | Change |
|------|--------|
| `src/services/core/telegram_notification.py` | Re-raise `GoogleDriveAuthError`, add `_is_google_auth_error()` |
| `src/services/core/posting.py` | Catch auth error in 3 methods, add `_send_gdrive_auth_alert()` |
| `src/services/core/telegram_commands.py` | Add `_send_gdrive_reconnect_message()`, update `handle_next()` + `_check_gdrive_setup()` |
| `src/api/routes/onboarding/helpers.py` | Add `gdrive_needs_reconnect` to setup state |
| `CHANGELOG.md` | Updated |

## Test plan
- [x] 17 new tests covering all error paths (1370 total, all passing)
- [x] `test_telegram_notification.py`: auth error propagates, RefreshError converts, other errors still return False
- [x] `test_posting.py`: force post returns auth error code, re-raise + rollback, alert + break, alert rate-limiting
- [x] `test_telegram_commands.py`: /next reconnect message, stale token detection, recently-expired still shows connected
- [x] `test_onboarding_routes.py`: gdrive_needs_reconnect flag in dashboard API
- [x] Ruff lint + format clean
- [ ] Manual: `/next` with expired Drive token → reconnect button instead of generic error

🤖 Generated with [Claude Code](https://claude.com/claude-code)