### PR TITLE
Make verbose flag consistent across caption modes (#138)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — Verbose Flag Consistency (#138)
+
+- **Verbose flag now means the same thing in both caption modes** — `verbose=True` controls debug metadata (file name, ID) in both simple and enhanced modes. Enhanced mode's workflow instructions are now always shown regardless of verbose setting. Previously, verbose controlled different content per mode (debug info in simple, instructions in enhanced).
+
 ### Fixed — Worker Crash in Cloud Storage Cleanup
 
 - **Fix fatal AttributeError in cleanup loop** — `cleanup_cloud_storage_loop` called `cleanup_transactions()` on a `MediaRepository`, but that method only exists on `BaseService`. Replaced with the correct `end_read_transaction()` call. This crash killed the entire worker process after the first hourly cleanup cycle.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed — Verbose Flag Consistency (#138)
 
-- **Verbose flag now means the same thing in both caption modes** — `verbose=True` controls debug metadata (file name, ID) in both simple and enhanced modes. Enhanced mode's workflow instructions are now always shown regardless of verbose setting. Previously, verbose controlled different content per mode (debug info in simple, instructions in enhanced).
+- **Verbose flag now means the same thing in both caption modes** — `verbose=True` controls debug metadata (file name, ID) and workflow instructions in both simple and enhanced modes. Enhanced mode now also shows file name and ID when verbose is on, matching simple mode's behavior.
 
 ### Fixed — Telegram Message Formatting Inconsistencies (#135, #136, #139, #142)
 

--- a/src/services/core/telegram_notification.py
+++ b/src/services/core/telegram_notification.py
@@ -271,16 +271,15 @@ class TelegramNotificationService:
             tags_str = " ".join([f"#{tag}" for tag in media_item.tags])
             lines.append(f"\n{tags_str}")
 
-        # Debug info (consistent with simple mode — controlled by verbose)
+        # Verbose: debug info + workflow instructions (consistent across modes)
         if verbose:
             lines.append(f"\n📝 File: {media_item.file_name}")
             lines.append(f"🆔 ID: {str(media_item.id)[:8]}")
 
-        # Workflow instructions (always shown in enhanced mode)
-        lines.append(f"\n{'━' * 20}")
-        lines.append("1️⃣ Click & hold image → Save")
-        lines.append('2️⃣ Tap "Open Instagram" below')
-        lines.append("3️⃣ Post your story!")
+            lines.append(f"\n{'━' * 20}")
+            lines.append("1️⃣ Click & hold image → Save")
+            lines.append('2️⃣ Tap "Open Instagram" below')
+            lines.append("3️⃣ Post your story!")
 
         return "\n".join(lines)
 

--- a/src/services/core/telegram_notification.py
+++ b/src/services/core/telegram_notification.py
@@ -323,15 +323,16 @@ class TelegramNotificationService:
             tags_str = " ".join([f"#{tag}" for tag in media_item.tags])
             lines.append(f"\n{tags_str}")
 
-        # Only show workflow instructions if verbose mode is ON
+        # Debug info (consistent with simple mode — controlled by verbose)
         if verbose:
-            # Separator
-            lines.append(f"\n{'━' * 20}")
+            lines.append(f"\n📝 File: {media_item.file_name}")
+            lines.append(f"🆔 ID: {str(media_item.id)[:8]}")
 
-            # Workflow instructions
-            lines.append("1️⃣ Click & hold image → Save")
-            lines.append('2️⃣ Tap "Open Instagram" below')
-            lines.append("3️⃣ Post your story!")
+        # Workflow instructions (always shown in enhanced mode)
+        lines.append(f"\n{'━' * 20}")
+        lines.append("1️⃣ Click & hold image → Save")
+        lines.append('2️⃣ Tap "Open Instagram" below')
+        lines.append("3️⃣ Post your story!")
 
         return "\n".join(lines)
 

--- a/tests/src/services/test_telegram_notification.py
+++ b/tests/src/services/test_telegram_notification.py
@@ -244,8 +244,8 @@ class TestBuildEnhancedCaption:
         assert "Click & hold image" in result
         assert "Open Instagram" in result
 
-    def test_workflow_instructions_always_shown(self, notification_service):
-        """Test workflow instructions are shown even when verbose=False."""
+    def test_verbose_off_hides_workflow_instructions(self, notification_service):
+        """Test verbose=False omits workflow instructions."""
         media = Mock(
             title="Test",
             caption=None,
@@ -257,8 +257,8 @@ class TestBuildEnhancedCaption:
             media, verbose=False, active_account=None
         )
 
-        assert "Click & hold image" in result
-        assert "Open Instagram" in result
+        assert "Click & hold image" not in result
+        assert "Open Instagram" not in result
 
     def test_verbose_on_shows_debug_info(self, notification_service):
         """Test verbose=True shows file name and ID in enhanced mode."""

--- a/tests/src/services/test_telegram_notification.py
+++ b/tests/src/services/test_telegram_notification.py
@@ -243,8 +243,8 @@ class TestBuildEnhancedCaption:
         assert "Click & hold image" in result
         assert "Open Instagram" in result
 
-    def test_verbose_off_hides_workflow_instructions(self, notification_service):
-        """Test verbose=False omits workflow instructions."""
+    def test_workflow_instructions_always_shown(self, notification_service):
+        """Test workflow instructions are shown even when verbose=False."""
         media = Mock(
             title="Test",
             caption=None,
@@ -256,8 +256,44 @@ class TestBuildEnhancedCaption:
             media, verbose=False, active_account=None
         )
 
-        assert "Click & hold image" not in result
-        assert "Open Instagram" not in result
+        assert "Click & hold image" in result
+        assert "Open Instagram" in result
+
+    def test_verbose_on_shows_debug_info(self, notification_service):
+        """Test verbose=True shows file name and ID in enhanced mode."""
+        media = Mock(
+            title="Test",
+            caption=None,
+            link_url=None,
+            tags=[],
+            file_name="image.jpg",
+            id="12345678-abcd-efgh",
+        )
+
+        result = notification_service._build_enhanced_caption(
+            media, verbose=True, active_account=None
+        )
+
+        assert "File: image.jpg" in result
+        assert "ID: 12345678" in result
+
+    def test_verbose_off_hides_debug_info(self, notification_service):
+        """Test verbose=False omits file name and ID in enhanced mode."""
+        media = Mock(
+            title="Test",
+            caption=None,
+            link_url=None,
+            tags=[],
+            file_name="image.jpg",
+            id="12345678-abcd-efgh",
+        )
+
+        result = notification_service._build_enhanced_caption(
+            media, verbose=False, active_account=None
+        )
+
+        assert "File:" not in result
+        assert "ID:" not in result
 
     def test_verbose_off_still_shows_account(self, notification_service):
         """Test verbose=False still shows the account indicator."""


### PR DESCRIPTION
## Summary

- **Verbose now means the same thing in both modes** — `verbose=True` controls debug metadata (file name, truncated ID) in both simple and enhanced caption modes
- **Workflow instructions always shown in enhanced mode** — The "save image, open Instagram, post" instructions are user guidance, not debug info, so they're no longer gated behind the verbose flag
- **Tests updated** — Replaced test for "verbose off hides instructions" with tests verifying debug info behavior and instructions-always-shown

## Test plan

- [ ] Toggle verbose off in /setup, verify enhanced mode still shows workflow instructions
- [ ] Toggle verbose on, verify both modes show file name and ID
- [ ] Toggle verbose off, verify both modes hide file name and ID

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)