### PR TITLE
Fix QueuePool overflow by recursively closing nested services

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **QueuePool overflow on concurrent autopost + /next** — `BaseService.close()` only closed direct `BaseRepository` attributes but did not recurse into nested `BaseService` instances, leaking their database connections. When autopost (which creates `InstagramAPIService` with 6+ nested services/repos) ran concurrently with `/next` (which creates `PostingService` with nested `TelegramService`), the pool of 20 connections was exhausted. `close()` now mirrors the recursive pattern already used by `cleanup_transactions()`, traversing nested services before closing repositories. Also added `TelegramService.close()` override to close `InteractionService`'s repo (which isn't a `BaseService` and was invisible to the traversal).
 - **Scheduler tenant scoping** — Queue items created by `create_schedule()` and `extend_schedule()` were missing `chat_settings_id`, making them invisible to the tenant-scoped processing loop (`process_pending_posts`), dashboard API, and Mini App. The scheduler ran every minute but found 0 items because `WHERE chat_settings_id = '<uuid>'` never matches NULL. Now all scheduler paths thread `chat_settings_id` from `telegram_chat_id` through to `queue_repo.create()`.
   - `_fill_schedule_slots()` now accepts and passes `chat_settings_id`
   - `create_schedule()` / `extend_schedule()` derive `chat_settings_id` via `_resolve_chat_settings_id()`

--- a/src/services/base_service.py
+++ b/src/services/base_service.py
@@ -59,15 +59,21 @@ class BaseService(ABC):
 
         Called automatically when using the service as a context manager,
         or can be called manually to release database connections.
+
+        Recursively closes nested BaseService instances (which hold their
+        own repositories) to prevent connection pool exhaustion.  This
+        mirrors the recursive pattern used in cleanup_transactions().
         """
         for attr_name in dir(self):
             try:
                 attr = getattr(self, attr_name, None)
-                if isinstance(attr, BaseRepository):
+                if isinstance(attr, BaseService) and attr is not self:
+                    attr.close()
+                elif isinstance(attr, BaseRepository):
                     attr.close()
             except Exception as e:
                 logger.warning(
-                    f"[{self.service_name}] Error closing repo {attr_name}: "
+                    f"[{self.service_name}] Error closing {attr_name}: "
                     f"{type(e).__name__}: {e}"
                 )
 

--- a/src/services/core/telegram_service.py
+++ b/src/services/core/telegram_service.py
@@ -98,6 +98,21 @@ class TelegramService(BaseService):
                 f"{type(e).__name__}: {e}"
             )
 
+    def close(self):
+        """Override to also close InteractionService's repository session.
+
+        InteractionService is not a BaseService, so the base close()
+        traversal won't find it. We explicitly close its repo here.
+        """
+        super().close()
+        try:
+            self.interaction_service.interaction_repo.close()
+        except Exception as e:
+            logger.warning(
+                f"[TelegramService] Interaction repo close failed: "
+                f"{type(e).__name__}: {e}"
+            )
+
     @property
     def is_paused(self) -> bool:
         """Check if bot posting is paused (from database)."""

--- a/tests/src/services/test_base_service.py
+++ b/tests/src/services/test_base_service.py
@@ -1,10 +1,11 @@
 """Tests for BaseService."""
 
 import pytest
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 from uuid import uuid4
 
 from src.services.base_service import BaseService
+from src.repositories.base_repository import BaseRepository
 
 
 class MockServiceForTesting(BaseService):
@@ -125,3 +126,69 @@ class TestBaseService:
         # BaseService uses module-level logger from src.utils.logger
         # Service is identified by service_name attribute
         assert mock_service.service_name == "TestService"
+
+
+@pytest.mark.unit
+class TestBaseServiceClose:
+    """Test suite for BaseService.close() recursive behavior."""
+
+    def test_close_closes_direct_repositories(self):
+        """Test that close() closes repositories directly on the service."""
+        with patch("src.services.base_service.ServiceRunRepository") as mock_repo_cls:
+            mock_repo_cls.return_value = Mock()
+            service = MockServiceForTesting()
+
+            # Add a mock repository attribute
+            mock_direct_repo = Mock(spec=BaseRepository)
+            service.some_repo = mock_direct_repo
+
+            service.close()
+
+            mock_direct_repo.close.assert_called()
+
+    def test_close_recursively_closes_nested_services(self):
+        """Test that close() closes nested BaseService instances and their repos."""
+        with patch("src.services.base_service.ServiceRunRepository") as mock_repo_cls:
+            mock_repo_cls.return_value = Mock()
+
+            outer = MockServiceForTesting()
+            inner = MockServiceForTesting()
+
+            # Give the inner service a mock repo to track
+            inner_repo = Mock(spec=BaseRepository)
+            inner.some_repo = inner_repo
+
+            # Nest inner inside outer
+            outer.nested_service = inner
+
+            outer.close()
+
+            # The inner service's repo should have been closed
+            inner_repo.close.assert_called()
+
+    def test_close_does_not_recurse_into_self(self):
+        """Test that close() skips self-references to prevent infinite recursion."""
+        with patch("src.services.base_service.ServiceRunRepository") as mock_repo_cls:
+            mock_repo_cls.return_value = Mock()
+
+            service = MockServiceForTesting()
+            # Create a self-referencing attribute (should not cause infinite loop)
+            service.self_ref = service
+
+            # Should complete without RecursionError
+            service.close()
+
+    def test_context_manager_triggers_recursive_close(self):
+        """Test that using a service as context manager triggers recursive close."""
+        with patch("src.services.base_service.ServiceRunRepository") as mock_repo_cls:
+            mock_repo_cls.return_value = Mock()
+
+            inner = MockServiceForTesting()
+            inner_repo = Mock(spec=BaseRepository)
+            inner.some_repo = inner_repo
+
+            with MockServiceForTesting() as outer:
+                outer.nested_service = inner
+
+            # After exiting context manager, inner repos should be closed
+            inner_repo.close.assert_called()


### PR DESCRIPTION
## Summary
Fixed a resource leak where `BaseService.close()` only closed direct repository attributes but failed to recursively close nested `BaseService` instances, causing database connection pool exhaustion when services with deep hierarchies (like `InstagramAPIService`) were used concurrently.

## Key Changes
- **BaseService.close()** — Enhanced to recursively close nested `BaseService` instances before closing direct repositories. Added self-reference check to prevent infinite recursion, mirroring the pattern used in `cleanup_transactions()`.
- **TelegramService.close()** — Added explicit override to close `InteractionService`'s repository since `InteractionService` is not a `BaseService` and won't be traversed by the base recursive logic.
- **Test coverage** — Added comprehensive test suite (`TestBaseServiceClose`) with four test cases covering:
  - Direct repository closure
  - Recursive nested service closure
  - Self-reference prevention
  - Context manager integration

## Implementation Details
- The recursive traversal uses `dir(self)` to find all attributes and checks `isinstance(attr, BaseService)` before recursing
- Self-references are explicitly skipped with `attr is not self` to prevent infinite loops
- Exception handling preserves existing error logging behavior with updated message to reflect both repos and services
- The fix maintains backward compatibility while preventing connection pool exhaustion in concurrent scenarios

https://claude.ai/code/session_01PgXYTdiXh6Z5smr6QXStTd