### PR TITLE
Standardize Telegram message formatting (#135, #136, #139, #142)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — Telegram Message Formatting Inconsistencies (#135, #136, #139, #142)
+
+- **Add `parse_mode="Markdown"` to photo captions** — Initial notifications now render Markdown formatting consistently with callback edits. (#135)
+- **Standardize on Markdown across all commands** — Convert `/start` from MarkdownV2 to Markdown, removing the only MarkdownV2 usage. (#136)
+- **Escape user-generated content in captions** — Apply Markdown escaping to media titles, captions, filenames, and account names. (#142)
+- **Standardize caption spacing** — Both caption modes now use consistent `"\n".join()` spacing and always show account status. (#139)
+- **Add `parse_mode="Markdown"` to callback edits** — Posted, skipped, back, cancel-reject, and dry-run messages now use Markdown consistently. (#142)
+
 ### Fixed — Worker Crash in Cloud Storage Cleanup
 
 - **Fix fatal AttributeError in cleanup loop** — `cleanup_cloud_storage_loop` called `cleanup_transactions()` on a `MediaRepository`, but that method only exists on `BaseService`. Replaced with the correct `end_read_transaction()` call. This crash killed the entire worker process after the first hourly cleanup cycle.

--- a/src/services/core/telegram_accounts.py
+++ b/src/services/core/telegram_accounts.py
@@ -438,4 +438,6 @@ class TelegramAccountHandlers:
             active_account=active_account,
         )
 
-        await query.edit_message_caption(caption=caption, reply_markup=reply_markup)
+        await query.edit_message_caption(
+            caption=caption, reply_markup=reply_markup, parse_mode="Markdown"
+        )

--- a/src/services/core/telegram_autopost.py
+++ b/src/services/core/telegram_autopost.py
@@ -362,6 +362,7 @@ class TelegramAutopostHandler:
             ctx.query.edit_message_caption,
             caption=caption,
             reply_markup=InlineKeyboardMarkup(keyboard),
+            parse_mode="Markdown",
         )
 
         self.service.interaction_service.log_callback(

--- a/src/services/core/telegram_callbacks.py
+++ b/src/services/core/telegram_callbacks.py
@@ -12,6 +12,7 @@ from sqlalchemy.exc import OperationalError
 
 from src.config.settings import settings
 from src.repositories.history_repository import HistoryCreateParams
+from src.services.core.telegram_service import _escape_markdown
 from src.services.core.telegram_utils import (
     build_queue_action_keyboard,
     validate_queue_and_media,
@@ -311,7 +312,9 @@ class TelegramCallbackHandlers:
                 )
 
         # Update message (retry on transient Telegram failures)
-        await telegram_edit_with_retry(query.edit_message_caption, caption=caption)
+        await telegram_edit_with_retry(
+            query.edit_message_caption, caption=caption, parse_mode="Markdown"
+        )
 
         # Log interaction (fire-and-forget, already has its own error handling)
         self.service.interaction_service.log_callback(
@@ -399,7 +402,10 @@ class TelegramCallbackHandlers:
         )
 
         await telegram_edit_with_retry(
-            query.edit_message_caption, caption=caption, reply_markup=reply_markup
+            query.edit_message_caption,
+            caption=caption,
+            reply_markup=reply_markup,
+            parse_mode="Markdown",
         )
 
         logger.info(f"Returned to queue item by {self.service._get_display_name(user)}")
@@ -412,7 +418,7 @@ class TelegramCallbackHandlers:
 
         # Get media item for filename
         media_item = self.service.media_repo.get_by_id(str(queue_item.media_item_id))
-        file_name = media_item.file_name if media_item else "Unknown"
+        file_name = _escape_markdown(media_item.file_name) if media_item else "Unknown"
 
         # Build confirmation keyboard (short labels - details in message above)
         keyboard = [
@@ -483,7 +489,10 @@ class TelegramCallbackHandlers:
         )
 
         await telegram_edit_with_retry(
-            query.edit_message_caption, caption=caption, reply_markup=reply_markup
+            query.edit_message_caption,
+            caption=caption,
+            reply_markup=reply_markup,
+            parse_mode="Markdown",
         )
 
         # Log interaction
@@ -561,10 +570,13 @@ class TelegramCallbackHandlers:
         # Update message with clear feedback (respect verbose setting)
         verbose = self.service._is_verbose(query.message.chat_id)
         if verbose:
+            file_name = (
+                _escape_markdown(media_item.file_name) if media_item else "Unknown"
+            )
             caption = (
                 f"🚫 *Permanently Rejected*\n\n"
                 f"By: {self.service._get_display_name(user)}\n"
-                f"File: {media_item.file_name if media_item else 'Unknown'}\n\n"
+                f"File: {file_name}\n\n"
                 f"This media will never be queued again."
             )
         else:

--- a/src/services/core/telegram_commands.py
+++ b/src/services/core/telegram_commands.py
@@ -51,16 +51,16 @@ class TelegramCommandHandlers:
             if onboarding_done:
                 button_text = "Open Storyline"
                 message_text = (
-                    "Welcome back to *Storyline AI*\\!\n\n"
+                    "Welcome back to *Storyline AI*!\n\n"
                     "Tap the button below to view your dashboard "
-                    "and manage your settings\\."
+                    "and manage your settings."
                 )
             else:
                 button_text = "Open Setup Wizard"
                 message_text = (
-                    "Welcome to *Storyline AI*\\!\n\n"
-                    "Let's get you set up\\. Tap the button below to "
-                    "connect your accounts and configure your posting schedule\\."
+                    "Welcome to *Storyline AI*!\n\n"
+                    "Let's get you set up. Tap the button below to "
+                    "connect your accounts and configure your posting schedule."
                 )
 
             button = build_webapp_button(
@@ -74,7 +74,7 @@ class TelegramCommandHandlers:
             keyboard = InlineKeyboardMarkup([[button]])
             await update.message.reply_text(
                 message_text,
-                parse_mode="MarkdownV2",
+                parse_mode="Markdown",
                 reply_markup=keyboard,
             )
         else:

--- a/src/services/core/telegram_notification.py
+++ b/src/services/core/telegram_notification.py
@@ -1,5 +1,7 @@
 """Notification sending and caption building for Telegram."""
 
+import re
+
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 
 from src.config.settings import settings
@@ -23,6 +25,11 @@ def _is_google_auth_error(exc: Exception) -> bool:
             return True
         current = getattr(current, "__cause__", None)
     return False
+
+
+def _escape_md(text: str) -> str:
+    """Escape Telegram Markdown special characters in user-generated text."""
+    return re.sub(r"([_*`\[])", r"\\\1", text)
 
 
 def _extract_button_labels(reply_markup) -> list:
@@ -128,6 +135,7 @@ class TelegramNotificationService:
                 photo=photo_buffer,
                 caption=caption,
                 reply_markup=reply_markup,
+                parse_mode="Markdown",
             )
 
             # Save telegram message ID
@@ -256,34 +264,34 @@ class TelegramNotificationService:
         active_account=None,
     ) -> str:
         """Build simple caption (original format)."""
-        caption_parts = []
+        lines = []
 
-        # Subtle indicator for force-sent posts
         if force_sent:
-            caption_parts.append("⚡")
+            lines.append("⚡")
 
         if media_item.title:
-            caption_parts.append(f"📸 {media_item.title}")
+            lines.append(f"📸 {_escape_md(media_item.title)}")
 
-        # Account indicator
         if active_account:
-            caption_parts.append(f"📸 Account: {active_account.display_name}")
+            lines.append(f"📸 Account: {_escape_md(active_account.display_name)}")
+        else:
+            lines.append("📸 Account: Not set")
 
         if media_item.caption:
-            caption_parts.append(media_item.caption)
+            lines.append(f"\n{_escape_md(media_item.caption)}")
 
         if media_item.link_url:
-            caption_parts.append(f"🔗 {media_item.link_url}")
+            lines.append(f"\n🔗 {media_item.link_url}")
 
         if media_item.tags:
             tags_str = " ".join([f"#{tag}" for tag in media_item.tags])
-            caption_parts.append(tags_str)
+            lines.append(f"\n{tags_str}")
 
         if verbose:
-            caption_parts.append(f"\n📝 File: {media_item.file_name}")
-            caption_parts.append(f"🆔 ID: {str(media_item.id)[:8]}")
+            lines.append(f"\n📝 File: {_escape_md(media_item.file_name)}")
+            lines.append(f"🆔 ID: {str(media_item.id)[:8]}")
 
-        return "\n\n".join(caption_parts)
+        return "\n".join(lines)
 
     def _build_enhanced_caption(
         self,
@@ -296,29 +304,23 @@ class TelegramNotificationService:
         """Build enhanced caption with better formatting."""
         lines = []
 
-        # Subtle indicator for force-sent posts (just a lightning bolt at the start)
         if force_sent:
             lines.append("⚡")
 
-        # Title and metadata
         if media_item.title:
-            lines.append(f"📸 {media_item.title}")
+            lines.append(f"📸 {_escape_md(media_item.title)}")
 
-        # Active account indicator (for multi-account awareness)
         if active_account:
-            lines.append(f"📸 Account: {active_account.display_name}")
+            lines.append(f"📸 Account: {_escape_md(active_account.display_name)}")
         else:
             lines.append("📸 Account: Not set")
 
-        # Caption
         if media_item.caption:
-            lines.append(f"\n{media_item.caption}")
+            lines.append(f"\n{_escape_md(media_item.caption)}")
 
-        # Link
         if media_item.link_url:
             lines.append(f"\n🔗 {media_item.link_url}")
 
-        # Tags
         if media_item.tags:
             tags_str = " ".join([f"#{tag}" for tag in media_item.tags])
             lines.append(f"\n{tags_str}")


### PR DESCRIPTION
## Summary

- **Add `parse_mode="Markdown"` to `send_photo()`** — Photo captions now render Markdown formatting, matching callback edits (#135)
- **Convert `/start` from MarkdownV2 to Markdown** — Removes the only MarkdownV2 usage, standardizing on Markdown everywhere (#136)
- **Escape user-generated content** — `_escape_md()` applied to media titles, captions, filenames, and account display names before Markdown interpolation (#142)
- **Standardize caption spacing** — Both simple and enhanced modes use `"\n".join()` with consistent `\n` prefix spacing. Simple mode now shows "Account: Not set" when none active (#139)
- **Add `parse_mode="Markdown"` to callback edits** — Posted, skipped, back, cancel-reject, dry-run, and rebuild messages all use Markdown consistently (#142)

## Test plan

- [ ] Send a notification with a media item that has `_underscores_` in the title — verify it renders correctly
- [ ] Run `/start` — verify welcome message renders bold without MarkdownV2 escaping artifacts
- [ ] Click Posted/Skipped/Rejected on a notification — verify callback messages render consistently
- [ ] Check dry-run auto-post output — verify formatting matches other messages
- [ ] Compare simple vs enhanced caption modes — verify spacing is now consistent

Closes #135, closes #136, closes #139, closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)