### PR TITLE
Fix service_runs table bloat with retention + no-op skip

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -13,11 +13,17 @@ from src.services.core.telegram_service import TelegramService
 from src.services.core.media_lock import MediaLockService
 from src.services.core.media_sync import MediaSyncService
 from src.repositories.queue_repository import QueueRepository
+from src.repositories.service_run_repository import ServiceRunRepository
 
 # Track session statistics
 session_start_time = None
 session_posts_sent = 0
 shutdown_in_progress = False
+
+# Retention policy: delete service_runs older than 7 days
+SERVICE_RUNS_RETENTION_DAYS = 7
+# Run retention once per hour (60 ticks at 1-minute intervals)
+RETENTION_INTERVAL_TICKS = 60
 
 
 async def run_scheduler_loop(
@@ -29,6 +35,8 @@ async def run_scheduler_loop(
     Iterates over all active (non-paused) tenants and processes each
     tenant's pending posts independently.
 
+    Also runs hourly retention cleanup on the service_runs table.
+
     Args:
         posting_service: PostingService instance
         settings_service: SettingsService instance for tenant discovery.
@@ -38,6 +46,8 @@ async def run_scheduler_loop(
     logger.info("Starting scheduler loop...")
 
     queue_repo = QueueRepository()
+    service_run_repo = ServiceRunRepository()
+    retention_tick_counter = 0
 
     while True:
         try:
@@ -110,6 +120,24 @@ async def run_scheduler_loop(
             logger.error(f"Error in scheduler loop: {e}", exc_info=True)
         finally:
             posting_service.cleanup_transactions()
+
+        # Hourly retention: purge old service_runs to prevent table bloat
+        retention_tick_counter += 1
+        if retention_tick_counter >= RETENTION_INTERVAL_TICKS:
+            retention_tick_counter = 0
+            try:
+                deleted = service_run_repo.delete_older_than(
+                    SERVICE_RUNS_RETENTION_DAYS
+                )
+                if deleted > 0:
+                    logger.info(
+                        f"Retention: deleted {deleted} service_runs older than "
+                        f"{SERVICE_RUNS_RETENTION_DAYS} days"
+                    )
+            except Exception as e:
+                logger.warning(f"Service runs retention cleanup failed: {e}")
+            finally:
+                service_run_repo.end_read_transaction()
 
         # Wait 1 minute before next check
         await asyncio.sleep(60)

--- a/src/repositories/service_run_repository.py
+++ b/src/repositories/service_run_repository.py
@@ -97,6 +97,24 @@ class ServiceRunRepository(BaseRepository):
 
         return query.order_by(ServiceRun.started_at.desc()).limit(limit).all()
 
+    def delete_older_than(self, days: int) -> int:
+        """Delete service runs older than the given number of days.
+
+        Used for retention policy to prevent unbounded table growth.
+
+        Args:
+            days: Delete runs with started_at older than this many days ago.
+
+        Returns:
+            Number of rows deleted.
+        """
+        cutoff = datetime.utcnow() - timedelta(days=days)
+        count = (
+            self.db.query(ServiceRun).filter(ServiceRun.started_at < cutoff).delete()
+        )
+        self.db.commit()
+        return count
+
     # NOTE: Unused in production as of 2026-02-10.
     # Planned for Phase 3 monitoring dashboard and alerting system.
     def get_failed_runs(

--- a/src/services/core/posting.py
+++ b/src/services/core/posting.py
@@ -281,6 +281,10 @@ class PostingService(BaseService):
         """
         Process all pending posts ready to be posted.
 
+        Checks pause state and pending items BEFORE creating a service_run
+        record, so no-op calls (nothing due, paused) don't bloat the
+        service_runs table.
+
         Args:
             user_id: User who triggered processing (for observability)
             telegram_chat_id: Chat to process posts for. When provided,
@@ -290,45 +294,46 @@ class PostingService(BaseService):
         Returns:
             Dict with results: {processed: 5, telegram: 5, automated: 0, failed: 0, paused: bool}
         """
+        # Check pause state BEFORE creating a service_run row
+        chat_settings = None
+        if telegram_chat_id:
+            chat_settings = self._get_chat_settings(telegram_chat_id)
+            is_paused = chat_settings.is_paused
+        else:
+            is_paused = self.telegram_service.is_paused
+
+        if is_paused:
+            return {
+                "processed": 0,
+                "telegram": 0,
+                "automated": 0,
+                "failed": 0,
+                "paused": True,
+            }
+
+        # Resolve tenant scope
+        chat_settings_id = None
+        if telegram_chat_id:
+            chat_settings_id = str(chat_settings.id) if chat_settings else None
+
+        # Check for pending items BEFORE creating a service_run row
+        pending_items = self.queue_repo.get_pending(
+            limit=1, chat_settings_id=chat_settings_id
+        )
+
+        if not pending_items:
+            return {"processed": 0, "telegram": 0, "automated": 0, "failed": 0}
+
+        # Only create a service_run when there's actual work to do
         with self.track_execution(
             method_name="process_pending_posts",
             user_id=user_id,
             triggered_by="scheduler" if not user_id else "cli",
         ) as run_id:
-            # Check if posting is paused for this chat
-            if telegram_chat_id:
-                chat_settings = self._get_chat_settings(telegram_chat_id)
-                is_paused = chat_settings.is_paused
-            else:
-                is_paused = self.telegram_service.is_paused
-
-            if is_paused:
-                logger.info("Posting is paused - skipping scheduled posts")
-                result = {
-                    "processed": 0,
-                    "telegram": 0,
-                    "automated": 0,
-                    "failed": 0,
-                    "paused": True,
-                }
-                self.set_result_summary(run_id, result)
-                return result
-
             processed_count = 0
             telegram_count = 0
             automated_count = 0
             failed_count = 0
-
-            # Resolve chat_settings_id for tenant-scoped queue queries
-            # (chat_settings was already fetched in the pause check above)
-            chat_settings_id = None
-            if telegram_chat_id:
-                chat_settings_id = str(chat_settings.id) if chat_settings else None
-
-            # Get next pending post (1 per cycle to space out deliveries)
-            pending_items = self.queue_repo.get_pending(
-                limit=1, chat_settings_id=chat_settings_id
-            )
 
             logger.info(f"Processing {len(pending_items)} pending posts")
 


### PR DESCRIPTION
## Summary
- Add `ServiceRunRepository.delete_older_than(days)` for retention cleanup
- Skip `service_run` creation in `process_pending_posts()` when paused or no items pending (checks moved before `track_execution`)
- Add hourly retention job in scheduler loop to purge service_runs older than 7 days

This drops service_runs growth from ~1,438 rows/day (no-op heartbeats) to ~20-50 rows/day (actual work only). Deploy immediately to reduce Neon WAL bloat.

## Test plan
- [x] All 1,387 existing tests pass (no test changes needed)
- [ ] After deploy: verify `SELECT count(*) FROM service_runs` stops growing on no-op cycles
- [ ] After 1 hour: verify retention deletes old rows
- [ ] Verify `pg_database_size()` stabilizes after VACUUM

🤖 Generated with [Claude Code](https://claude.com/claude-code)