### PR TITLE
fix: resolve worker crash and add task isolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — Worker Crash in Cloud Storage Cleanup
+
+- **Fix fatal AttributeError in cleanup loop** — `cleanup_cloud_storage_loop` called `cleanup_transactions()` on a `MediaRepository`, but that method only exists on `BaseService`. Replaced with the correct `end_read_transaction()` call. This crash killed the entire worker process after the first hourly cleanup cycle.
+- **Add task-level exception isolation** — Background loops (scheduler, lock cleanup, cloud cleanup, media sync, transaction cleanup) are now wrapped with `_guarded()` so an unhandled exception in one loop logs a critical error instead of crashing the entire worker via `asyncio.gather()`.
+
 ### Fixed — Telegram Callback Concurrency
 
 - **Preserve post attribution on duplicate callbacks** — Double-tapping Auto Post (or any button after a post completes) no longer overwrites the "Posted to @account by @user" caption with a generic "Already posted via Instagram API" message. The race condition guard now silently acknowledges duplicate callbacks instead of replacing attribution info.

--- a/src/main.py
+++ b/src/main.py
@@ -5,6 +5,8 @@ import signal
 import sys
 from time import time
 
+from typing import Coroutine
+
 from src.config.settings import settings
 from src.utils.logger import logger
 from src.utils.validators import ConfigValidator
@@ -26,6 +28,20 @@ shutdown_in_progress = False
 SERVICE_RUNS_RETENTION_DAYS = 7
 # Run retention once per hour (60 ticks at 1-minute intervals)
 RETENTION_INTERVAL_TICKS = 60
+
+
+async def _guarded(name: str, coro: Coroutine) -> None:
+    """Run a coroutine and log (not propagate) unhandled exceptions.
+
+    Prevents a crash in one background loop from killing the whole worker
+    via asyncio.gather().
+    """
+    try:
+        await coro
+    except asyncio.CancelledError:
+        raise  # let shutdown propagate
+    except Exception:
+        logger.critical(f"Background task '{name}' crashed", exc_info=True)
 
 
 async def run_scheduler_loop(
@@ -181,7 +197,7 @@ async def cleanup_cloud_storage_loop(cloud_service):
             logger.error(f"Error in cloud storage cleanup loop: {e}", exc_info=True)
         finally:
             cloud_service.cleanup_transactions()
-            media_repo.cleanup_transactions()
+            media_repo.end_read_transaction()
 
 
 async def transaction_cleanup_loop(services: list):
@@ -385,9 +401,14 @@ async def main_async():
     ]
     tasks = [
         asyncio.create_task(
-            run_scheduler_loop(scheduler_service, posting_service, settings_service)
+            _guarded(
+                "scheduler",
+                run_scheduler_loop(
+                    scheduler_service, posting_service, settings_service
+                ),
+            )
         ),
-        asyncio.create_task(cleanup_locks_loop(lock_service)),
+        asyncio.create_task(_guarded("lock_cleanup", cleanup_locks_loop(lock_service))),
         asyncio.create_task(telegram_service.start_polling()),
     ]
 
@@ -397,22 +418,33 @@ async def main_async():
     cloud_service = CloudStorageService()
     if cloud_service.is_configured():
         all_services.append(cloud_service)
-        tasks.append(asyncio.create_task(cleanup_cloud_storage_loop(cloud_service)))
+        tasks.append(
+            asyncio.create_task(
+                _guarded("cloud_cleanup", cleanup_cloud_storage_loop(cloud_service))
+            )
+        )
 
     # Add media sync loop if enabled
     if sync_service:
         all_services.append(sync_service)
         tasks.append(
             asyncio.create_task(
-                media_sync_loop(
-                    sync_service,
-                    settings_service=settings_service,
-                    telegram_service=telegram_service,
+                _guarded(
+                    "media_sync",
+                    media_sync_loop(
+                        sync_service,
+                        settings_service=settings_service,
+                        telegram_service=telegram_service,
+                    ),
                 )
             )
         )
 
-    tasks.append(asyncio.create_task(transaction_cleanup_loop(all_services)))
+    tasks.append(
+        asyncio.create_task(
+            _guarded("transaction_cleanup", transaction_cleanup_loop(all_services))
+        )
+    )
 
     logger.info("✓ All services started (JIT scheduler)")
     logger.info(


### PR DESCRIPTION
## Summary

- **Fix fatal worker crash** — `cleanup_cloud_storage_loop` called `cleanup_transactions()` on a `MediaRepository` (a method that only exists on `BaseService`). After the first hourly cleanup cycle, the `AttributeError` propagated through `asyncio.gather()` and killed the entire worker process. The worker has been **completely dead since April 10**. Fixed by calling the correct `end_read_transaction()` method.
- **Add task-level exception isolation** — All background loops (scheduler, lock cleanup, cloud cleanup, media sync, transaction cleanup) are now wrapped with `_guarded()` so an unhandled exception in one loop logs a critical error instead of crashing the entire worker.
- (From prior commits) Preserve post attribution on duplicate callbacks, non-blocking auto-post

## Root Cause

Commit `81f5c0c` (April 9) introduced `cleanup_cloud_storage_loop` with a `finally` block that calls `media_repo.cleanup_transactions()`. `MediaRepository` extends `BaseRepository`, which does **not** have a `cleanup_transactions()` method — only `BaseService` does. The correct repository method is `end_read_transaction()`.

## Test plan

- [x] All 1480 tests pass
- [x] Ruff lint + format clean
- [ ] Deploy to Railway and verify worker starts
- [ ] Verify Telegram receives media for approval within next posting window
- [ ] Monitor `railway logs` for any errors in first hour (when cloud cleanup runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)