### PR TITLE
Extract shared test fixtures to conftest.py files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Extract shared test fixtures** — Reduced ~360 lines of duplicated test boilerplate across 17 test files
+  - `mock_telegram_service` fixture in `tests/src/services/conftest.py` replaces 5 identical ~55-line TelegramService mock setups
+  - `mock_track_execution` context manager shared across 9 service test files (was copy-pasted in each)
+  - API test helpers (`client`, `mock_validate`, `service_ctx`, `CHAT_ID`) in `tests/src/api/conftest.py` shared across 3 API test files
 - **Extract callback error handling wrapper** — Deduplicated the lock/keyboard-removal/error-display/cleanup pattern that was repeated in `complete_queue_action()` and `handle_rejected()` into a shared `_safe_locked_callback()` method
 - **Replace silent message edit patterns** — Error fallback message edits in `handle_resume_callback()` and `handle_reset_callback()` now use `telegram_edit_with_retry` instead of bare `try/except: pass`
 - **Narrow exception handling in API routes** — Added `OperationalError` → 503 and `ValueError` → 400 catches before the generic `Exception` → 500 in scheduler and sync endpoints (`extend-schedule`, `regenerate-schedule`, `sync-media`, `start-indexing`)

--- a/tests/src/api/conftest.py
+++ b/tests/src/api/conftest.py
@@ -1,0 +1,40 @@
+"""Shared fixtures for API-layer tests."""
+
+import pytest
+from unittest.mock import Mock, patch
+
+from fastapi.testclient import TestClient
+
+from src.api.app import app
+
+VALID_USER = {"user_id": 12345, "first_name": "Chris"}
+CHAT_ID = -1001234567890
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+def mock_validate(return_value=None):
+    """Patch validate_init_data to skip HMAC validation in tests.
+
+    The default return has no chat_id, simulating DM-opened Mini Apps.
+    Pass chat_id in return_value to test group-chat initData.
+    """
+    return patch(
+        "src.api.routes.onboarding.helpers.validate_init_data",
+        return_value=return_value or VALID_USER,
+    )
+
+
+def service_ctx(mock_cls):
+    """Set up __enter__/__exit__ on mock_cls.return_value for context manager use.
+
+    Returns the mock service instance (mock_cls.return_value) configured
+    so that ``with ServiceClass() as svc:`` works in the code under test.
+    """
+    mock_svc = mock_cls.return_value
+    mock_svc.__enter__ = Mock(return_value=mock_svc)
+    mock_svc.__exit__ = Mock(return_value=False)
+    return mock_svc

--- a/tests/src/api/test_oauth_routes.py
+++ b/tests/src/api/test_oauth_routes.py
@@ -1,16 +1,6 @@
 """Unit tests for OAuth API routes (Instagram and Google Drive)."""
 
-import pytest
 from unittest.mock import AsyncMock, Mock, patch
-
-from fastapi.testclient import TestClient
-
-from src.api.app import app
-
-
-@pytest.fixture
-def client():
-    return TestClient(app)
 
 
 class TestOAuthStartEndpoint:

--- a/tests/src/api/test_onboarding_dashboard.py
+++ b/tests/src/api/test_onboarding_dashboard.py
@@ -5,25 +5,8 @@ from unittest.mock import Mock, patch
 from uuid import uuid4
 
 import pytest
-from fastapi.testclient import TestClient
 
-from src.api.app import app
-
-
-@pytest.fixture
-def client():
-    return TestClient(app)
-
-
-VALID_USER = {"user_id": 12345, "first_name": "Chris"}
-CHAT_ID = -1001234567890
-
-
-def _mock_validate(return_value=None):
-    return patch(
-        "src.api.routes.onboarding.helpers.validate_init_data",
-        return_value=return_value or VALID_USER,
-    )
+from tests.src.api.conftest import CHAT_ID, mock_validate, service_ctx
 
 
 def _mock_settings_obj(**overrides):
@@ -47,14 +30,6 @@ def _mock_settings_obj(**overrides):
     return Mock(**defaults)
 
 
-def _service_ctx(mock_cls):
-    """Set up __enter__/__exit__ on mock_cls.return_value for context manager use."""
-    mock_svc = mock_cls.return_value
-    mock_svc.__enter__ = Mock(return_value=mock_svc)
-    mock_svc.__exit__ = Mock(return_value=False)
-    return mock_svc
-
-
 # =============================================================================
 # GET /api/onboarding/queue-detail
 # =============================================================================
@@ -67,12 +42,12 @@ class TestQueueDetail:
     def test_queue_detail_returns_items(self, client):
         """Queue detail returns items with media info and day summary."""
         with (
-            _mock_validate(),
+            mock_validate(),
             patch(
                 "src.api.routes.onboarding.dashboard.DashboardService"
             ) as MockDashboard,
         ):
