### PR TITLE
Add Instagram story camera deep link redirect service

### DIFF
--- a/documentation/planning/instagram-deeplink-redirect.md
+++ b/documentation/planning/instagram-deeplink-redirect.md
@@ -37,48 +37,61 @@ Telegram Bot API only allows HTTPS URLs in `InlineKeyboardButton(url=...)`. Cust
 | `instagram://user?username=X` | Opens profile | iOS/Android | Working |
 | `instagram://media?id=X` | Opens specific post | iOS/Android | Working |
 
+**Additional schemes** (from research):
+
+| Scheme | Purpose | Platform | Status |
+|--------|---------|----------|--------|
+| `instagram://location?id=X` | Opens location page | iOS/Android | Working |
+| `instagram://settings` | Opens settings | iOS/Android | Working |
+| `instagram-stories://share?source_application=X` | Share to Stories (native only) | iOS | Official Meta SDK |
+
 **Important caveats**:
 - These are **undocumented** by Meta — they could break without notice
 - No official Meta documentation confirms `instagram://story-camera` specifically
 - Deep linking tools (URLgenius, JotURL) actively advertise story camera deep linking, suggesting it works
 - Community-maintained lists (GitHub, DEV Community) confirm `instagram://camera` at minimum
+- No deprecation reports found for any of these schemes as of March 2026
 
 ### Web URL Alternatives
 
 | URL | Behavior |
 |-----|----------|
 | `https://www.instagram.com/` | Opens feed (current behavior) |
-| `https://www.instagram.com/stories/create/` | May redirect to story camera on mobile (unconfirmed reliability) |
-| `https://www.instagram.com/{username}/` | Opens profile |
+| `https://www.instagram.com/stories/create/` | **Does NOT work** as a deep link — story camera is app-only with no web equivalent |
+| `https://www.instagram.com/{username}/` | Opens profile (may open in app via Universal Links on mobile) |
+
+**Key finding**: There is **no web URL that opens the story creation flow**. The story camera is exclusively an app feature. A redirect page with custom URL scheme is the only option.
+
+### Instagram Share to Stories (Official API — Not Applicable)
+
+Meta's official "Sharing to Stories" SDK (`instagram-stories://share`) requires a **native iOS/Android app** as the source. It uses `UIPasteboard` (iOS) or Android Intents to pass image data. There is **no web/JavaScript equivalent** — from a web context, we can only open the story camera, not pre-populate it with an image. This confirms the redirect page approach is the right solution for our use case.
 
 ### The Redirect Page Technique
 
-A simple static HTML page can bridge HTTPS → custom scheme:
+A static HTML page bridges HTTPS → custom scheme. **However, iOS and Android require different approaches**:
 
-```html
-<script>
-  // Try to open Instagram story camera via custom scheme
-  window.location.href = "instagram://story-camera";
+**iOS**: `instagram://story-camera` works via `window.location.href`, but if Instagram is NOT installed, Safari shows an alert: *"Safari cannot open the page because the address is invalid."* There is no way to suppress this.
 
-  // Fallback: if app not installed, redirect to Instagram web after 1.5s
-  setTimeout(() => {
-    window.location.href = "https://www.instagram.com/";
-  }, 1500);
-</script>
+**Android**: Chrome 25+ **dropped support** for direct custom scheme redirects via JavaScript. The `intent://` syntax must be used instead:
 ```
+intent://story-camera#Intent;scheme=instagram;package=com.instagram.android;S.browser_fallback_url=https%3A%2F%2Fwww.instagram.com%2F;end
+```
+The `intent://` format includes a built-in `browser_fallback_url` that Chrome uses automatically when the app is not installed — no timeout hack needed.
 
 **How it works**:
 1. User taps "Open Instagram" button in Telegram
 2. Telegram opens the HTTPS URL (our redirect page)
-3. Page immediately tries `instagram://story-camera`
-4. If Instagram app is installed → app opens to story camera
-5. If not installed → after 1.5s timeout, falls back to Instagram web
+3. Page detects platform (iOS vs Android vs Desktop)
+4. **iOS**: Redirects via `instagram://story-camera` with timeout fallback
+5. **Android**: Redirects via `intent://` URL (Chrome handles fallback natively)
+6. **Desktop**: Goes straight to `instagram.com`
 
 **Known issues**:
-- iOS Safari may show a "Open in Instagram?" confirmation dialog (expected, not a problem)
-- Android Chrome handles custom schemes transparently
+- **iOS Safari**: If app not installed, shows "invalid address" alert before fallback fires (unavoidable)
+- **iOS Safari**: The `setTimeout` fallback may still fire even after app opens (double-redirect). Mitigation: use `visibilitychange`/`pagehide` events to cancel the fallback timer
+- **Android Chrome**: `instagram://` scheme does NOT work — must use `intent://` syntax
 - If Instagram is not installed, user briefly sees the redirect page before fallback
