### PR TITLE
Fix stale account captions + add cycle switcher (#140, #141)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — Multi-Account UX Improvements (#140, #141)
+
+- **Batch-update pending messages on account switch** — When switching Instagram accounts, all pending notification captions and button labels now update to reflect the new account. Previously only the message where you clicked updated, leaving other pending posts showing the old account name. (#140)
+- **Single-tap account cycle for 2-3 accounts** — The account selector button now cycles through accounts with one tap instead of opening a submenu. For users with 4+ accounts, the submenu is preserved. (#141)
+- **Consolidated keyboard builder** — `TelegramNotificationService._build_keyboard()` now delegates to the shared `build_queue_action_keyboard()` utility, eliminating a duplicate keyboard implementation. (#137 partial)
+
 ### Fixed — Worker Crash in Cloud Storage Cleanup
 
 - **Fix fatal AttributeError in cleanup loop** — `cleanup_cloud_storage_loop` called `cleanup_transactions()` on a `MediaRepository`, but that method only exists on `BaseService`. Replaced with the correct `end_read_transaction()` call. This crash killed the entire worker process after the first hourly cleanup cycle.

--- a/src/repositories/queue_repository.py
+++ b/src/repositories/queue_repository.py
@@ -314,6 +314,33 @@ class QueueRepository(BaseRepository):
 
         return len(abandoned)
 
+    def get_pending_with_telegram_message(
+        self, telegram_chat_id: int
+    ) -> List[PostingQueue]:
+        """Get pending/processing queue items that have been sent to Telegram.
+
+        Used to find all active notifications for a chat so their captions
+        and keyboards can be batch-updated (e.g., after an account switch).
+
+        Args:
+            telegram_chat_id: The Telegram chat ID to filter by
+
+        Returns:
+            List of PostingQueue items with telegram_message_id set
+        """
+        result = (
+            self.db.query(PostingQueue)
+            .filter(
+                PostingQueue.telegram_chat_id == telegram_chat_id,
+                PostingQueue.telegram_message_id.isnot(None),
+                PostingQueue.status.in_(["pending", "processing"]),
+            )
+            .order_by(PostingQueue.scheduled_for.asc())
+            .all()
+        )
+        self.end_read_transaction()
+        return result
+
     def delete_all_pending(self, chat_settings_id: Optional[str] = None) -> int:
         """Delete all pending queue items. Returns count of deleted items."""
         count = (

--- a/src/services/core/instagram_account_service.py
+++ b/src/services/core/instagram_account_service.py
@@ -490,6 +490,10 @@ class InstagramAccountService(BaseService):
 
             return account
 
+    def count_active_accounts(self) -> int:
+        """Count active Instagram accounts (lightweight, single COUNT query)."""
+        return self.account_repo.count_active()
+
     def get_accounts_for_display(self, telegram_chat_id: int) -> Dict[str, Any]:
         """
         Get account info formatted for /settings display.

--- a/src/services/core/telegram_accounts.py
+++ b/src/services/core/telegram_accounts.py
@@ -387,6 +387,11 @@ class TelegramAccountHandlers:
             # User can click "Back to Post" to return to posting workflow
             await self.handle_post_account_selector(str(queue_item.id), user, query)
 
+            # Batch-update all OTHER pending messages to show the new account
+            await self._batch_update_pending_captions(
+                chat_id, switched_account, exclude_message_id=query.message.message_id
+            )
+
             logger.info("Successfully rebuilt account selector menu")
 
         except ValueError as e:
@@ -409,7 +414,77 @@ class TelegramAccountHandlers:
 
         await self.rebuild_posting_workflow(str(queue_item.id), query)
 
-    async def rebuild_posting_workflow(self, queue_id: str, query):
+    async def handle_cycle_account(self, queue_id: str, user, query):
+        """Cycle to the next Instagram account with a single tap.
+
+        Used when there are 2-3 accounts — replaces the submenu with a
+        single-tap cycle button. Switches the active account to the next
+        one in the list and rebuilds the current message inline.
+        """
+        chat_id = query.message.chat_id
+
+        queue_item = await validate_queue_item(self.service, queue_id, query)
+        if not queue_item:
+            return
+
+        account_data = self.service.ig_account_service.get_accounts_for_display(chat_id)
+        accounts = account_data["accounts"]
+        active_id = account_data["active_account_id"]
+
+        if len(accounts) < 2:
+            await query.answer("Only one account configured", show_alert=False)
+            return
+
+        # Find current index and cycle to next
+        current_idx = next(
+            (i for i, a in enumerate(accounts) if a["id"] == active_id), 0
+        )
+        next_idx = (current_idx + 1) % len(accounts)
+        next_account_id = accounts[next_idx]["id"]
+
+        try:
+            switched = self.service.ig_account_service.switch_account(
+                chat_id, next_account_id, user
+            )
+
+            self.service.interaction_service.log_callback(
+                user_id=str(user.id),
+                callback_name="cycle_account",
+                context={
+                    "queue_item_id": str(queue_item.id),
+                    "account_id": next_account_id,
+                    "account_username": switched.instagram_username,
+                },
+                telegram_chat_id=chat_id,
+                telegram_message_id=query.message.message_id,
+            )
+
+            await query.answer(f"📸 {switched.display_name}")
+
+            account_count = len(accounts)
+
+            # Rebuild this message with updated account
+            await self.rebuild_posting_workflow(
+                str(queue_item.id), query, account_count=account_count
+            )
+
+            # Batch-update all other pending messages
+            await self._batch_update_pending_captions(
+                chat_id,
+                switched,
+                exclude_message_id=query.message.message_id,
+                account_count=account_count,
+            )
+
+        except ValueError as e:
+            await query.answer(f"Error: {e}", show_alert=True)
+        except Exception as e:
+            logger.error(f"Error cycling account: {e}", exc_info=True)
+            await query.answer(f"⚠️ Error: {str(e)[:50]}", show_alert=True)
+
+    async def rebuild_posting_workflow(
+        self, queue_id: str, query, *, account_count: int | None = None
+    ):
         """Rebuild the original posting workflow message.
 
         Used after account selection or when returning from submenu.
@@ -432,10 +507,86 @@ class TelegramAccountHandlers:
 
         # Rebuild keyboard with account selector
         chat_settings = self.service.settings_service.get_settings(chat_id)
+        if account_count is None:
+            account_count = self.service.ig_account_service.count_active_accounts()
         reply_markup = build_queue_action_keyboard(
             queue_id,
             enable_instagram_api=chat_settings.enable_instagram_api,
             active_account=active_account,
+            account_count=account_count,
         )
 
         await query.edit_message_caption(caption=caption, reply_markup=reply_markup)
+
+    async def _batch_update_pending_captions(
+        self,
+        chat_id: int,
+        new_account,
+        exclude_message_id: int | None = None,
+        account_count: int | None = None,
+    ):
+        """Update captions and keyboards on all pending messages after account switch.
+
+        Edits every active notification in the chat to reflect the new active
+        account, so users don't see stale account names on other pending posts.
+
+        Args:
+            chat_id: Telegram chat ID
+            new_account: The newly active InstagramAccount
+            exclude_message_id: Message ID to skip (already updated by caller)
+            account_count: Pre-fetched account count (avoids redundant DB query)
+        """
+        pending_items = self.service.queue_repo.get_pending_with_telegram_message(
+            chat_id
+        )
+        chat_settings = self.service.settings_service.get_settings(chat_id)
+        if account_count is None:
+            account_count = self.service.ig_account_service.count_active_accounts()
+        verbose = self.service._is_verbose(chat_id, chat_settings=chat_settings)
+        updated = 0
+
+        for queue_item in pending_items:
+            if (
+                exclude_message_id is not None
+                and queue_item.telegram_message_id == exclude_message_id
+            ):
+                continue
+
+            try:
+                media_item = self.service.media_repo.get_by_id(
+                    str(queue_item.media_item_id)
+                )
+                if not media_item:
+                    continue
+
+                caption = self.service._build_caption(
+                    media_item,
+                    queue_item,
+                    verbose=verbose,
+                    active_account=new_account,
+                )
+                reply_markup = build_queue_action_keyboard(
+                    str(queue_item.id),
+                    enable_instagram_api=chat_settings.enable_instagram_api,
+                    active_account=new_account,
+                    account_count=account_count,
+                )
+
+                await self.service.bot.edit_message_caption(
+                    chat_id=chat_id,
+                    message_id=queue_item.telegram_message_id,
+                    caption=caption,
+                    reply_markup=reply_markup,
+                )
+                updated += 1
+            except Exception as e:
+                logger.debug(
+                    f"Could not update caption for queue item "
+                    f"{str(queue_item.id)[:8]}: {e}"
+                )
+
+        if updated:
+            logger.info(
+                f"Batch-updated {updated} pending message(s) with new account: "
+                f"{new_account.display_name}"
+            )

--- a/src/services/core/telegram_callbacks.py
+++ b/src/services/core/telegram_callbacks.py
@@ -391,11 +391,19 @@ class TelegramCallbackHandlers:
             return
 
         # Rebuild original caption
-        caption = self.service._build_caption(media_item, queue_item)
+        chat_id = query.message.chat_id
+        active_account = self.service.ig_account_service.get_active_account(chat_id)
+        caption = self.service._build_caption(
+            media_item, queue_item, active_account=active_account
+        )
 
         # Rebuild original keyboard
+        chat_settings = self.service.settings_service.get_settings(chat_id)
         reply_markup = build_queue_action_keyboard(
-            queue_id, enable_instagram_api=settings.ENABLE_INSTAGRAM_API
+            queue_id,
+            enable_instagram_api=chat_settings.enable_instagram_api,
+            active_account=active_account,
+            account_count=self.service.ig_account_service.count_active_accounts(),
         )
 
         await telegram_edit_with_retry(
@@ -480,6 +488,7 @@ class TelegramCallbackHandlers:
             queue_id,
             enable_instagram_api=chat_settings.enable_instagram_api,
             active_account=active_account,
+            account_count=self.service.ig_account_service.count_active_accounts(),
         )
 
         await telegram_edit_with_retry(

--- a/src/services/core/telegram_notification.py
+++ b/src/services/core/telegram_notification.py
@@ -1,7 +1,5 @@
 """Notification sending and caption building for Telegram."""
 
-from telegram import InlineKeyboardButton, InlineKeyboardMarkup
-
 from src.config.settings import settings
 from src.exceptions.google_drive import GoogleDriveAuthError
 from src.utils.logger import logger
@@ -105,9 +103,17 @@ class TelegramNotificationService:
             active_account=active_account,
         )
 
+        # Get account count for keyboard cycle behavior
+        account_count = self.service.ig_account_service.count_active_accounts()
+
         # Build inline keyboard
-        reply_markup = self._build_keyboard(
-            queue_item_id, chat_settings, active_account
+        from src.services.core.telegram_utils import build_queue_action_keyboard
+
+        reply_markup = build_queue_action_keyboard(
+            queue_item_id,
+            enable_instagram_api=chat_settings.enable_instagram_api,
+            active_account=active_account,
+            account_count=account_count,
         )
 
         try:
@@ -161,66 +167,6 @@ class TelegramNotificationService:
                 ) from e
             logger.error(f"Failed to send Telegram notification: {e}")
             return False
-
-    def _build_keyboard(self, queue_item_id, chat_settings, active_account):
-        """Build inline keyboard buttons for the notification.
-
-        Layout: Auto Post (if enabled) -> Status actions -> Instagram actions
-        """
-        keyboard = []
-
-        # Add Auto Post button if Instagram API is enabled (from database settings)
-        if chat_settings.enable_instagram_api:
-            keyboard.append(
-                [
-                    InlineKeyboardButton(
-                        "🤖 Auto Post to Instagram",
-                        callback_data=f"autopost:{queue_item_id}",
-                    ),
-                ]
-            )
-
-        # Status action buttons (grouped together)
-        keyboard.extend(
-            [
-                [
-                    InlineKeyboardButton(
-                        "✅ Posted", callback_data=f"posted:{queue_item_id}"
-                    ),
-                    InlineKeyboardButton(
-                        "⏭️ Skip", callback_data=f"skip:{queue_item_id}"
-                    ),
-                ],
-                [
-                    InlineKeyboardButton(
-                        "🚫 Reject",
-                        callback_data=f"reject:{queue_item_id}",
-                    ),
-                ],
-            ]
-        )
-
-        # Instagram-related buttons (grouped together)
-        account_label = (
-            f"📸 {active_account.display_name}" if active_account else "📸 No Account"
-        )
-        keyboard.extend(
-            [
-                [
-                    InlineKeyboardButton(
-                        account_label,
-                        callback_data=f"select_account:{queue_item_id}",
-                    ),
-                ],
-                [
-                    InlineKeyboardButton(
-                        "📱 Open Instagram",
-                        url=settings.INSTAGRAM_DEEPLINK_URL,
-                    ),
-                ],
-            ]
-        )
-        return InlineKeyboardMarkup(keyboard)
 
     def _build_caption(
         self,

--- a/src/services/core/telegram_service.py
+++ b/src/services/core/telegram_service.py
@@ -224,6 +224,7 @@ class TelegramService(BaseService):
             "account_remove": self.accounts.handle_account_remove_confirm,
             "account_remove_confirmed": self.accounts.handle_account_remove_execute,
             "select_account": self.accounts.handle_post_account_selector,
+            "cycle_account": self.accounts.handle_cycle_account,
             "sap": self.accounts.handle_post_account_switch,
             "btp": self.accounts.handle_back_to_post,
         }

--- a/src/services/core/telegram_utils.py
+++ b/src/services/core/telegram_utils.py
@@ -145,6 +145,7 @@ def build_queue_action_keyboard(
     queue_id: str,
     enable_instagram_api: bool = False,
     active_account=None,
+    account_count: int = 0,
 ) -> InlineKeyboardMarkup:
     """Build the standard action keyboard for a queue item notification.
 
@@ -152,7 +153,7 @@ def build_queue_action_keyboard(
     - Auto Post button (if Instagram API is enabled)
     - Posted / Skip buttons
     - Reject button
-    - Account selector button
+    - Account selector button (cycle for 2-3 accounts, submenu for 4+)
     - Open Instagram link
 
     Args:
@@ -160,6 +161,7 @@ def build_queue_action_keyboard(
         enable_instagram_api: Whether to show the Auto Post button
         active_account: The active InstagramAccount object (for account label),
                         or None to show "No Account"
+        account_count: Total number of active accounts (determines cycle vs submenu)
 
     Returns:
         InlineKeyboardMarkup with the complete action keyboard
@@ -190,16 +192,23 @@ def build_queue_action_keyboard(
         ]
     )
 
-    # Instagram-related buttons
+    # Account button: cycle (2-3 accounts) or submenu (4+)
     account_label = (
         f"📸 {active_account.display_name}" if active_account else "📸 No Account"
     )
+    if 2 <= account_count <= 3:
+        # Single-tap cycle: switches to next account inline
+        callback = f"cycle_account:{queue_id}"
+    else:
+        # Submenu: opens account selector list
+        callback = f"select_account:{queue_id}"
+
     keyboard.extend(
         [
             [
                 InlineKeyboardButton(
                     account_label,
-                    callback_data=f"select_account:{queue_id}",
+                    callback_data=callback,
                 ),
             ],
             [

--- a/tests/src/services/conftest.py
+++ b/tests/src/services/conftest.py
@@ -77,5 +77,6 @@ def mock_telegram_service():
         service.interaction_service = mock_interaction_service_class.return_value
         service.settings_service = mock_settings_service_class.return_value
         service.ig_account_service = mock_ig_account_service_class.return_value
+        service.ig_account_service.count_active_accounts.return_value = 1
 
         yield service

--- a/tests/src/services/test_telegram_accounts.py
+++ b/tests/src/services/test_telegram_accounts.py
@@ -37,6 +37,7 @@ class TestAccountSelectorCallbacks:
         )
 
         mock_account_handlers.service.ig_account_service = Mock()
+        mock_account_handlers.service.ig_account_service.count_active_accounts.return_value = 2
         mock_account_handlers.service.ig_account_service.get_accounts_for_display.return_value = {
             "accounts": [
                 {"id": "acc1", "display_name": "Main Account", "username": "main"},
@@ -85,6 +86,7 @@ class TestAccountSelectorCallbacks:
         )
 
         mock_account_handlers.service.ig_account_service = Mock()
+        mock_account_handlers.service.ig_account_service.count_active_accounts.return_value = 1
         mock_account_handlers.service.ig_account_service.get_active_account.return_value = None
 
         mock_account_handlers.service.settings_service = Mock()
@@ -131,6 +133,7 @@ class TestAccountSelectorCallbacks:
         mock_account.display_name = "Test Account"
         mock_account.instagram_username = "testaccount"
         mock_account_handlers.service.ig_account_service = Mock()
+        mock_account_handlers.service.ig_account_service.count_active_accounts.return_value = 1
         mock_account_handlers.service.ig_account_service.get_account_by_id_prefix.return_value = mock_account
         mock_account_handlers.service.ig_account_service.switch_account.return_value = (
             mock_account

--- a/tests/src/services/test_telegram_notification.py
+++ b/tests/src/services/test_telegram_notification.py
@@ -26,6 +26,7 @@ def mock_telegram_service():
     service.settings_service = Mock()
     service.interaction_service = Mock()
     service.ig_account_service = Mock()
+    service.ig_account_service.count_active_accounts.return_value = 1
     return service
 
 
@@ -371,108 +372,88 @@ class TestGetHeaderEmoji:
 
 @pytest.mark.unit
 class TestBuildKeyboard:
-    """Tests for _build_keyboard."""
+    """Tests for build_queue_action_keyboard (via telegram_utils)."""
 
-    def test_includes_autopost_when_api_enabled(self, notification_service):
+    def test_includes_autopost_when_api_enabled(self):
         """Test keyboard includes Auto Post button when Instagram API is on."""
+        from src.services.core.telegram_utils import build_queue_action_keyboard
+
         queue_id = str(uuid4())
-        chat_settings = Mock(enable_instagram_api=True)
         active_account = Mock(display_name="Test Account")
 
-        result = notification_service._build_keyboard(
-            queue_id, chat_settings, active_account
+        result = build_queue_action_keyboard(
+            queue_id, enable_instagram_api=True, active_account=active_account
         )
 
-        # Extract all button texts
-        buttons = []
-        for row in result.inline_keyboard:
-            for button in row:
-                buttons.append(button.text)
-
+        buttons = [b.text for row in result.inline_keyboard for b in row]
         assert any("Auto Post" in b for b in buttons)
 
-    def test_excludes_autopost_when_api_disabled(self, notification_service):
+    def test_excludes_autopost_when_api_disabled(self):
         """Test keyboard excludes Auto Post button when Instagram API is off."""
+        from src.services.core.telegram_utils import build_queue_action_keyboard
+
         queue_id = str(uuid4())
-        chat_settings = Mock(enable_instagram_api=False)
         active_account = Mock(display_name="Test Account")
 
-        result = notification_service._build_keyboard(
-            queue_id, chat_settings, active_account
+        result = build_queue_action_keyboard(
+            queue_id, enable_instagram_api=False, active_account=active_account
         )
 
-        # Extract all button texts
-        buttons = []
-        for row in result.inline_keyboard:
-            for button in row:
-                buttons.append(button.text)
-
+        buttons = [b.text for row in result.inline_keyboard for b in row]
         assert not any("Auto Post" in b for b in buttons)
 
-    def test_includes_posted_skip_reject_buttons(self, notification_service):
+    def test_includes_posted_skip_reject_buttons(self):
         """Test keyboard always includes Posted, Skip, and Reject buttons."""
-        queue_id = str(uuid4())
-        chat_settings = Mock(enable_instagram_api=False)
-        active_account = None
+        from src.services.core.telegram_utils import build_queue_action_keyboard
 
-        result = notification_service._build_keyboard(
-            queue_id, chat_settings, active_account
+        queue_id = str(uuid4())
+
+        result = build_queue_action_keyboard(
+            queue_id, enable_instagram_api=False, active_account=None
         )
 
-        buttons = []
-        for row in result.inline_keyboard:
-            for button in row:
-                buttons.append(button.text)
-
+        buttons = [b.text for row in result.inline_keyboard for b in row]
         assert any("Posted" in b for b in buttons)
         assert any("Skip" in b for b in buttons)
         assert any("Reject" in b for b in buttons)
 
-    def test_shows_account_display_name(self, notification_service):
+    def test_shows_account_display_name(self):
         """Test account selector button shows display name."""
+        from src.services.core.telegram_utils import build_queue_action_keyboard
+
         queue_id = str(uuid4())
-        chat_settings = Mock(enable_instagram_api=False)
         active_account = Mock(display_name="My Brand")
 
-        result = notification_service._build_keyboard(
-            queue_id, chat_settings, active_account
+        result = build_queue_action_keyboard(
+            queue_id, enable_instagram_api=False, active_account=active_account
         )
 
-        buttons = []
-        for row in result.inline_keyboard:
-            for button in row:
-                buttons.append(button.text)
-
+        buttons = [b.text for row in result.inline_keyboard for b in row]
         assert any("My Brand" in b for b in buttons)
 
-    def test_shows_no_account_when_none(self, notification_service):
+    def test_shows_no_account_when_none(self):
         """Test account selector shows 'No Account' when none configured."""
-        queue_id = str(uuid4())
-        chat_settings = Mock(enable_instagram_api=False)
-        active_account = None
+        from src.services.core.telegram_utils import build_queue_action_keyboard
 
-        result = notification_service._build_keyboard(
-            queue_id, chat_settings, active_account
+        queue_id = str(uuid4())
+
+        result = build_queue_action_keyboard(
+            queue_id, enable_instagram_api=False, active_account=None
         )
 
-        buttons = []
-        for row in result.inline_keyboard:
-            for button in row:
-                buttons.append(button.text)
-
+        buttons = [b.text for row in result.inline_keyboard for b in row]
         assert any("No Account" in b for b in buttons)
 
-    def test_includes_open_instagram_link(self, notification_service):
+    def test_includes_open_instagram_link(self):
         """Test keyboard includes Open Instagram button with URL."""
-        queue_id = str(uuid4())
-        chat_settings = Mock(enable_instagram_api=False)
-        active_account = None
+        from src.services.core.telegram_utils import build_queue_action_keyboard
 
-        result = notification_service._build_keyboard(
-            queue_id, chat_settings, active_account
+        queue_id = str(uuid4())
+
+        result = build_queue_action_keyboard(
+            queue_id, enable_instagram_api=False, active_account=None
         )
 
-        # Find the Open Instagram button
         for row in result.inline_keyboard:
             for button in row:
                 if "Instagram" in button.text:


### PR DESCRIPTION
## Summary

- **Batch-update pending messages on account switch** — When switching Instagram accounts, all pending notification captions and button labels now update to reflect the new account. Previously only the clicked message updated, leaving other posts showing the old account name.
- **Single-tap account cycle for 2-3 accounts** — Account button now cycles through accounts with one tap instead of opening a submenu. Submenu preserved for 4+ accounts.
- **Consolidated keyboard builder** — `_build_keyboard()` in notification service now delegates to shared `build_queue_action_keyboard()`, eliminating duplicate implementation.
- **Efficiency** — Added `count_active_accounts()` (single COUNT query) to avoid fetching full account data when only the count is needed. Threaded `account_count` through methods to avoid redundant DB queries.

## Test plan

- [ ] Switch account on a post with 2+ pending messages — verify all messages update
- [ ] With 2-3 accounts, verify account button cycles instead of opening submenu
- [ ] With 4+ accounts, verify submenu behavior preserved
- [ ] Verify "Back" button in callbacks rebuilds with correct account
- [ ] Verify autopost still works after account switch

Closes #140, closes #141, partial #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)