### PR TITLE
fix: prevent cascading media sync failures from UniqueViolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Fix fatal AttributeError in cleanup loop** — `cleanup_cloud_storage_loop` called `cleanup_transactions()` on a `MediaRepository`, but that method only exists on `BaseService`. Replaced with the correct `end_read_transaction()` call. This crash killed the entire worker process after the first hourly cleanup cycle.
 - **Add task-level exception isolation** — Background loops (scheduler, lock cleanup, cloud cleanup, media sync, transaction cleanup) are now wrapped with `_guarded()` so an unhandled exception in one loop logs a critical error instead of crashing the entire worker via `asyncio.gather()`.
+- **Fix cascading media sync errors** — A `UniqueViolation` during hash-based rename detection poisoned the database session, causing every subsequent file in the sync batch to fail. Added per-item rollback and a pre-update path conflict check.
 
 ### Fixed — Telegram Callback Concurrency
 

--- a/src/services/core/media_sync.py
+++ b/src/services/core/media_sync.py
@@ -179,6 +179,7 @@ class MediaSyncService(BaseService):
                         result=result,
                     )
                 except Exception as e:
+                    self.media_repo.rollback()
                     result.errors += 1
                     error_msg = f"Error processing {file_info.name}: {e}"
                     result.error_details.append(error_msg)
@@ -260,6 +261,14 @@ class MediaSyncService(BaseService):
             existing = existing_items[0]
 
             file_path = self._build_file_path(source_type, file_info)
+
+            # Skip if another item already holds this file_path (e.g. inactive
+            # duplicate with same Drive ID).  Updating would hit the unique
+            # constraint and poison the session.
+            if self.media_repo.get_by_path(file_path):
+                result.unchanged += 1
+                return
+
             self.media_repo.update_source_info(
                 media_id=str(existing.id),
                 file_name=file_info.name,

--- a/tests/src/services/test_media_sync.py
+++ b/tests/src/services/test_media_sync.py
@@ -206,6 +206,7 @@ class TestMediaSyncServiceSync:
             source_identifier="/media/original.jpg",
         )
         sync_service.media_repo.get_active_by_source_type.return_value = [db_item]
+        sync_service.media_repo.get_by_path.return_value = None
 
         result = sync_service.sync()
 


### PR DESCRIPTION
## Summary

- **Fix cascading sync failures** — When hash-based rename detection hit a `UniqueViolation` (inactive item already held the target `file_path`), the DB session was poisoned and every subsequent file in the batch failed. Added per-item `rollback()` and a pre-update path conflict check.
- Stops the log storm that was hitting Railway's rate limit (13,626+ messages dropped per sync cycle)

## Root Cause

Two Google Drive copies of the same image (same content hash, different Drive file IDs) caused the sync to try updating an active item's `file_path` to one already held by an inactive item. The `unique_file_path_per_tenant` constraint rejected this, and the resulting `UniqueViolation` poisoned the SQLAlchemy session for the entire sync batch.

## Test plan

- [x] All 1480 tests pass (including updated rename detection test)
- [x] Ruff lint + format clean
- [ ] Monitor Railway logs after deploy — sync errors should drop to near zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)