-- Instagram's in-app browser may not support custom schemes (not relevant — we're coming from Telegram, not Instagram)
+- Coming from Telegram (not Instagram's in-app browser), so in-app browser restrictions don't apply
 
 ### GitHub Pages Viability
 
@@ -132,7 +145,7 @@ Using the `docs/` folder approach (vs `gh-pages` branch) keeps everything in the
 5. Clean, branded appearance (in case user sees the page briefly)
 6. No external dependencies (no JS libraries, no CDN)
 
-**Enhanced approach with device detection**:
+**Platform-aware approach (recommended)**:
 
 ```html
 <!DOCTYPE html>
@@ -142,33 +155,50 @@ Using the `docs/` folder approach (vs `gh-pages` branch) keeps everything in the
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Opening Instagram...</title>
   <style>
-    /* Minimal loading UI */
+    body { font-family: -apple-system, system-ui, sans-serif; text-align: center; padding: 60px 20px; }
+    .container { max-width: 400px; margin: 0 auto; }
+    .fallback { display: none; margin-top: 20px; }
+    .fallback a { color: #0095f6; text-decoration: none; font-size: 16px; }
   </style>
 </head>
 <body>
   <div class="container">
-    <p>Opening Instagram...</p>
-    <p class="fallback" style="display:none">
+    <p>Opening Instagram Stories...</p>
+    <p class="fallback">
       <a href="https://www.instagram.com/">Tap here if Instagram didn't open</a>
     </p>
   </div>
   <script>
     (function() {
-      var isMobile = /iPhone|iPad|iPod|Android/i.test(navigator.userAgent);
+      var ua = navigator.userAgent || '';
+      var isAndroid = /android/i.test(ua);
+      var isIOS = /iphone|ipad|ipod/i.test(ua);
       var fallbackUrl = "https://www.instagram.com/";
-      var deepLink = "instagram://story-camera";
+      var fallbackTimer;
 
-      if (isMobile) {
-        // Try deep link
-        window.location.href = deepLink;
+      if (isAndroid) {
+        // Android: Use intent:// syntax (required for Chrome 25+)
+        // browser_fallback_url handles app-not-installed case natively
+        window.location.href = 'intent://story-camera#Intent;scheme=instagram;package=com.instagram.android;S.browser_fallback_url=' + encodeURIComponent(fallbackUrl) + ';end';
+      } else if (isIOS) {
+        // iOS: Use custom scheme with visibility-aware fallback
+        window.location.href = "instagram://story-camera";
 
-        // Show fallback link after delay
+        // Cancel fallback if page becomes hidden (app opened successfully)
+        document.addEventListener('visibilitychange', function() {
+          if (document.hidden) { clearTimeout(fallbackTimer); }
+        });
+        document.addEventListener('pagehide', function() {
+          clearTimeout(fallbackTimer);
+        });
+
+        // Show manual fallback link after 1.5s
         setTimeout(function() {
           document.querySelector('.fallback').style.display = 'block';
         }, 1500);
 
-        // Auto-fallback after longer delay
-        setTimeout(function() {
+        // Auto-fallback after 3s if app didn't open
+        fallbackTimer = setTimeout(function() {
           window.location.href = fallbackUrl;
         }, 3000);
       } else {
@@ -180,6 +210,11 @@ Using the `docs/` folder approach (vs `gh-pages` branch) keeps everything in the
 </body>
 </html>
 ```
+
+**Key improvements over the naive approach**:
+- **Android**: Uses `intent://` syntax required by Chrome, with built-in `browser_fallback_url`
+- **iOS**: Uses `visibilitychange`/`pagehide` events to cancel the fallback timer when the app opens successfully (prevents double-redirect)
+- **Desktop**: Skips the deep link attempt entirely
 
 ### Query Parameter Support (Enhancement)
 
@@ -270,11 +305,13 @@ If the deep link redirect causes issues:
 
 | Risk | Likelihood | Impact | Mitigation |
 |------|-----------|--------|------------|
-| `instagram://story-camera` stops working | Low | Medium | Fallback to instagram.com after timeout |
+| `instagram://story-camera` stops working | Low | Medium | Fallback to instagram.com after timeout; can switch to `instagram://camera` |
 | GitHub Pages goes down | Very Low | Low | Setting-based URL allows quick swap to any host |
 | User sees redirect page briefly | Expected | Low | Clean "Opening Instagram..." UI |
 | Telegram blocks the redirect URL | Very Low | High | URL is standard HTTPS, no reason to block |
-| iOS confirmation dialog ("Open in Instagram?") | Expected | None | Standard iOS behavior, one tap to confirm |
+| iOS "invalid address" alert (app not installed) | Medium | Low | Only affects users without Instagram installed (unlikely for our use case); auto-fallback fires after alert dismissed |
+| iOS double-redirect (fallback fires after app opens) | Medium | Medium | `visibilitychange`/`pagehide` event listeners cancel fallback timer |
+| Android `instagram://` fails in Chrome | **Confirmed** | High | Use `intent://` syntax with `browser_fallback_url` (required for Chrome 25+) |
 
 ---
 
@@ -292,13 +329,25 @@ These are potential improvements but should NOT be included in the initial imple
 
 ## Sources
 
-- [Instagram URL Schemes (community list)](https://github.com/Tanaschita/ios-known-url-schemes-and-universal-links)
+### URL Schemes & Deep Linking
+- [Instagram URL Schemes - DEV Community](https://dev.to/ahandsel/instagram-url-schemes-1k6n)
+- [iOS Known URL Schemes & Universal Links (community list)](https://github.com/Tanaschita/ios-known-url-schemes-and-universal-links)
 - [Instagram Story Camera Deep Links (URLgenius)](https://app.urlgeni.us/blog/introducing-instagram-story-camera-deep-links)
-- [Instagram Deep Link Guide (JotURL)](https://joturl.com/blog/easiest-way-to-deep-link-to-instagram)
-- [Deep Link Instagram (Gist)](https://gist.github.com/juniorthiesen/d2a8162e3a51b25dd2f8cf2ba921c018)
-- [Social Deep Link Redirecting for GitHub Pages](https://github.com/Camprowe/social-deep-link-redirecting)
-- [Universal Link + URL Scheme from Instagram Stories (Medium)](https://medium.com/@cemnisan/how-to-automatically-open-your-app-from-instagram-stories-using-universal-link-and-url-scheme-71650ee90a8b)
+- [Instagram Story Camera Deep Linking (JotURL)](https://joturl.com/blog/instagram-story-camera-deep-link)
 - [Instagram Deep Link Guide (Replug)](https://blog.replug.io/instagram-deep-link/)
+
+### Redirect Technique & Fallback Handling
+- [Deep Link Instagram (Gist - redirect snippet)](https://gist.github.com/juniorthiesen/d2a8162e3a51b25dd2f8cf2ba921c018)
+- [Deep link to native app from browser with fallback (Gist)](https://gist.github.com/diachedelic/0d60233dab3dcae3215da8a4dfdcd434)
+- [Universal Link + URL Scheme from Instagram Stories (Medium, Feb 2024)](https://medium.com/@cemnisan/how-to-automatically-open-your-app-from-instagram-stories-using-universal-link-and-url-scheme-71650ee90a8b)
+- [Open Android Apps from Instagram Webview (Medium, Dec 2024)](https://medium.com/@python-javascript-php-html-css/how-to-open-android-apps-from-instagram-webview-using-javascript-7a6facc012a9)
+
+### GitHub Pages Hosting
+- [Social Deep Link Redirecting for GitHub Pages](https://github.com/Camprowe/social-deep-link-redirecting)
+- [Setup a redirect on GitHub Pages (DEV)](https://dev.to/steveblue/setup-a-redirect-on-github-pages-1ok7)
+
+### Official Meta Documentation
+- [Sharing to Stories - Meta for Developers](https://developers.facebook.com/docs/instagram-platform/sharing-to-stories/) (native SDK only, not applicable to web)
 
 ---
 


### PR DESCRIPTION
## Summary

This PR adds a planning document for implementing an Instagram story camera deep link redirect service. The service will replace the current generic Instagram feed link with a deep link that opens the Instagram story camera directly, improving the user experience for the manual posting workflow.

## Changes

- **Added**: `documentation/planning/instagram-deeplink-redirect.md` - Comprehensive planning document covering:
  - Problem statement: Current workflow requires manual navigation to story camera
  - Research findings on Instagram URL schemes and deep linking techniques
  - Proposed implementation using a GitHub Pages redirect page
  - Platform-specific handling for iOS (custom scheme with fallback) and Android (intent:// syntax)
  - Configuration approach using `INSTAGRAM_DEEPLINK_URL` setting
  - Testing plan and rollback strategy
  - Risk assessment and mitigation strategies

## Implementation Details

The document outlines a solution that:

1. **Hosts a static redirect page** on GitHub Pages (`docs/index.html`) that bridges HTTPS → custom URL schemes
2. **Uses platform-aware redirects**:
   - iOS: `instagram://story-camera` with visibility-aware fallback to prevent double-redirects
   - Android: `intent://` syntax (required for Chrome 25+) with built-in fallback URL
   - Desktop: Direct redirect to instagram.com
3. **Makes the URL configurable** via `INSTAGRAM_DEEPLINK_URL` setting in `.env` for easy rollback
4. **Requires minimal code changes** (3 lines in `telegram_utils.py` and `telegram_notification.py`)

## Next Steps

This is a planning document. Implementation will involve:
- Creating the redirect page in `docs/index.html`
- Updating configuration in `src/config/settings.py`
- Modifying Telegram button URLs in service files
- Updating tests to use the configurable setting
- Manual testing on iOS and Android devices

https://claude.ai/code/session_0181mMFYok2CKQ6wUZCLFAfW