### PR TITLE
Consolidate keyboard builders (#137)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — Keyboard Builder Consolidation (#137)
+
+- **Merge `build_error_recovery_keyboard` into `build_queue_action_keyboard`** — The two near-identical keyboard builders are now one function with an `error_recovery` parameter. Error recovery mode shows "Retry Auto Post" instead of "Auto Post" and hides the account selector.
+
 ### Fixed — Worker Crash in Cloud Storage Cleanup
 
 - **Fix fatal AttributeError in cleanup loop** — `cleanup_cloud_storage_loop` called `cleanup_transactions()` on a `MediaRepository`, but that method only exists on `BaseService`. Replaced with the correct `end_read_transaction()` call. This crash killed the entire worker process after the first hourly cleanup cycle.

--- a/src/services/core/telegram_autopost.py
+++ b/src/services/core/telegram_autopost.py
@@ -18,7 +18,7 @@ from src.exceptions.instagram import (
 from src.repositories.history_repository import HistoryCreateParams
 from src.services.core.telegram_service import _escape_markdown
 from src.services.core.telegram_utils import (
-    build_error_recovery_keyboard,
+    build_queue_action_keyboard,
     validate_queue_item,
 )
 from src.utils.logger import logger
@@ -551,8 +551,10 @@ class TelegramAutopostHandler:
             f"You can try again or use manual posting."
         )
 
-        reply_markup = build_error_recovery_keyboard(
-            ctx.queue_id, enable_instagram_api=settings.ENABLE_INSTAGRAM_API
+        reply_markup = build_queue_action_keyboard(
+            ctx.queue_id,
+            enable_instagram_api=settings.ENABLE_INSTAGRAM_API,
+            error_recovery=True,
         )
 
         await telegram_edit_with_retry(

--- a/src/services/core/telegram_utils.py
+++ b/src/services/core/telegram_utils.py
@@ -145,33 +145,35 @@ def build_queue_action_keyboard(
     queue_id: str,
     enable_instagram_api: bool = False,
     active_account=None,
+    error_recovery: bool = False,
 ) -> InlineKeyboardMarkup:
-    """Build the standard action keyboard for a queue item notification.
+    """Build the action keyboard for a queue item notification.
 
-    This is the keyboard shown on every posting notification message. It includes:
-    - Auto Post button (if Instagram API is enabled)
-    - Posted / Skip buttons
-    - Reject button
-    - Account selector button
-    - Open Instagram link
+    Handles both the standard posting workflow and error recovery after
+    a failed auto-post. The ``error_recovery`` flag swaps the Auto Post
+    button for Retry, hides the account selector, and uses a plain
+    Instagram URL instead of the deeplink.
 
     Args:
         queue_id: The queue item UUID string (used in callback_data)
-        enable_instagram_api: Whether to show the Auto Post button
+        enable_instagram_api: Whether to show the Auto Post / Retry button
         active_account: The active InstagramAccount object (for account label),
-                        or None to show "No Account"
+                        or None to show "No Account". Ignored when error_recovery=True.
+        error_recovery: If True, show "Retry Auto Post" instead of "Auto Post"
+                        and omit the account selector button.
 
     Returns:
         InlineKeyboardMarkup with the complete action keyboard
     """
     keyboard = []
 
-    # Auto Post button (if Instagram API is enabled)
+    # Auto Post / Retry button
     if enable_instagram_api:
+        label = "🔄 Retry Auto Post" if error_recovery else "🤖 Auto Post to Instagram"
         keyboard.append(
             [
                 InlineKeyboardButton(
-                    "🤖 Auto Post to Instagram",
+                    label,
                     callback_data=f"autopost:{queue_id}",
                 ),
             ]
@@ -190,72 +192,29 @@ def build_queue_action_keyboard(
         ]
     )
 
-    # Instagram-related buttons
-    account_label = (
-        f"📸 {active_account.display_name}" if active_account else "📸 No Account"
-    )
-    keyboard.extend(
-        [
+    # Account selector (hidden in error recovery — user needs simpler options)
+    if not error_recovery:
+        account_label = (
+            f"📸 {active_account.display_name}" if active_account else "📸 No Account"
+        )
+        keyboard.append(
             [
                 InlineKeyboardButton(
                     account_label,
                     callback_data=f"select_account:{queue_id}",
                 ),
-            ],
-            [
-                InlineKeyboardButton(
-                    "📱 Open Instagram", url=app_settings.INSTAGRAM_DEEPLINK_URL
-                ),
-            ],
-        ]
-    )
-
-    return InlineKeyboardMarkup(keyboard)
-
-
-def build_error_recovery_keyboard(
-    queue_id: str,
-    enable_instagram_api: bool = False,
-) -> InlineKeyboardMarkup:
-    """Build the keyboard shown after an auto-post failure.
-
-    Similar to the standard keyboard but with a "Retry" button instead of
-    Auto Post, and no account selector.
-
-    Args:
-        queue_id: The queue item UUID string
-        enable_instagram_api: Whether to show the Retry Auto Post button
-
-    Returns:
-        InlineKeyboardMarkup with retry and fallback options
-    """
-    keyboard = []
-
-    if enable_instagram_api:
-        keyboard.append(
-            [
-                InlineKeyboardButton(
-                    "🔄 Retry Auto Post",
-                    callback_data=f"autopost:{queue_id}",
-                ),
             ]
         )
 
-    keyboard.extend(
+    # Instagram link (plain URL for error recovery, deeplink for standard)
+    instagram_url = (
+        "https://www.instagram.com/"
+        if error_recovery
+        else app_settings.INSTAGRAM_DEEPLINK_URL
+    )
+    keyboard.append(
         [
-            [
-                InlineKeyboardButton("✅ Posted", callback_data=f"posted:{queue_id}"),
-                InlineKeyboardButton("⏭️ Skip", callback_data=f"skip:{queue_id}"),
-            ],
-            [
-                InlineKeyboardButton(
-                    "📱 Open Instagram",
-                    url="https://www.instagram.com/",
-                ),
-            ],
-            [
-                InlineKeyboardButton("🚫 Reject", callback_data=f"reject:{queue_id}"),
-            ],
+            InlineKeyboardButton("📱 Open Instagram", url=instagram_url),
         ]
     )
 


### PR DESCRIPTION
## Summary

- **Merge `build_error_recovery_keyboard` into `build_queue_action_keyboard`** — The two near-identical keyboard builders are now one function with an `error_recovery` flag
- Error recovery mode: "Retry Auto Post" label, no account selector, plain Instagram URL
- Standard mode: unchanged behavior
- Net -35 lines of code

## Test plan

- [ ] Trigger an auto-post failure — verify retry keyboard shows "Retry Auto Post" and no account selector
- [ ] Normal posting workflow — verify standard keyboard unchanged
- [ ] Verify Open Instagram links: deeplink in standard, www.instagram.com in error recovery

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)