### PR TITLE
feat: Instagram story camera deep link redirect

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -97,6 +97,10 @@ FACEBOOK_APP_SECRET=
 # OAuth redirect base URL (required for cloud — your Railway web domain)
 # OAUTH_REDIRECT_BASE_URL=https://your-app.up.railway.app
 
+# Instagram deep link redirect URL (GitHub Pages — opens story camera on mobile)
+# Default: https://www.instagram.com/ (opens feed, no deep link)
+# INSTAGRAM_DEEPLINK_URL=https://your-username.github.io/storyline-ai/
+
 # Rate limit for Instagram API (Meta allows ~25/hour for Stories)
 INSTAGRAM_POSTS_PER_HOUR=25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Instagram Deep Link Redirect
+
+- **Story camera deep link** — "Open Instagram" button now opens the story camera directly on mobile instead of the feed
+  - Static redirect page (`docs/index.html`) bridges HTTPS → `instagram://story-camera`
+  - Platform-aware: `intent://` syntax for Android Chrome, custom scheme for iOS, web fallback for desktop
+  - Hosted via GitHub Pages (zero infrastructure)
+- **`INSTAGRAM_DEEPLINK_URL` setting** — configurable redirect URL with instant rollback (set to `https://www.instagram.com/` to revert)
+
 ### Added — Mini App Secure Account Input
 
 - **Secure account form in Mini App** — Instagram accounts can now be added via an HTTPS form in the Telegram Mini App dashboard, replacing the message-based wizard where credentials were visible in chat history

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,81 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Opening Instagram...</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+      text-align: center;
+      padding: 80px 20px;
+      margin: 0;
+      background: #fafafa;
+      color: #262626;
+    }
+    .container { max-width: 360px; margin: 0 auto; }
+    .icon { font-size: 48px; margin-bottom: 16px; }
+    .title { font-size: 18px; font-weight: 600; margin-bottom: 8px; }
+    .subtitle { font-size: 14px; color: #8e8e8e; margin-bottom: 24px; }
+    .fallback { display: none; margin-top: 24px; }
+    .fallback a {
+      display: inline-block;
+      padding: 10px 24px;
+      background: #0095f6;
+      color: #fff;
+      text-decoration: none;
+      font-size: 14px;
+      font-weight: 600;
+      border-radius: 8px;
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <div class="icon">&#x1F4F8;</div>
+    <div class="title">Opening Instagram Stories...</div>
+    <div class="subtitle">You should be redirected automatically.</div>
+    <div class="fallback" id="fallback">
+      <a href="https://www.instagram.com/">Open Instagram</a>
+    </div>
+  </div>
+  <script>
+    (function() {
+      var ua = navigator.userAgent || '';
+      var isAndroid = /android/i.test(ua);
+      var isIOS = /iphone|ipad|ipod/i.test(ua);
+      var fallbackUrl = 'https://www.instagram.com/';
+      var fallbackTimer;
+
+      if (isAndroid) {
+        // Chrome 25+ requires intent:// syntax for custom schemes.
+        // browser_fallback_url handles app-not-installed case natively.
+        window.location.href = 'intent://story-camera#Intent;scheme=instagram;package=com.instagram.android;S.browser_fallback_url=' + encodeURIComponent(fallbackUrl) + ';end';
+      } else if (isIOS) {
+        window.location.href = 'instagram://story-camera';
+
+        // Cancel fallback if page becomes hidden (app opened)
+        document.addEventListener('visibilitychange', function() {
+          if (document.hidden) clearTimeout(fallbackTimer);
+        });
+        document.addEventListener('pagehide', function() {
+          clearTimeout(fallbackTimer);
+        });
+
+        // Show manual fallback after 1.5s
+        setTimeout(function() {
+          document.getElementById('fallback').style.display = 'block';
+        }, 1500);
+
+        // Auto-fallback after 3s if app didn't open
+        fallbackTimer = setTimeout(function() {
+          window.location.href = fallbackUrl;
+        }, 3000);
+      } else {
+        // Desktop: go straight to Instagram web
+        window.location.href = fallbackUrl;
+      }
+    })();
+  </script>
+</body>
+</html>

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -51,6 +51,7 @@ class Settings(BaseSettings):
     FACEBOOK_APP_ID: Optional[str] = None
     FACEBOOK_APP_SECRET: Optional[str] = None
     OAUTH_REDIRECT_BASE_URL: Optional[str] = None  # e.g., "https://api.storyline.ai"
+    INSTAGRAM_DEEPLINK_URL: str = "https://www.instagram.com/"
 
     # Google Drive OAuth (Phase 05 Multi-Tenant)
     GOOGLE_CLIENT_ID: Optional[str] = None

--- a/src/services/core/telegram_notification.py
+++ b/src/services/core/telegram_notification.py
@@ -215,7 +215,7 @@ class TelegramNotificationService:
                 [
                     InlineKeyboardButton(
                         "📱 Open Instagram",
-                        url="https://www.instagram.com/",
+                        url=settings.INSTAGRAM_DEEPLINK_URL,
                     ),
                 ],
             ]

--- a/src/services/core/telegram_utils.py
+++ b/src/services/core/telegram_utils.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, WebAppInfo
 
+from src.config.settings import settings as app_settings
 from src.utils.logger import logger
 from src.utils.webapp_auth import generate_url_token
 
@@ -174,7 +175,7 @@ def build_queue_action_keyboard(
             ],
             [
                 InlineKeyboardButton(
-                    "📱 Open Instagram", url="https://www.instagram.com/"
+                    "📱 Open Instagram", url=app_settings.INSTAGRAM_DEEPLINK_URL
                 ),
             ],
         ]

