### PR TITLE
Extract callback error handling wrapper, narrow API exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Extract callback error handling wrapper** — Deduplicated the lock/keyboard-removal/error-display/cleanup pattern that was repeated in `complete_queue_action()` and `handle_rejected()` into a shared `_safe_locked_callback()` method
+- **Replace silent message edit patterns** — Error fallback message edits in `handle_resume_callback()` and `handle_reset_callback()` now use `telegram_edit_with_retry` instead of bare `try/except: pass`
+- **Narrow exception handling in API routes** — Added `OperationalError` → 503 and `ValueError` → 400 catches before the generic `Exception` → 500 in scheduler and sync endpoints (`extend-schedule`, `regenerate-schedule`, `sync-media`, `start-indexing`)
 - **Fix layer boundary violations** — API and CLI layers no longer import repositories directly, enforcing the strict separation of concerns defined in CLAUDE.md (CLI/API → Services → Repositories → Models)
   - **API layer**: Removed all 14 direct repository imports across 4 onboarding route files (`helpers.py`, `dashboard.py`, `settings.py`, `setup.py`)
   - **CLI layer**: Removed repository imports from `queue.py`, `users.py`, and `media.py` — all now call services

--- a/src/api/routes/onboarding/settings.py
+++ b/src/api/routes/onboarding/settings.py
@@ -1,6 +1,7 @@
 """Settings and schedule action endpoints for onboarding Mini App."""
 
 from fastapi import APIRouter, HTTPException
+from sqlalchemy.exc import OperationalError
 
 from src.services.core.instagram_account_service import InstagramAccountService
 from src.services.core.media_sync import MediaSyncService
@@ -136,6 +137,12 @@ async def onboarding_sync_media(request: InitRequest):
             )
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
+        except OperationalError as e:
+            logger.error(f"Media sync DB error: {e}")
+            raise HTTPException(
+                status_code=503,
+                detail="Database temporarily unavailable. Please try again.",
+            )
         except Exception as e:
             logger.error(f"Media sync from dashboard failed: {e}")
             raise HTTPException(
@@ -170,6 +177,14 @@ async def onboarding_extend_schedule(request: ScheduleActionRequest):
                 "total_slots": result.get("total_slots", 0),
                 "extended_from": result.get("extended_from"),
             }
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+        except OperationalError as e:
+            logger.error(f"Extend schedule DB error: {e}")
+            raise HTTPException(
+                status_code=503,
+                detail="Database temporarily unavailable. Please try again.",
+            )
         except Exception as e:
             logger.error(f"Failed to extend schedule: {e}")
             raise HTTPException(status_code=500, detail=str(e))
@@ -198,6 +213,14 @@ async def onboarding_regenerate_schedule(request: ScheduleActionRequest):
                 "total_slots": result.get("total_slots", 0),
                 "cleared": deleted,
             }
+        except ValueError as e:
+            raise HTTPException(status_code=400, detail=str(e))
+        except OperationalError as e:
+            logger.error(f"Regenerate schedule DB error: {e}")
+            raise HTTPException(
+                status_code=503,
+                detail="Database temporarily unavailable. Please try again.",
+            )
         except Exception as e:
             logger.error(f"Failed to regenerate schedule: {e}")
             raise HTTPException(status_code=500, detail=str(e))

--- a/src/api/routes/onboarding/setup.py
+++ b/src/api/routes/onboarding/setup.py
@@ -1,6 +1,7 @@
 """Setup wizard endpoints for onboarding Mini App."""
 
 from fastapi import APIRouter, HTTPException
+from sqlalchemy.exc import OperationalError
 
 from src.services.core.media_sync import MediaSyncService
 from src.services.core.oauth_service import OAuthService