-            mock_svc = _service_ctx(MockDashboard)
+            mock_svc = service_ctx(MockDashboard)
             mock_svc.get_queue_detail.return_value = {
                 "items": [
                     {
@@ -132,12 +107,12 @@ class TestQueueDetail:
     def test_queue_detail_empty(self, client):
         """Queue detail with no pending items."""
         with (
-            _mock_validate(),
+            mock_validate(),
             patch(
                 "src.api.routes.onboarding.dashboard.DashboardService"
             ) as MockDashboard,
         ):
-            mock_svc = _service_ctx(MockDashboard)
+            mock_svc = service_ctx(MockDashboard)
             mock_svc.get_queue_detail.return_value = {
                 "items": [],
                 "total_pending": 0,
@@ -190,12 +165,12 @@ class TestHistoryDetail:
     def test_history_detail_returns_items(self, client):
         """History detail returns items with media info and status."""
         with (
-            _mock_validate(),
+            mock_validate(),
             patch(
                 "src.api.routes.onboarding.dashboard.DashboardService"
             ) as MockDashboard,
         ):
-            mock_svc = _service_ctx(MockDashboard)
+            mock_svc = service_ctx(MockDashboard)
             mock_svc.get_history_detail.return_value = {
                 "items": [
                     {
@@ -233,12 +208,12 @@ class TestHistoryDetail:
     def test_history_detail_empty(self, client):
         """History detail with no posts."""
         with (
-            _mock_validate(),
+            mock_validate(),
             patch(
                 "src.api.routes.onboarding.dashboard.DashboardService"
             ) as MockDashboard,
         ):
-            mock_svc = _service_ctx(MockDashboard)
+            mock_svc = service_ctx(MockDashboard)
             mock_svc.get_history_detail.return_value = {"items": []}
 
             response = client.get(
@@ -262,12 +237,12 @@ class TestMediaStats:
     def test_media_stats_returns_categories(self, client):
         """Media stats returns category breakdown sorted by count."""
         with (
-            _mock_validate(),
+            mock_validate(),
             patch(
                 "src.api.routes.onboarding.dashboard.DashboardService"
             ) as MockDashboard,
         ):
-            mock_svc = _service_ctx(MockDashboard)
+            mock_svc = service_ctx(MockDashboard)
             mock_svc.get_media_stats.return_value = {
                 "total_active": 6,
                 "categories": [
@@ -299,12 +274,12 @@ class TestMediaStats:
     def test_media_stats_empty(self, client):
         """Media stats with no active media."""
         with (
-            _mock_validate(),
+            mock_validate(),
             patch(
                 "src.api.routes.onboarding.dashboard.DashboardService"
             ) as MockDashboard,
         ):
-            mock_svc = _service_ctx(MockDashboard)
+            mock_svc = service_ctx(MockDashboard)
             mock_svc.get_media_stats.return_value = {
                 "total_active": 0,
                 "categories": [],
@@ -333,10 +308,10 @@ class TestToggleSetting:
     def test_toggle_setting_paused(self, client):
         """Toggle is_paused returns new value."""
         with (
-            _mock_validate(),
+            mock_validate(),
             patch("src.api.routes.onboarding.settings.SettingsService") as MockService,
         ):
-            mock_svc = _service_ctx(MockService)
+            mock_svc = service_ctx(MockService)
             mock_svc.toggle_setting.return_value = True
 
             response = client.post(
@@ -356,10 +331,10 @@ class TestToggleSetting:
     def test_toggle_setting_dry_run(self, client):
         """Toggle dry_run_mode returns new value."""
         with (
-            _mock_validate(),
+            mock_validate(),
             patch("src.api.routes.onboarding.settings.SettingsService") as MockService,
         ):
-            mock_svc = _service_ctx(MockService)
+            mock_svc = service_ctx(MockService)
             mock_svc.toggle_setting.return_value = False
 
             response = client.post(
@@ -379,10 +354,10 @@ class TestToggleSetting:
     def test_toggle_setting_instagram_api(self, client):
         """Toggle enable_instagram_api returns new value."""
         with (
-            _mock_validate(),
+            mock_validate(),
             patch("src.api.routes.onboarding.settings.SettingsService") as MockService,
         ):
-            mock_svc = _service_ctx(MockService)
+            mock_svc = service_ctx(MockService)
             mock_svc.toggle_setting.return_value = True
 
             response = client.post(
@@ -400,10 +375,10 @@ class TestToggleSetting:
     def test_toggle_setting_verbose(self, client):
         """Toggle show_verbose_notifications returns new value."""
         with (
-            _mock_validate(),
+            mock_validate(),
             patch("src.api.routes.onboarding.settings.SettingsService") as MockService,
         ):
-            mock_svc = _service_ctx(MockService)
+            mock_svc = service_ctx(MockService)
             mock_svc.toggle_setting.return_value = False
 
             response = client.post(
@@ -421,10 +396,10 @@ class TestToggleSetting:
     def test_toggle_setting_media_sync(self, client):
         """Toggle media_sync_enabled returns new value."""
         with (
-            _mock_validate(),
+            mock_validate(),
             patch("src.api.routes.onboarding.settings.SettingsService") as MockService,
         ):
-            mock_svc = _service_ctx(MockService)
+            mock_svc = service_ctx(MockService)
             mock_svc.toggle_setting.return_value = True
 
             response = client.post(
@@ -441,7 +416,7 @@ class TestToggleSetting:
 
     def test_toggle_setting_disallowed(self, client):
         """Cannot toggle settings not in the allowed list."""
-        with _mock_validate():
+        with mock_validate():
             response = client.post(
                 "/api/onboarding/toggle-setting",
                 json={
@@ -490,10 +465,10 @@ class TestUpdateSetting:
     def test_update_posts_per_day(self, client):
         """Update posts_per_day returns new value."""
         with (
-            _mock_validate(),
+            mock_validate(),
             patch("src.api.routes.onboarding.settings.SettingsService") as MockService,
         ):
-            mock_svc = _service_ctx(MockService)
+            mock_svc = service_ctx(MockService)
 
             response = client.post(
                 "/api/onboarding/update-setting",
@@ -514,10 +489,10 @@ class TestUpdateSetting:
     def test_update_posting_hours_start(self, client):
         """Update posting_hours_start returns new value."""
         with (
-            _mock_validate(),
+            mock_validate(),
             patch("src.api.routes.onboarding.settings.SettingsService") as MockService,
         ):
-            _service_ctx(MockService)
+            service_ctx(MockService)
 
             response = client.post(
                 "/api/onboarding/update-setting",
@@ -535,10 +510,10 @@ class TestUpdateSetting:
     def test_update_posting_hours_end(self, client):
         """Update posting_hours_end returns new value."""
         with (
-            _mock_validate(),
+            mock_validate(),
             patch("src.api.routes.onboarding.settings.SettingsService") as MockService,
         ):
-            _service_ctx(MockService)
+            service_ctx(MockService)
 
             response = client.post(
                 "/api/onboarding/update-setting",
@@ -555,7 +530,7 @@ class TestUpdateSetting:
 
     def test_update_setting_disallowed(self, client):
         """Cannot update settings not in the allowed list."""
-        with _mock_validate():
+        with mock_validate():
             response = client.post(
                 "/api/onboarding/update-setting",
                 json={
@@ -571,7 +546,7 @@ class TestUpdateSetting:
 
     def test_update_setting_validation_error(self, client):
         """Update rejects invalid values via Pydantic validation."""
-        with _mock_validate():
+        with mock_validate():
             response = client.post(
                 "/api/onboarding/update-setting",
                 json={
@@ -621,12 +596,12 @@ class TestExtendSchedule:
     def test_extend_schedule(self, client):
         """Extend schedule calls scheduler and returns result."""
         with (
-            _mock_validate(),
+            mock_validate(),
             patch(
                 "src.api.routes.onboarding.settings.SchedulerService"
             ) as MockScheduler,
         ):
-            mock_svc = _service_ctx(MockScheduler)
+            mock_svc = service_ctx(MockScheduler)
             mock_svc.extend_schedule.return_value = {
                 "scheduled": 21,
                 "skipped": 0,
@@ -652,12 +627,12 @@ class TestExtendSchedule:
     def test_extend_schedule_default_days(self, client):
         """Extend schedule defaults to 7 days."""
         with (
-            _mock_validate(),
+            mock_validate(),
             patch(
                 "src.api.routes.onboarding.settings.SchedulerService"
             ) as MockScheduler,
         ):
-            mock_svc = _service_ctx(MockScheduler)
+            mock_svc = service_ctx(MockScheduler)
             mock_svc.extend_schedule.return_value = {
                 "scheduled": 21,
                 "skipped": 0,
@@ -687,12 +662,12 @@ class TestRegenerateSchedule:
     def test_regenerate_schedule(self, client):
         """Regenerate clears pending items and creates new schedule."""
         with (
-            _mock_validate(),
+            mock_validate(),
             patch(
                 "src.api.routes.onboarding.settings.SchedulerService"
             ) as MockScheduler,
         ):
-            mock_svc = _service_ctx(MockScheduler)
+            mock_svc = service_ctx(MockScheduler)
             mock_svc.clear_pending_queue.return_value = 42
             mock_svc.create_schedule.return_value = {
                 "scheduled": 21,
@@ -786,12 +761,12 @@ class TestEnhancedSetupState:
         }
 
         with (
-            _mock_validate(),
+            mock_validate(),
             patch(
                 "src.api.routes.onboarding.helpers.SetupStateService"
             ) as MockSetupState,
         ):
-            mock_svc = _service_ctx(MockSetupState)
+            mock_svc = service_ctx(MockSetupState)
             mock_svc.get_setup_state.return_value = setup_state
 
             response = client.post(
@@ -834,12 +809,12 @@ class TestEnhancedSetupState:
         }
 
         with (
-            _mock_validate(),
+            mock_validate(),
             patch(
                 "src.api.routes.onboarding.helpers.SetupStateService"
             ) as MockSetupState,
         ):
-            mock_svc = _service_ctx(MockSetupState)
+            mock_svc = service_ctx(MockSetupState)
             mock_svc.get_setup_state.return_value = setup_state
 
             response = client.post(
@@ -884,12 +859,12 @@ class TestEnhancedSetupState:
         }
 
         with (
-            _mock_validate(),
+            mock_validate(),
             patch(
                 "src.api.routes.onboarding.helpers.SetupStateService"
             ) as MockSetupState,
         ):
-            mock_svc = _service_ctx(MockSetupState)
+            mock_svc = service_ctx(MockSetupState)
             mock_svc.get_setup_state.return_value = setup_state
 
             response = client.post(
@@ -956,12 +931,12 @@ class TestSystemStatus:
     def test_system_status_healthy(self, client):
         """System status returns health checks when all healthy."""
         with (
-            _mock_validate(),
+            mock_validate(),
             patch(
                 "src.api.routes.onboarding.dashboard.HealthCheckService"
             ) as MockHealthService,
         ):
-            mock_svc = _service_ctx(MockHealthService)
+            mock_svc = service_ctx(MockHealthService)
             mock_svc.check_all.return_value = _mock_health_checks()
 
             response = client.get(
@@ -985,12 +960,12 @@ class TestSystemStatus:
         )
 
         with (
-            _mock_validate(),
+            mock_validate(),
             patch(
                 "src.api.routes.onboarding.dashboard.HealthCheckService"
             ) as MockHealthService,
         ):
-            mock_svc = _service_ctx(MockHealthService)
+            mock_svc = service_ctx(MockHealthService)
             mock_svc.check_all.return_value = health_data
 
             response = client.get(
@@ -1044,7 +1019,7 @@ class TestSyncMedia:
         mock_result.total_processed = 108
 
         with (
-            _mock_validate(),
+            mock_validate(),
             patch(
                 "src.api.routes.onboarding.settings.SettingsService"
             ) as MockSettingsService,
@@ -1052,12 +1027,12 @@ class TestSyncMedia:
                 "src.api.routes.onboarding.settings.MediaSyncService"
             ) as MockSyncService,
         ):
-            mock_settings_svc = _service_ctx(MockSettingsService)
+            mock_settings_svc = service_ctx(MockSettingsService)
             mock_settings_svc.get_media_source_config.return_value = (
                 "google_drive",
                 "folder123",
             )
-            mock_sync_svc = _service_ctx(MockSyncService)
+            mock_sync_svc = service_ctx(MockSyncService)
             mock_sync_svc.sync.return_value = mock_result
 
             response = client.post(
@@ -1083,12 +1058,12 @@ class TestSyncMedia:
     def test_sync_media_no_folder_configured(self, client):
         """Sync media returns 400 when no media folder is configured."""
         with (
-            _mock_validate(),
+            mock_validate(),
             patch(
                 "src.api.routes.onboarding.settings.SettingsService"
             ) as MockSettingsService,
         ):
-            mock_settings_svc = _service_ctx(MockSettingsService)
+            mock_settings_svc = service_ctx(MockSettingsService)
             mock_settings_svc.get_media_source_config.return_value = (None, None)
 
             response = client.post(
@@ -1102,7 +1077,7 @@ class TestSyncMedia:
     def test_sync_media_service_error(self, client):
         """Sync media returns 500 when sync service fails."""
         with (
-            _mock_validate(),
+            mock_validate(),
             patch(
                 "src.api.routes.onboarding.settings.SettingsService"
             ) as MockSettingsService,
@@ -1110,12 +1085,12 @@ class TestSyncMedia:
                 "src.api.routes.onboarding.settings.MediaSyncService"
             ) as MockSyncService,
         ):
-            mock_settings_svc = _service_ctx(MockSettingsService)
+            mock_settings_svc = service_ctx(MockSettingsService)
             mock_settings_svc.get_media_source_config.return_value = (
                 "google_drive",
                 "folder123",
             )
-            mock_sync_svc = _service_ctx(MockSyncService)
+            mock_sync_svc = service_ctx(MockSyncService)
             mock_sync_svc.sync.side_effect = RuntimeError("Drive error")
 
             response = client.post(
@@ -1175,7 +1150,7 @@ class TestAccounts:
         )
 
         with (
-            _mock_validate(),
+            mock_validate(),
             patch(
                 "src.api.routes.onboarding.dashboard.InstagramAccountService"
             ) as MockIGService,
@@ -1183,9 +1158,9 @@ class TestAccounts:
                 "src.api.routes.onboarding.dashboard.SettingsService"
             ) as MockSettingsService,
         ):
-            mock_ig_svc = _service_ctx(MockIGService)
+            mock_ig_svc = service_ctx(MockIGService)
             mock_ig_svc.list_accounts.return_value = [acct_1, acct_2]
-            mock_settings_svc = _service_ctx(MockSettingsService)
+            mock_settings_svc = service_ctx(MockSettingsService)
             mock_settings_svc.get_settings.return_value = mock_settings
 
             response = client.get(
@@ -1207,7 +1182,7 @@ class TestAccounts:
         mock_settings = _mock_settings_obj(active_instagram_account_id=None)
 
         with (
-            _mock_validate(),
+            mock_validate(),
             patch(
                 "src.api.routes.onboarding.dashboard.InstagramAccountService"
             ) as MockIGService,
@@ -1215,9 +1190,9 @@ class TestAccounts:
                 "src.api.routes.onboarding.dashboard.SettingsService"
             ) as MockSettingsService,
         ):
-            mock_ig_svc = _service_ctx(MockIGService)
+            mock_ig_svc = service_ctx(MockIGService)
             mock_ig_svc.list_accounts.return_value = []
-            mock_settings_svc = _service_ctx(MockSettingsService)
+            mock_settings_svc = service_ctx(MockSettingsService)
             mock_settings_svc.get_settings.return_value = mock_settings
 
             response = client.get(
@@ -1264,12 +1239,12 @@ class TestSwitchAccount:
         acct = _mock_account("Side Project", "sideproject")
 
         with (
-            _mock_validate(),
+            mock_validate(),
             patch(
                 "src.api.routes.onboarding.settings.InstagramAccountService"
             ) as MockIGService,
         ):
-            mock_svc = _service_ctx(MockIGService)
+            mock_svc = service_ctx(MockIGService)
             mock_svc.switch_account.return_value = acct
 
             response = client.post(
@@ -1293,12 +1268,12 @@ class TestSwitchAccount:
     def test_switch_account_not_found(self, client):
         """Switch account returns 400 for unknown account."""
         with (
-            _mock_validate(),
+            mock_validate(),
             patch(
                 "src.api.routes.onboarding.settings.InstagramAccountService"
             ) as MockIGService,
         ):
-            mock_svc = _service_ctx(MockIGService)
+            mock_svc = service_ctx(MockIGService)
             mock_svc.switch_account.side_effect = ValueError("Account not found")
 
             response = client.post(
@@ -1351,12 +1326,12 @@ class TestRemoveAccount:
         acct = _mock_account("Old Account", "oldaccount")
 
         with (
-            _mock_validate(),
+            mock_validate(),
             patch(
                 "src.api.routes.onboarding.settings.InstagramAccountService"
             ) as MockIGService,
         ):
-            mock_svc = _service_ctx(MockIGService)
+            mock_svc = service_ctx(MockIGService)
             mock_svc.deactivate_account.return_value = acct
 
             response = client.post(
@@ -1379,12 +1354,12 @@ class TestRemoveAccount:
     def test_remove_account_not_found(self, client):
         """Remove account returns 400 for unknown account."""
         with (
-            _mock_validate(),
+            mock_validate(),
             patch(
                 "src.api.routes.onboarding.settings.InstagramAccountService"
             ) as MockIGService,
         ):
-            mock_svc = _service_ctx(MockIGService)
+            mock_svc = service_ctx(MockIGService)
             mock_svc.deactivate_account.side_effect = ValueError("Account not found")
 
             response = client.post(

--- a/tests/src/api/test_onboarding_routes.py
+++ b/tests/src/api/test_onboarding_routes.py
@@ -3,33 +3,7 @@
 import pytest
 from unittest.mock import Mock, patch
 
-from fastapi.testclient import TestClient
-
-from src.api.app import app
-
-
-@pytest.fixture
-def client():
-    return TestClient(app)
-
-
-VALID_USER = {"user_id": 12345, "first_name": "Chris"}
-CHAT_ID = -1001234567890
-
-
-def _mock_validate(return_value=None):
-    """Patch validate_init_data to skip HMAC validation in tests."""
-    return patch(
-        "src.api.routes.onboarding.helpers.validate_init_data",
-        return_value=return_value or VALID_USER,
-    )
-
-
-def _ctx(mock_class):
-    """Configure context manager support on a mock service class."""
-    mock_class.return_value.__enter__ = Mock(return_value=mock_class.return_value)
-    mock_class.return_value.__exit__ = Mock(return_value=False)
-    return mock_class.return_value
+from tests.src.api.conftest import CHAT_ID, mock_validate, service_ctx
 
 
 def _default_setup_state(**overrides):
@@ -89,13 +63,13 @@ class TestOnboardingInit:
     def test_init_returns_setup_state(self, client):
         """Valid initData returns chat_id, user, and setup_state."""
         with (
-            _mock_validate(),
+            mock_validate(),
             _mock_setup_state(),
             patch(
                 "src.api.routes.onboarding.setup.SettingsService"
             ) as MockSettingsService,
         ):
-            _ctx(MockSettingsService)
+            service_ctx(MockSettingsService)
             response = client.post(
                 "/api/onboarding/init",
                 json={"init_data": "test", "chat_id": CHAT_ID},
@@ -112,7 +86,7 @@ class TestOnboardingInit:
     def test_init_shows_connected_instagram(self, client):
         """When Instagram is connected, setup_state reflects it."""
         with (
-            _mock_validate(),
+            mock_validate(),
             _mock_setup_state(
                 instagram_connected=True,
                 instagram_username="storyline_ai",
@@ -121,7 +95,7 @@ class TestOnboardingInit:
                 "src.api.routes.onboarding.setup.SettingsService"
             ) as MockSettingsService,
         ):
-            _ctx(MockSettingsService)
+            service_ctx(MockSettingsService)
             response = client.post(
                 "/api/onboarding/init",
                 json={"init_data": "test", "chat_id": CHAT_ID},
@@ -134,7 +108,7 @@ class TestOnboardingInit:
     def test_init_shows_connected_gdrive(self, client):
         """When Google Drive is connected, setup_state reflects it."""
         with (
-            _mock_validate(),
+            mock_validate(),
             _mock_setup_state(
                 gdrive_connected=True,
                 gdrive_email="user@gmail.com",
@@ -144,7 +118,7 @@ class TestOnboardingInit:
                 "src.api.routes.onboarding.setup.SettingsService"
             ) as MockSettingsService,
         ):
-            _ctx(MockSettingsService)
+            service_ctx(MockSettingsService)
             response = client.post(
                 "/api/onboarding/init",
                 json={"init_data": "test", "chat_id": CHAT_ID},
@@ -158,7 +132,7 @@ class TestOnboardingInit:
     def test_init_shows_gdrive_needs_reconnect(self, client):
         """When Google Drive token is stale (expired >7 days), flag is set."""
         with (
-            _mock_validate(),
+            mock_validate(),
             _mock_setup_state(
                 gdrive_connected=True,
                 gdrive_needs_reconnect=True,
@@ -167,7 +141,7 @@ class TestOnboardingInit:
                 "src.api.routes.onboarding.setup.SettingsService"
             ) as MockSettingsService,
         ):
-            _ctx(MockSettingsService)
+            service_ctx(MockSettingsService)
             response = client.post(
                 "/api/onboarding/init",
                 json={"init_data": "test", "chat_id": CHAT_ID},
@@ -194,7 +168,7 @@ class TestOnboardingInit:
     def test_init_includes_media_folder_fields(self, client):
         """Init response contains media_folder_configured, media_indexed, media_count."""
         with (
-            _mock_validate(),
+            mock_validate(),
             _mock_setup_state(
                 media_folder_configured=True,
                 media_folder_id="abc123",
@@ -206,7 +180,7 @@ class TestOnboardingInit:
                 "src.api.routes.onboarding.setup.SettingsService"
             ) as MockSettingsService,
         ):
-            _ctx(MockSettingsService)
+            service_ctx(MockSettingsService)
             response = client.post(
                 "/api/onboarding/init",
                 json={"init_data": "test", "chat_id": CHAT_ID},
@@ -222,13 +196,13 @@ class TestOnboardingInit:
     def test_init_sets_welcome_step_on_first_access(self, client):
         """Init sets onboarding_step='welcome' when not yet started."""
         with (
-            _mock_validate(),
+            mock_validate(),
             _mock_setup_state(onboarding_completed=False, onboarding_step=None),
             patch(
                 "src.api.routes.onboarding.setup.SettingsService"
             ) as MockSettingsService,
         ):
-            svc = _ctx(MockSettingsService)
+            svc = service_ctx(MockSettingsService)
             response = client.post(
                 "/api/onboarding/init",
                 json={"init_data": "test", "chat_id": CHAT_ID},
@@ -242,7 +216,7 @@ class TestOnboardingInit:
     def test_init_returns_dashboard_fields(self, client):
         """Init response includes queue_count, last_post_at, is_paused, dry_run_mode."""
         with (
-            _mock_validate(),
+            mock_validate(),
             _mock_setup_state(
                 onboarding_completed=True,
                 is_paused=False,
@@ -254,7 +228,7 @@ class TestOnboardingInit:
                 "src.api.routes.onboarding.setup.SettingsService"
             ) as MockSettingsService,
         ):
-            _ctx(MockSettingsService)
+            service_ctx(MockSettingsService)
             response = client.post(
                 "/api/onboarding/init",
                 json={"init_data": "test", "chat_id": CHAT_ID},
@@ -270,7 +244,7 @@ class TestOnboardingInit:
     def test_init_dashboard_fields_default_on_error(self, client):
         """Queue/history errors don't break the init response (handled in service)."""
         with (
-            _mock_validate(),
+            mock_validate(),
             _mock_setup_state(
                 onboarding_completed=True,
                 is_paused=False,
@@ -282,7 +256,7 @@ class TestOnboardingInit:
                 "src.api.routes.onboarding.setup.SettingsService"
             ) as MockSettingsService,
         ):
-            _ctx(MockSettingsService)
+            service_ctx(MockSettingsService)
             response = client.post(
                 "/api/onboarding/init",
                 json={"init_data": "test", "chat_id": CHAT_ID},
@@ -306,10 +280,10 @@ class TestOnboardingOAuthUrl:
     def test_instagram_returns_auth_url(self, client):
         """Instagram provider returns OAuth authorization URL."""
         with (
-            _mock_validate(),
+            mock_validate(),
             patch("src.api.routes.onboarding.setup.OAuthService") as MockOAuth,
         ):
-            svc = _ctx(MockOAuth)
+            svc = service_ctx(MockOAuth)
             svc.generate_authorization_url.return_value = (
                 "https://facebook.com/dialog/oauth?client_id=123"
             )
@@ -323,12 +297,12 @@ class TestOnboardingOAuthUrl:
     def test_gdrive_returns_auth_url(self, client):
         """Google Drive provider returns OAuth authorization URL."""
         with (
-            _mock_validate(),
+            mock_validate(),
             patch(
                 "src.api.routes.onboarding.setup.GoogleDriveOAuthService"
             ) as MockGDrive,
         ):
-            svc = _ctx(MockGDrive)
+            svc = service_ctx(MockGDrive)
             svc.generate_authorization_url.return_value = (
                 "https://accounts.google.com/o/oauth2/auth?client_id=123"
             )
@@ -342,7 +316,7 @@ class TestOnboardingOAuthUrl:
 
     def test_unknown_provider_returns_400(self, client):
         """Unknown provider returns 400."""
-        with _mock_validate():
+        with mock_validate():
             response = client.get(
                 f"/api/onboarding/oauth-url/twitter?init_data=test&chat_id={CHAT_ID}"
             )
@@ -381,15 +355,15 @@ class TestOnboardingMediaFolder:
         ]
 
         with (
-            _mock_validate(),
+            mock_validate(),
             patch("src.api.routes.onboarding.setup.GoogleDriveService") as MockGDrive,
             patch("src.api.routes.onboarding.setup.SettingsService") as MockSettings,
         ):
-            gdrive_svc = _ctx(MockGDrive)
+            gdrive_svc = service_ctx(MockGDrive)
             mock_provider = Mock()
             mock_provider.list_files.return_value = mock_files
             gdrive_svc.get_provider_for_chat.return_value = mock_provider
-            settings_svc = _ctx(MockSettings)
+            settings_svc = service_ctx(MockSettings)
 
             response = client.post(
                 "/api/onboarding/media-folder",
@@ -419,7 +393,7 @@ class TestOnboardingMediaFolder:
 
     def test_invalid_folder_url_returns_400(self, client):
         """Non-Drive URL returns 400."""
-        with _mock_validate():
+        with mock_validate():
             response = client.post(
                 "/api/onboarding/media-folder",
                 json={
@@ -435,10 +409,10 @@ class TestOnboardingMediaFolder:
     def test_inaccessible_folder_returns_400(self, client):
         """Folder that can't be accessed returns 400."""
         with (
-            _mock_validate(),
+            mock_validate(),
             patch("src.api.routes.onboarding.setup.GoogleDriveService") as MockGDrive,
         ):
-            svc = _ctx(MockGDrive)
+            svc = service_ctx(MockGDrive)
             svc.get_provider_for_chat.side_effect = Exception("No credentials")
 
             response = client.post(
@@ -470,18 +444,18 @@ class TestOnboardingStartIndexing:
         )
 
         with (
-            _mock_validate(),
+            mock_validate(),
             patch("src.api.routes.onboarding.setup.SettingsService") as MockSettings,
             patch("src.api.routes.onboarding.setup.MediaSyncService") as MockSync,
         ):
             # First SettingsService context: get_media_source_config
-            settings_svc = _ctx(MockSettings)
+            settings_svc = service_ctx(MockSettings)
             settings_svc.get_media_source_config.return_value = (
                 "google_drive",
                 "abc123",
             )
             # Second SettingsService context reuses same mock
-            sync_svc = _ctx(MockSync)
+            sync_svc = service_ctx(MockSync)
             sync_svc.sync.return_value = mock_sync_result
 
             response = client.post(
@@ -499,10 +473,10 @@ class TestOnboardingStartIndexing:
     def test_indexing_without_folder_returns_400(self, client):
         """Start indexing without a configured folder returns 400."""
         with (
-            _mock_validate(),
+            mock_validate(),
             patch("src.api.routes.onboarding.setup.SettingsService") as MockSettings,
         ):
-            svc = _ctx(MockSettings)
+            svc = service_ctx(MockSettings)
             svc.get_media_source_config.return_value = ("local", None)
 
             response = client.post(
@@ -516,13 +490,13 @@ class TestOnboardingStartIndexing:
     def test_indexing_sync_error_returns_500(self, client):
         """MediaSyncService failure returns 500 with user-friendly message."""
         with (
-            _mock_validate(),
+            mock_validate(),
             patch("src.api.routes.onboarding.setup.SettingsService") as MockSettings,
             patch("src.api.routes.onboarding.setup.MediaSyncService") as MockSync,
         ):
-            svc = _ctx(MockSettings)
+            svc = service_ctx(MockSettings)
             svc.get_media_source_config.return_value = ("google_drive", "abc123")
-            sync_svc = _ctx(MockSync)
+            sync_svc = service_ctx(MockSync)
             sync_svc.sync.side_effect = Exception("Connection timeout")
 
             response = client.post(
@@ -536,13 +510,13 @@ class TestOnboardingStartIndexing:
     def test_indexing_value_error_returns_400(self, client):
         """MediaSyncService ValueError (e.g., unconfigured provider) returns 400."""
         with (
-            _mock_validate(),
+            mock_validate(),
             patch("src.api.routes.onboarding.setup.SettingsService") as MockSettings,
             patch("src.api.routes.onboarding.setup.MediaSyncService") as MockSync,
         ):
-            svc = _ctx(MockSettings)
+            svc = service_ctx(MockSettings)
             svc.get_media_source_config.return_value = ("google_drive", "abc123")
-            sync_svc = _ctx(MockSync)
+            sync_svc = service_ctx(MockSync)
             sync_svc.sync.side_effect = ValueError("Provider not configured")
 
             response = client.post(
@@ -565,10 +539,10 @@ class TestOnboardingSchedule:
     def test_schedule_saves_config(self, client):
         """Valid schedule config saves to settings."""
         with (
-            _mock_validate(),
+            mock_validate(),
             patch("src.api.routes.onboarding.setup.SettingsService") as MockSettings,
         ):
-            svc = _ctx(MockSettings)
+            svc = service_ctx(MockSettings)
 
             response = client.post(
                 "/api/onboarding/schedule",
@@ -592,10 +566,10 @@ class TestOnboardingSchedule:
     def test_schedule_service_validation_error_returns_400(self, client):
         """Service-level validation error returns 400."""
         with (
-            _mock_validate(),
+            mock_validate(),
             patch("src.api.routes.onboarding.setup.SettingsService") as MockSettings,
         ):
-            svc = _ctx(MockSettings)
+            svc = service_ctx(MockSettings)
             svc.update_setting.side_effect = ValueError("Invalid setting value")
 
             response = client.post(
@@ -624,13 +598,13 @@ class TestOnboardingComplete:
     def test_complete_marks_onboarding_done(self, client):
         """Complete endpoint marks onboarding as finished."""
         with (
-            _mock_validate(),
+            mock_validate(),
             patch(
                 "src.api.routes.onboarding.setup.SettingsService"
             ) as MockSettingsService,
             _mock_setup_state(),
         ):
-            svc = _ctx(MockSettingsService)
+            svc = service_ctx(MockSettingsService)
             response = client.post(
                 "/api/onboarding/complete",
                 json={
@@ -649,15 +623,15 @@ class TestOnboardingComplete:
     def test_complete_creates_schedule(self, client):
         """Complete with create_schedule=true calls SchedulerService."""
         with (
-            _mock_validate(),
+            mock_validate(),
             patch(
                 "src.api.routes.onboarding.setup.SettingsService"
             ) as MockSettingsService,
             _mock_setup_state(),
             patch("src.api.routes.onboarding.setup.SchedulerService") as MockScheduler,
         ):
-            _ctx(MockSettingsService)
-            sched_svc = _ctx(MockScheduler)
+            service_ctx(MockSettingsService)
+            sched_svc = service_ctx(MockScheduler)
             sched_svc.create_schedule.return_value = {
                 "scheduled": 21,
                 "total_slots": 21,
@@ -685,15 +659,15 @@ class TestOnboardingComplete:
     def test_complete_handles_schedule_error(self, client):
         """Schedule creation error doesn't fail the whole request."""
         with (
-            _mock_validate(),
+            mock_validate(),
             patch(
                 "src.api.routes.onboarding.setup.SettingsService"
             ) as MockSettingsService,
             _mock_setup_state(),
             patch("src.api.routes.onboarding.setup.SchedulerService") as MockScheduler,
         ):
-            _ctx(MockSettingsService)
-            sched_svc = _ctx(MockScheduler)
+            service_ctx(MockSettingsService)
+            sched_svc = service_ctx(MockScheduler)
             sched_svc.create_schedule.side_effect = Exception("No media items")
 
             response = client.post(
@@ -714,13 +688,13 @@ class TestOnboardingComplete:
     def test_complete_enables_instagram_when_connected(self, client):
         """When Instagram is connected, complete enables enable_instagram_api."""
         with (
-            _mock_validate(),
+            mock_validate(),
             patch(
                 "src.api.routes.onboarding.setup.SettingsService"
             ) as MockSettingsService,
             _mock_setup_state(instagram_connected=True),
         ):
-            svc = _ctx(MockSettingsService)
+            svc = service_ctx(MockSettingsService)
             response = client.post(
                 "/api/onboarding/complete",
                 json={
@@ -738,7 +712,7 @@ class TestOnboardingComplete:
     def test_complete_does_not_disable_dry_run(self, client):
         """Complete NEVER changes dry_run_mode."""
         with (
-            _mock_validate(),
+            mock_validate(),
             patch(
                 "src.api.routes.onboarding.setup.SettingsService"
             ) as MockSettingsService,
@@ -747,7 +721,7 @@ class TestOnboardingComplete:
                 media_folder_configured=True,
             ),
         ):
-            svc = _ctx(MockSettingsService)
+            svc = service_ctx(MockSettingsService)
             client.post(
                 "/api/onboarding/complete",
                 json={
@@ -778,7 +752,7 @@ class TestOnboardingChatIdVerification:
             "first_name": "Chris",
             "chat_id": 999,
         }
-        with _mock_validate(return_value=user_with_chat):
+        with mock_validate(return_value=user_with_chat):
             response = client.post(
                 "/api/onboarding/init",
                 json={"init_data": "test", "chat_id": CHAT_ID},
@@ -795,13 +769,13 @@ class TestOnboardingChatIdVerification:
             "chat_id": CHAT_ID,
         }
         with (
-            _mock_validate(return_value=user_with_chat),
+            mock_validate(return_value=user_with_chat),
             _mock_setup_state(),
             patch(
                 "src.api.routes.onboarding.setup.SettingsService"
             ) as MockSettingsService,
         ):
-            _ctx(MockSettingsService)
+            service_ctx(MockSettingsService)
             response = client.post(
                 "/api/onboarding/init",
                 json={"init_data": "test", "chat_id": CHAT_ID},
@@ -812,13 +786,13 @@ class TestOnboardingChatIdVerification:
     def test_no_chat_id_in_initdata_allows_any(self, client):
         """If initData has no chat_id (DM context), request proceeds."""
         with (
-            _mock_validate(),
+            mock_validate(),
             _mock_setup_state(),
             patch(
                 "src.api.routes.onboarding.setup.SettingsService"
             ) as MockSettingsService,
         ):
-            _ctx(MockSettingsService)
+            service_ctx(MockSettingsService)
             response = client.post(
                 "/api/onboarding/init",
                 json={"init_data": "test", "chat_id": CHAT_ID},
@@ -838,7 +812,7 @@ class TestOnboardingInputValidation:
 
     def test_posts_per_day_zero_rejected(self, client):
         """posts_per_day=0 is rejected by Pydantic validation."""
-        with _mock_validate():
+        with mock_validate():
             response = client.post(
                 "/api/onboarding/schedule",
                 json={
@@ -854,7 +828,7 @@ class TestOnboardingInputValidation:
 
     def test_posts_per_day_negative_rejected(self, client):
         """Negative posts_per_day is rejected."""
-        with _mock_validate():
+        with mock_validate():
             response = client.post(
                 "/api/onboarding/schedule",
                 json={
@@ -870,7 +844,7 @@ class TestOnboardingInputValidation:
 
     def test_posting_hours_out_of_range_rejected(self, client):
         """posting_hours_start=25 is rejected."""
-        with _mock_validate():
+        with mock_validate():
             response = client.post(
                 "/api/onboarding/schedule",
                 json={
@@ -886,7 +860,7 @@ class TestOnboardingInputValidation:
 
     def test_schedule_days_over_max_rejected(self, client):
         """schedule_days=100 is rejected on complete endpoint."""
-        with _mock_validate():
+        with mock_validate():
             response = client.post(
                 "/api/onboarding/complete",
                 json={

--- a/tests/src/services/conftest.py
+++ b/tests/src/services/conftest.py
@@ -1,0 +1,81 @@
+"""Shared fixtures for service-layer tests."""
+
+import pytest
+from contextlib import contextmanager
+from unittest.mock import patch
+
+from src.services.core.telegram_service import TelegramService
+
+
+@contextmanager
+def mock_track_execution(*args, **kwargs):
+    """Mock context manager for BaseService.track_execution.
+
+    Yields a fake run_id. Use by assigning to ``service.track_execution``
+    after bypassing ``__init__`` with ``patch.object``.
+    """
+    yield "mock_run_id"
+
+
+@pytest.fixture
+def mock_telegram_service():
+    """Create a TelegramService with all 10 dependencies mocked.
+
+    Yields the service instance. Individual test files create their
+    handler from this service, e.g.::
+
+        @pytest.fixture
+        def mock_callback_handlers(mock_telegram_service):
+            return TelegramCallbackHandlers(mock_telegram_service)
+
+    The service has all repos/services as Mock instances for assertion.
+    """
+    with (
+        patch("src.services.core.telegram_service.settings") as mock_settings,
+        patch(
+            "src.services.core.telegram_service.UserRepository"
+        ) as mock_user_repo_class,
+        patch(
+            "src.services.core.telegram_service.QueueRepository"
+        ) as mock_queue_repo_class,
+        patch(
+            "src.services.core.telegram_service.MediaRepository"
+        ) as mock_media_repo_class,
+        patch(
+            "src.services.core.telegram_service.HistoryRepository"
+        ) as mock_history_repo_class,
+        patch(
+            "src.services.core.telegram_service.LockRepository"
+        ) as mock_lock_repo_class,
+        patch(
+            "src.services.core.telegram_service.MediaLockService"
+        ) as mock_lock_service_class,
+        patch(
+            "src.services.core.telegram_service.InteractionService"
+        ) as mock_interaction_service_class,
+        patch(
+            "src.services.core.telegram_service.SettingsService"
+        ) as mock_settings_service_class,
+        patch(
+            "src.services.core.telegram_service.InstagramAccountService"
+        ) as mock_ig_account_service_class,
+    ):
+        mock_settings.TELEGRAM_BOT_TOKEN = "123456:ABC-DEF1234ghIkl"
+        mock_settings.TELEGRAM_CHANNEL_ID = -1001234567890
+        mock_settings.CAPTION_STYLE = "enhanced"
+        mock_settings.SEND_LIFECYCLE_NOTIFICATIONS = False
+
+        service = TelegramService()
+
+        # Make repos/services accessible for test assertions
+        service.user_repo = mock_user_repo_class.return_value
+        service.queue_repo = mock_queue_repo_class.return_value
+        service.media_repo = mock_media_repo_class.return_value
+        service.history_repo = mock_history_repo_class.return_value
+        service.lock_repo = mock_lock_repo_class.return_value
+        service.lock_service = mock_lock_service_class.return_value
+        service.interaction_service = mock_interaction_service_class.return_value
+        service.settings_service = mock_settings_service_class.return_value
+        service.ig_account_service = mock_ig_account_service_class.return_value
+
+        yield service

--- a/tests/src/services/test_cloud_storage.py
+++ b/tests/src/services/test_cloud_storage.py
@@ -2,18 +2,12 @@
 
 import pytest
 from unittest.mock import Mock, patch, MagicMock
-from contextlib import contextmanager
 from datetime import datetime, timedelta
 import tempfile
 from pathlib import Path
 
 from src.exceptions import MediaUploadError
-
-
-@contextmanager
-def mock_track_execution(*args, **kwargs):
-    """Mock context manager for track_execution."""
-    yield "mock_run_id"
+from tests.src.services.conftest import mock_track_execution
 
 
 @pytest.mark.unit

--- a/tests/src/services/test_google_drive_oauth.py
+++ b/tests/src/services/test_google_drive_oauth.py
@@ -2,17 +2,12 @@
 
 import json
 import uuid
-from contextlib import contextmanager
 
 import pytest
 from unittest.mock import AsyncMock, Mock, patch
 
 from src.services.integrations.google_drive_oauth import GoogleDriveOAuthService
-
-
-@contextmanager
-def mock_track_execution(*args, **kwargs):
-    yield str(uuid.uuid4())
+from tests.src.services.conftest import mock_track_execution
 
 
 # ==================== State Token Tests ====================

--- a/tests/src/services/test_instagram_account_service.py
+++ b/tests/src/services/test_instagram_account_service.py
@@ -2,17 +2,11 @@
 
 import pytest
 from unittest.mock import Mock, patch
-from contextlib import contextmanager
 from datetime import datetime
 import uuid
 
 from src.services.core.instagram_account_service import InstagramAccountService
-
-
-@contextmanager
-def mock_track_execution(*args, **kwargs):
-    """Mock track_execution context manager that yields a fake run_id."""
-    yield str(uuid.uuid4())
+from tests.src.services.conftest import mock_track_execution
 
 
 @pytest.fixture

--- a/tests/src/services/test_instagram_api.py
+++ b/tests/src/services/test_instagram_api.py
@@ -2,7 +2,6 @@
 
 import pytest
 from unittest.mock import Mock, patch, AsyncMock
-from contextlib import contextmanager
 from datetime import datetime
 
 import httpx
@@ -12,12 +11,7 @@ from src.exceptions import (
     RateLimitError,
     TokenExpiredError,
 )
-
-
-@contextmanager
-def mock_track_execution(*args, **kwargs):
-    """Mock context manager for track_execution."""
-    yield "mock_run_id"
+from tests.src.services.conftest import mock_track_execution
 
 
 @pytest.mark.unit

--- a/tests/src/services/test_media_lock.py
+++ b/tests/src/services/test_media_lock.py
@@ -2,16 +2,10 @@
 
 import pytest
 from unittest.mock import Mock, patch
-from contextlib import contextmanager
 from uuid import uuid4
 
 from src.services.core.media_lock import MediaLockService
-
-
-@contextmanager
-def mock_track_execution(*args, **kwargs):
-    """Mock context manager for track_execution."""
-    yield "mock_run_id"
+from tests.src.services.conftest import mock_track_execution
 
 
 @pytest.fixture

--- a/tests/src/services/test_oauth_service.py
+++ b/tests/src/services/test_oauth_service.py
@@ -1,18 +1,12 @@
 """Unit tests for OAuthService."""
 
 import json
-import uuid
-from contextlib import contextmanager
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import pytest
 
 from src.services.core.oauth_service import OAuthService
-
-
-@contextmanager
-def mock_track_execution(*args, **kwargs):
-    yield str(uuid.uuid4())
+from tests.src.services.conftest import mock_track_execution
 
 
 class TestStateTokenGeneration:

--- a/tests/src/services/test_posting.py
+++ b/tests/src/services/test_posting.py
@@ -4,17 +4,11 @@ import time
 
 import pytest
 from unittest.mock import AsyncMock, Mock, patch
-from contextlib import contextmanager
 from uuid import uuid4
 
 from src.exceptions.google_drive import GoogleDriveAuthError
 from src.services.core.posting import PostingService
-
-
-@contextmanager
-def mock_track_execution(*args, **kwargs):
-    """Mock context manager for track_execution."""
-    yield "mock_run_id"
+from tests.src.services.conftest import mock_track_execution
 
 
 @pytest.fixture

--- a/tests/src/services/test_posting_delivery_reschedule.py
+++ b/tests/src/services/test_posting_delivery_reschedule.py
@@ -3,16 +3,10 @@
 import pytest
 from datetime import datetime, timedelta
 from unittest.mock import Mock, patch, MagicMock
-from contextlib import contextmanager
 from uuid import uuid4
 
 from src.services.core.posting import PostingService
-
-
-@contextmanager
-def mock_track_execution(*args, **kwargs):
-    """Mock context manager for track_execution."""
-    yield "mock_run_id"
+from tests.src.services.conftest import mock_track_execution
 
 
 @pytest.fixture

--- a/tests/src/services/test_telegram_accounts.py
+++ b/tests/src/services/test_telegram_accounts.py
@@ -4,68 +4,19 @@ import pytest
 from unittest.mock import Mock, patch, AsyncMock
 from uuid import uuid4
 
-from src.services.core.telegram_service import TelegramService
 from src.services.core.telegram_settings import TelegramSettingsHandlers
 from src.services.core.telegram_accounts import TelegramAccountHandlers
 
 
 @pytest.fixture
-def mock_account_handlers():
-    """Create TelegramAccountHandlers with mocked service dependencies."""
-    with (
-        patch("src.services.core.telegram_service.settings") as mock_settings,
-        patch(
-            "src.services.core.telegram_service.UserRepository"
-        ) as mock_user_repo_class,
-        patch(
-            "src.services.core.telegram_service.QueueRepository"
-        ) as mock_queue_repo_class,
-        patch(
-            "src.services.core.telegram_service.MediaRepository"
-        ) as mock_media_repo_class,
-        patch(
-            "src.services.core.telegram_service.HistoryRepository"
-        ) as mock_history_repo_class,
-        patch(
-            "src.services.core.telegram_service.LockRepository"
-        ) as mock_lock_repo_class,
-        patch(
-            "src.services.core.telegram_service.MediaLockService"
-        ) as mock_lock_service_class,
-        patch(
-            "src.services.core.telegram_service.InteractionService"
-        ) as mock_interaction_service_class,
-        patch(
-            "src.services.core.telegram_service.SettingsService"
-        ) as mock_settings_service_class,
-        patch(
-            "src.services.core.telegram_service.InstagramAccountService"
-        ) as mock_ig_account_service_class,
-    ):
-        mock_settings.TELEGRAM_BOT_TOKEN = "123456:ABC-DEF1234ghIkl"
-        mock_settings.TELEGRAM_CHANNEL_ID = -1001234567890
-        mock_settings.CAPTION_STYLE = "enhanced"
-        mock_settings.SEND_LIFECYCLE_NOTIFICATIONS = False
-
-        service = TelegramService()
-
-        # Make repos accessible for test assertions
-        service.user_repo = mock_user_repo_class.return_value
-        service.queue_repo = mock_queue_repo_class.return_value
-        service.media_repo = mock_media_repo_class.return_value
-        service.history_repo = mock_history_repo_class.return_value
-        service.lock_repo = mock_lock_repo_class.return_value
-        service.lock_service = mock_lock_service_class.return_value
-        service.interaction_service = mock_interaction_service_class.return_value
-        service.settings_service = mock_settings_service_class.return_value
-        service.ig_account_service = mock_ig_account_service_class.return_value
-
-        # Wire up cross-handler references
-        service.settings_handler = TelegramSettingsHandlers(service)
-        handlers = TelegramAccountHandlers(service)
-        service.accounts = handlers
-
-        yield handlers
+def mock_account_handlers(mock_telegram_service):
+    """Create TelegramAccountHandlers from shared mock_telegram_service."""
+    mock_telegram_service.settings_handler = TelegramSettingsHandlers(
+        mock_telegram_service
+    )
+    handlers = TelegramAccountHandlers(mock_telegram_service)
+    mock_telegram_service.accounts = handlers
+    yield handlers
 
 
 @pytest.mark.unit

--- a/tests/src/services/test_telegram_autopost.py
+++ b/tests/src/services/test_telegram_autopost.py
@@ -5,7 +5,6 @@ from unittest.mock import Mock, patch, AsyncMock
 from uuid import uuid4
 import threading
 
-from src.services.core.telegram_service import TelegramService
 from src.services.core.telegram_autopost import (
     AutopostContext,
     TelegramAutopostHandler,
@@ -13,58 +12,10 @@ from src.services.core.telegram_autopost import (
 
 
 @pytest.fixture
-def mock_autopost_handler():
-    """Create TelegramAutopostHandler with mocked service dependencies."""
-    with (
-        patch("src.services.core.telegram_service.settings") as mock_settings,
-        patch(
-            "src.services.core.telegram_service.UserRepository"
-        ) as mock_user_repo_class,
-        patch(
-            "src.services.core.telegram_service.QueueRepository"
-        ) as mock_queue_repo_class,
-        patch(
-            "src.services.core.telegram_service.MediaRepository"
-        ) as mock_media_repo_class,
-        patch(
-            "src.services.core.telegram_service.HistoryRepository"
-        ) as mock_history_repo_class,
-        patch(
-            "src.services.core.telegram_service.LockRepository"
-        ) as mock_lock_repo_class,
-        patch(
-            "src.services.core.telegram_service.MediaLockService"
-        ) as mock_lock_service_class,
-        patch(
-            "src.services.core.telegram_service.InteractionService"
-        ) as mock_interaction_service_class,
-        patch(
-            "src.services.core.telegram_service.SettingsService"
-        ) as mock_settings_service_class,
-        patch(
-            "src.services.core.telegram_service.InstagramAccountService"
-        ) as mock_ig_account_service_class,
-    ):
-        mock_settings.TELEGRAM_BOT_TOKEN = "123456:ABC-DEF1234ghIkl"
-        mock_settings.TELEGRAM_CHANNEL_ID = -1001234567890
-        mock_settings.CAPTION_STYLE = "enhanced"
-        mock_settings.SEND_LIFECYCLE_NOTIFICATIONS = False
-        mock_settings.ENABLE_INSTAGRAM_API = True
-
-        service = TelegramService()
-
-        service.user_repo = mock_user_repo_class.return_value
-        service.queue_repo = mock_queue_repo_class.return_value
-        service.media_repo = mock_media_repo_class.return_value
-        service.history_repo = mock_history_repo_class.return_value
-        service.lock_repo = mock_lock_repo_class.return_value
-        service.lock_service = mock_lock_service_class.return_value
-        service.interaction_service = mock_interaction_service_class.return_value
-        service.settings_service = mock_settings_service_class.return_value
-        service.ig_account_service = mock_ig_account_service_class.return_value
-
-        handler = TelegramAutopostHandler(service)
-        yield handler
+def mock_autopost_handler(mock_telegram_service):
+    """Create TelegramAutopostHandler from shared mock_telegram_service."""
+    handler = TelegramAutopostHandler(mock_telegram_service)
+    yield handler
 
 
 @pytest.mark.unit

--- a/tests/src/services/test_telegram_callbacks.py
+++ b/tests/src/services/test_telegram_callbacks.py
@@ -1,69 +1,20 @@
 """Tests for TelegramCallbackHandlers (extracted from test_telegram_service.py)."""
 
 import pytest
-from unittest.mock import Mock, patch, AsyncMock
+from unittest.mock import Mock, AsyncMock
 from datetime import datetime
 from uuid import uuid4
 
 from sqlalchemy.exc import OperationalError
 
-from src.services.core.telegram_service import TelegramService
 from src.services.core.telegram_callbacks import TelegramCallbackHandlers
 
 
 @pytest.fixture
-def mock_callback_handlers():
-    """Create TelegramCallbackHandlers with mocked service dependencies."""
-    with (
-        patch("src.services.core.telegram_service.settings") as mock_settings,
-        patch(
-            "src.services.core.telegram_service.UserRepository"
-        ) as mock_user_repo_class,
-        patch(
-            "src.services.core.telegram_service.QueueRepository"
-        ) as mock_queue_repo_class,
-        patch(
-            "src.services.core.telegram_service.MediaRepository"
-        ) as mock_media_repo_class,
-        patch(
-            "src.services.core.telegram_service.HistoryRepository"
-        ) as mock_history_repo_class,
-        patch(
-            "src.services.core.telegram_service.LockRepository"
-        ) as mock_lock_repo_class,
-        patch(
-            "src.services.core.telegram_service.MediaLockService"
-        ) as mock_lock_service_class,
-        patch(
-            "src.services.core.telegram_service.InteractionService"
-        ) as mock_interaction_service_class,
-        patch(
-            "src.services.core.telegram_service.SettingsService"
-        ) as mock_settings_service_class,
-        patch(
-            "src.services.core.telegram_service.InstagramAccountService"
-        ) as mock_ig_account_service_class,
-    ):
-        mock_settings.TELEGRAM_BOT_TOKEN = "123456:ABC-DEF1234ghIkl"
-        mock_settings.TELEGRAM_CHANNEL_ID = -1001234567890
-        mock_settings.CAPTION_STYLE = "enhanced"
-        mock_settings.SEND_LIFECYCLE_NOTIFICATIONS = False
-
-        service = TelegramService()
-
-        # Make repos accessible for test assertions
-        service.user_repo = mock_user_repo_class.return_value
-        service.queue_repo = mock_queue_repo_class.return_value
-        service.media_repo = mock_media_repo_class.return_value
-        service.history_repo = mock_history_repo_class.return_value
-        service.lock_repo = mock_lock_repo_class.return_value
-        service.lock_service = mock_lock_service_class.return_value
-        service.interaction_service = mock_interaction_service_class.return_value
-        service.settings_service = mock_settings_service_class.return_value
-        service.ig_account_service = mock_ig_account_service_class.return_value
-
-        handlers = TelegramCallbackHandlers(service)
-        yield handlers
+def mock_callback_handlers(mock_telegram_service):
+    """Create TelegramCallbackHandlers from shared mock_telegram_service."""
+    handlers = TelegramCallbackHandlers(mock_telegram_service)
+    yield handlers
 
 
 @pytest.mark.unit

--- a/tests/src/services/test_telegram_commands.py
+++ b/tests/src/services/test_telegram_commands.py
@@ -5,64 +5,14 @@ from unittest.mock import Mock, patch, AsyncMock
 from datetime import datetime
 from uuid import uuid4
 
-from src.services.core.telegram_service import TelegramService
 from src.services.core.telegram_commands import TelegramCommandHandlers
 
 
 @pytest.fixture
-def mock_command_handlers():
-    """Create TelegramCommandHandlers with mocked TelegramService dependencies."""
-    with (
-        patch("src.services.core.telegram_service.settings") as mock_settings,
-        patch(
-            "src.services.core.telegram_service.UserRepository"
-        ) as mock_user_repo_class,
-        patch(
-            "src.services.core.telegram_service.QueueRepository"
-        ) as mock_queue_repo_class,
-        patch(
-            "src.services.core.telegram_service.MediaRepository"
-        ) as mock_media_repo_class,
-        patch(
-            "src.services.core.telegram_service.HistoryRepository"
-        ) as mock_history_repo_class,
-        patch(
-            "src.services.core.telegram_service.LockRepository"
-        ) as mock_lock_repo_class,
-        patch(
-            "src.services.core.telegram_service.MediaLockService"
-        ) as mock_lock_service_class,
-        patch(
-            "src.services.core.telegram_service.InteractionService"
-        ) as mock_interaction_service_class,
-        patch(
-            "src.services.core.telegram_service.SettingsService"
-        ) as mock_settings_service_class,
-        patch(
-            "src.services.core.telegram_service.InstagramAccountService"
-        ) as mock_ig_account_service_class,
-    ):
-        mock_settings.TELEGRAM_BOT_TOKEN = "123456:ABC-DEF1234ghIkl"
-        mock_settings.TELEGRAM_CHANNEL_ID = -1001234567890
-        mock_settings.CAPTION_STYLE = "enhanced"
-        mock_settings.SEND_LIFECYCLE_NOTIFICATIONS = False
-
-        service = TelegramService()
-
-        # Make repos accessible for test assertions
-        service.user_repo = mock_user_repo_class.return_value
-        service.queue_repo = mock_queue_repo_class.return_value
-        service.media_repo = mock_media_repo_class.return_value
-        service.history_repo = mock_history_repo_class.return_value
-        service.lock_repo = mock_lock_repo_class.return_value
-        service.lock_service = mock_lock_service_class.return_value
-        service.interaction_service = mock_interaction_service_class.return_value
-        service.settings_service = mock_settings_service_class.return_value
-        service.ig_account_service = mock_ig_account_service_class.return_value
-
-        handlers = TelegramCommandHandlers(service)
-
-        yield handlers
+def mock_command_handlers(mock_telegram_service):
+    """Create TelegramCommandHandlers from shared mock_telegram_service."""
+    handlers = TelegramCommandHandlers(mock_telegram_service)
+    yield handlers
 
 
 @pytest.mark.unit

--- a/tests/src/services/test_telegram_settings.py
+++ b/tests/src/services/test_telegram_settings.py
@@ -4,65 +4,15 @@ import pytest
 from unittest.mock import Mock, patch, AsyncMock
 from uuid import uuid4
 
-from src.services.core.telegram_service import TelegramService
 from src.services.core.telegram_settings import TelegramSettingsHandlers
 
 
 @pytest.fixture
-def mock_settings_handlers():
-    """Create TelegramSettingsHandlers with mocked service dependencies."""
-    with (
-        patch("src.services.core.telegram_service.settings") as mock_settings,
-        patch(
-            "src.services.core.telegram_service.UserRepository"
-        ) as mock_user_repo_class,
-        patch(
-            "src.services.core.telegram_service.QueueRepository"
-        ) as mock_queue_repo_class,
-        patch(
-            "src.services.core.telegram_service.MediaRepository"
-        ) as mock_media_repo_class,
-        patch(
-            "src.services.core.telegram_service.HistoryRepository"
-        ) as mock_history_repo_class,
-        patch(
-            "src.services.core.telegram_service.LockRepository"
-        ) as mock_lock_repo_class,
-        patch(
-            "src.services.core.telegram_service.MediaLockService"
-        ) as mock_lock_service_class,
-        patch(
-            "src.services.core.telegram_service.InteractionService"
-        ) as mock_interaction_service_class,
-        patch(
-            "src.services.core.telegram_service.SettingsService"
-        ) as mock_settings_service_class,
-        patch(
-            "src.services.core.telegram_service.InstagramAccountService"
-        ) as mock_ig_account_service_class,
-    ):
-        mock_settings.TELEGRAM_BOT_TOKEN = "123456:ABC-DEF1234ghIkl"
-        mock_settings.TELEGRAM_CHANNEL_ID = -1001234567890
-        mock_settings.CAPTION_STYLE = "enhanced"
-        mock_settings.SEND_LIFECYCLE_NOTIFICATIONS = False
-
-        service = TelegramService()
-
-        # Make repos accessible for test assertions
-        service.user_repo = mock_user_repo_class.return_value
-        service.queue_repo = mock_queue_repo_class.return_value
-        service.media_repo = mock_media_repo_class.return_value
-        service.history_repo = mock_history_repo_class.return_value
-        service.lock_repo = mock_lock_repo_class.return_value
-        service.lock_service = mock_lock_service_class.return_value
-        service.interaction_service = mock_interaction_service_class.return_value
-        service.settings_service = mock_settings_service_class.return_value
-        service.ig_account_service = mock_ig_account_service_class.return_value
-
-        handlers = TelegramSettingsHandlers(service)
-        service.settings_handler = handlers
-
-        yield handlers
+def mock_settings_handlers(mock_telegram_service):
+    """Create TelegramSettingsHandlers from shared mock_telegram_service."""
+    handlers = TelegramSettingsHandlers(mock_telegram_service)
+    mock_telegram_service.settings_handler = handlers
+    yield handlers
 
 
 @pytest.mark.unit

--- a/tests/src/services/test_token_refresh.py
+++ b/tests/src/services/test_token_refresh.py
@@ -2,16 +2,10 @@
 
 import pytest
 from unittest.mock import Mock, patch, AsyncMock
-from contextlib import contextmanager
 from datetime import datetime, timedelta
 
 from src.exceptions import TokenExpiredError
-
-
-@contextmanager
-def mock_track_execution(*args, **kwargs):
-    """Mock context manager for track_execution."""
-    yield "mock_run_id"
+from tests.src.services.conftest import mock_track_execution
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary
- **Shared TelegramService mock**: 5 Telegram handler test files each had an identical ~55-line fixture to create a mocked TelegramService. Extracted to `tests/src/services/conftest.py` as `mock_telegram_service` — each test file now has a 3-5 line wrapper.
- **Shared `mock_track_execution`**: 9 service test files each copy-pasted the same 4-line context manager mock. Now imported from `conftest.py`.
- **Shared API test helpers**: `client` fixture, `mock_validate`, `service_ctx`, and `CHAT_ID` extracted to `tests/src/api/conftest.py`, shared across 3 API test files.

### New Files
- `tests/src/services/conftest.py` — `mock_telegram_service` fixture + `mock_track_execution`
- `tests/src/api/conftest.py` — `client`, `mock_validate`, `service_ctx`, `CHAT_ID`

### Files Updated (17)
**Telegram handlers** (5): `test_telegram_callbacks.py`, `test_telegram_commands.py`, `test_telegram_settings.py`, `test_telegram_autopost.py`, `test_telegram_accounts.py`
**Service tests** (9): `test_posting.py`, `test_posting_delivery_reschedule.py`, `test_instagram_api.py`, `test_instagram_account_service.py`, `test_google_drive_oauth.py`, `test_oauth_service.py`, `test_cloud_storage.py`, `test_media_lock.py`, `test_token_refresh.py`
**API tests** (3): `test_oauth_routes.py`, `test_onboarding_dashboard.py`, `test_onboarding_routes.py`

## Test plan
- [x] All 1387 tests pass (0 failures, 21 skipped)
- [x] `ruff check` clean
- [x] `ruff format --check` clean
- [x] Net -361 lines of duplicated boilerplate

🤖 Generated with [Claude Code](https://claude.com/claude-code)