--- a/tests/src/services/test_telegram_notification.py
+++ b/tests/src/services/test_telegram_notification.py
@@ -4,6 +4,7 @@ import pytest
 from unittest.mock import Mock, AsyncMock, patch
 from uuid import uuid4
 
+from src.config.settings import settings
 from src.exceptions.google_drive import GoogleDriveAuthError
 from src.services.core.telegram_notification import (
     TelegramNotificationService,
@@ -475,7 +476,7 @@ class TestBuildKeyboard:
         for row in result.inline_keyboard:
             for button in row:
                 if "Instagram" in button.text:
-                    assert button.url == "https://www.instagram.com/"
+                    assert button.url == settings.INSTAGRAM_DEEPLINK_URL
                     return
 
         pytest.fail("Open Instagram button not found")

--- a/tests/src/services/test_telegram_service.py
+++ b/tests/src/services/test_telegram_service.py
@@ -5,6 +5,7 @@ from unittest.mock import Mock, patch, AsyncMock
 from datetime import datetime
 from uuid import uuid4
 
+from src.config.settings import settings
 from src.services.core.telegram_service import TelegramService
 from src.services.core.telegram_callbacks import TelegramCallbackHandlers
 from src.services.core.telegram_autopost import TelegramAutopostHandler
@@ -165,7 +166,7 @@ class TestButtonLayout:
             ],
             [
                 InlineKeyboardButton(
-                    "📱 Open Instagram", url="https://www.instagram.com/"
+                    "📱 Open Instagram", url=settings.INSTAGRAM_DEEPLINK_URL
                 ),
             ],
             [
@@ -564,7 +565,7 @@ class TestInlineAccountSelector:
             ],
             [
                 InlineKeyboardButton(
-                    "📱 Open Instagram", url="https://www.instagram.com/"
+                    "📱 Open Instagram", url=settings.INSTAGRAM_DEEPLINK_URL
                 ),
             ],
         ]


### PR DESCRIPTION
## Summary

- "Open Instagram" button now opens the **story camera** directly on mobile instead of the feed
- Static redirect page (`docs/index.html`) handles platform-specific deep linking
- Configurable via `INSTAGRAM_DEEPLINK_URL` setting with instant rollback

## How it works

```
Telegram Bot → GitHub Pages redirect → Instagram story camera
               (docs/index.html)
```

- **Android**: Uses `intent://` syntax (required by Chrome 25+) with built-in fallback
- **iOS**: Uses `instagram://story-camera` with visibility-aware timeout fallback
- **Desktop**: Redirects straight to instagram.com

## Changes

| File | Change |
|------|--------|
| `docs/index.html` | New redirect page (platform-aware deep link) |
| `src/config/settings.py` | New `INSTAGRAM_DEEPLINK_URL` setting |
| `src/services/core/telegram_utils.py` | Use setting instead of hardcoded URL |
| `src/services/core/telegram_notification.py` | Use setting instead of hardcoded URL |
| `.env.example` | Document new setting |
| 2 test files | Use setting instead of hardcoded URL |

## Manual setup required after merge

**GitHub Pages** needs to be enabled once (1 minute):

1. Go to **Settings** > **Pages** in the GitHub repo
2. Under "Build and deployment", set Source to **Deploy from a branch**
3. Set Branch to **main**, folder to **/docs**
4. Click **Save**
5. Wait ~1 min for deployment
6. Note the URL: `https://chrisrogers37.github.io/storyline-ai/`

**Then set the env var** on Railway (both worker + API):

```
INSTAGRAM_DEEPLINK_URL=https://chrisrogers37.github.io/storyline-ai/
```

Until GitHub Pages is enabled and the env var is set, behavior is unchanged (defaults to `https://www.instagram.com/`).

## Rollback

Set `INSTAGRAM_DEEPLINK_URL=https://www.instagram.com/` — instant, no code change needed.

## Test plan
- [x] `pytest` — 1399 passed, 16 skipped
- [x] `ruff check` + `ruff format --check` — all passed
- [ ] Enable GitHub Pages and verify redirect page loads
- [ ] Test on iOS: tap "Open Instagram" → story camera opens
- [ ] Test on Android: tap "Open Instagram" → story camera opens
- [ ] Test on desktop: redirects to instagram.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)