@@ -155,6 +156,12 @@ async def onboarding_start_indexing(request: StartIndexingRequest):
             )
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))
+        except OperationalError as e:
+            logger.error(f"Media indexing DB error: {e}")
+            raise HTTPException(
+                status_code=503,
+                detail="Database temporarily unavailable. Please try again.",
+            )
         except Exception as e:
             logger.error(f"Media indexing failed during onboarding: {e}")
             raise HTTPException(

--- a/src/services/core/telegram_callbacks.py
+++ b/src/services/core/telegram_callbacks.py
@@ -35,6 +35,61 @@ class TelegramCallbackHandlers:
     def __init__(self, service: TelegramService):
         self.service = service
 
+    async def _safe_locked_callback(
+        self,
+        queue_id: str,
+        query,
+        callback_name: str,
+        error_msg: str,
+        coro,
+    ):
+        """Run a callback under an operation lock with keyboard removal and error handling.
+
+        Shared wrapper for ``complete_queue_action`` and ``handle_rejected``,
+        which both follow the same pattern: acquire lock, remove keyboard,
+        run the real work, show error on failure, and clean up.
+
+        Args:
+            queue_id: Queue item ID (used for lock key and cleanup).
+            query: Telegram callback query (for UI feedback).
+            callback_name: Human-readable name for logging.
+            error_msg: Caption to show if the callback raises.
+            coro: Awaitable that does the actual work.
+        """
+        lock = self.service.get_operation_lock(queue_id)
+        if lock.locked():
+            coro.close()  # Prevent "coroutine was never awaited" warning
+            await query.answer("⏳ Already processing this item...", show_alert=False)
+            return
+
+        async with lock:
+            try:
+                # Immediate visual feedback: remove buttons to signal action received.
+                # Best-effort — message may already be updated by a concurrent handler.
+                try:
+                    await query.edit_message_reply_markup(
+                        reply_markup=InlineKeyboardMarkup([])
+                    )
+                except Exception:
+                    logger.debug(
+                        f"Could not remove keyboard for queue item {queue_id} "
+                        f"(message may have been already updated)"
+                    )
+
+                await coro
+            except Exception as e:
+                logger.error(
+                    f"Failed to complete {callback_name} for queue {queue_id[:8]}: "
+                    f"{type(e).__name__}: {e}",
+                    exc_info=True,
+                )
+                await telegram_edit_with_retry(
+                    query.edit_message_caption,
+                    caption=error_msg,
+                )
+            finally:
+                self.service.cleanup_operation_state(queue_id)
+
     async def complete_queue_action(
         self,
         queue_id: str,
@@ -53,41 +108,15 @@ class TelegramCallbackHandlers:
 
         Uses operation locks to prevent duplicate actions from rapid button clicks.
         """
-        lock = self.service.get_operation_lock(queue_id)
-        if lock.locked():
-            await query.answer("⏳ Already processing this item...", show_alert=False)
-            return
-
-        async with lock:
-            try:
-                # Immediate visual feedback: remove buttons to signal action received
-                try:
-                    await query.edit_message_reply_markup(
-                        reply_markup=InlineKeyboardMarkup([])
-                    )
-                except Exception:
-                    logger.debug(
-                        f"Could not remove keyboard for queue item {queue_id} "
-                        f"(message may have been already updated)"
-                    )
-
-                await self._do_complete_queue_action(
-                    queue_id, user, query, status, success, caption, callback_name
-                )
-            except Exception as e:
-                logger.error(
-                    f"Failed to complete {callback_name} for queue {queue_id[:8]}: "
-                    f"{type(e).__name__}: {e}",
-                    exc_info=True,
-                )
-                try:
-                    await query.edit_message_caption(
-                        caption="❌ Error processing action. Please try again or use /next."
-                    )
-                except Exception:
-                    pass  # Message may already be gone
-            finally:
-                self.service.cleanup_operation_state(queue_id)
+        await self._safe_locked_callback(
+            queue_id,
+            query,
+            callback_name,
+            "❌ Error processing action. Please try again or use /next.",
+            self._do_complete_queue_action(
+                queue_id, user, query, status, success, caption, callback_name
+            ),
+        )
 
     @contextmanager
     def _shared_session(self):
@@ -473,37 +502,13 @@ class TelegramCallbackHandlers:
         cancel_flag = self.service.get_cancel_flag(queue_id)
         cancel_flag.set()
 
-        lock = self.service.get_operation_lock(queue_id)
-        if lock.locked():
-            await query.answer("⏳ Already processing this item...", show_alert=False)
-            return
-
-        async with lock:
-            try:
-                # Immediate visual feedback: remove buttons to signal action received
-                try:
-                    await query.edit_message_reply_markup(
-                        reply_markup=InlineKeyboardMarkup([])
-                    )
-                except Exception:
-                    logger.debug(
-                        f"Could not remove keyboard for rejected item {queue_id}"
-                    )
-
-                await self._do_handle_rejected(queue_id, user, query)
-            except Exception as e:
-                logger.error(
-                    f"Failed to reject queue {queue_id[:8]}: {type(e).__name__}: {e}",
-                    exc_info=True,
-                )
-                try:
-                    await query.edit_message_caption(
-                        caption="❌ Error rejecting item. Please try again."
-                    )
-                except Exception:
-                    pass  # Message may already be gone
-            finally:
-                self.service.cleanup_operation_state(queue_id)
+        await self._safe_locked_callback(
+            queue_id,
+            query,
+            "reject",
+            "❌ Error rejecting item. Please try again.",
+            self._do_handle_rejected(queue_id, user, query),
+        )
 
     async def _do_handle_rejected(self, queue_id: str, user, query):
         """Internal implementation of rejection (runs under lock)."""
@@ -600,13 +605,11 @@ class TelegramCallbackHandlers:
                 f"Failed to handle resume:{action}: {type(e).__name__}: {e}",
                 exc_info=True,
             )
-            try:
-                await query.edit_message_text(
-                    "❌ Error during resume. Please try /settings.",
-                    parse_mode="Markdown",
-                )
-            except Exception:
-                pass
+            await telegram_edit_with_retry(
+                query.edit_message_text,
+                "❌ Error during resume. Please try /settings.",
+                parse_mode="Markdown",
+            )
 
     async def _do_resume_callback(self, action: str, user, query):
         """Internal implementation of resume callback."""
@@ -727,10 +730,8 @@ class TelegramCallbackHandlers:
                 f"Failed to handle reset:{action}: {type(e).__name__}: {e}",
                 exc_info=True,
             )
-            try:
-                await query.edit_message_text(
-                    "❌ Error clearing queue. Please try again.",
-                    parse_mode="Markdown",
-                )
-            except Exception:
-                pass
+            await telegram_edit_with_retry(
+                query.edit_message_text,
+                "❌ Error clearing queue. Please try again.",
+                parse_mode="Markdown",
+            )


### PR DESCRIPTION
## Summary
- **Callback dedup (#4)**: Extracted `_safe_locked_callback()` from `complete_queue_action()` and `handle_rejected()` which shared identical lock → keyboard removal → error display → cleanup structure. Reduces ~80 lines of duplication to a single 30-line wrapper.
- **Silent edit patterns (#7)**: Error fallback edits in `handle_resume_callback()` and `handle_reset_callback()` now use `telegram_edit_with_retry` instead of bare `try/except: pass`
- **API exception narrowing (#8)**: Added `OperationalError` → 503 and `ValueError` → 400 catches before the generic `Exception` → 500 in 4 scheduler/sync endpoints

### Files Changed (4)
- `src/services/core/telegram_callbacks.py` — new `_safe_locked_callback()`, refactored callers
- `src/api/routes/onboarding/settings.py` — narrowed exceptions in 3 endpoints
- `src/api/routes/onboarding/setup.py` — narrowed exceptions in 1 endpoint
- `CHANGELOG.md`

## Test plan
- [x] All 1387 tests pass (0 failures, 21 skipped)
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] Verified callback lock/keyboard/error/cleanup behavior preserved
- [x] Verified coroutine cleanup on early lock-held return

🤖 Generated with [Claude Code](https://claude.com/claude-code)