### PR TITLE
Add Telegram alert when background task crashes (#132)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Telegram Crash Alerts (#132)
+
+- **Send Telegram alert when a background task crashes** — `_guarded()` now sends a message to the admin chat when any background loop (scheduler, lock cleanup, cloud cleanup, media sync, transaction cleanup) crashes. The worker stays alive but the user is immediately notified which loop stopped. Alert failures are caught separately so they never mask the original crash.
+
 ### Changed — Keyboard Builder Consolidation (#137)
 
 - **Merge `build_error_recovery_keyboard` into `build_queue_action_keyboard`** — The two near-identical keyboard builders are now one function with an `error_recovery` parameter. Error recovery mode shows "Retry Auto Post" instead of "Auto Post" and hides the account selector.

--- a/src/main.py
+++ b/src/main.py
@@ -30,18 +30,34 @@ SERVICE_RUNS_RETENTION_DAYS = 7
 RETENTION_INTERVAL_TICKS = 60
 
 
-async def _guarded(name: str, coro: Coroutine) -> None:
+async def _guarded(name: str, coro: Coroutine, *, bot=None) -> None:
     """Run a coroutine and log (not propagate) unhandled exceptions.
 
     Prevents a crash in one background loop from killing the whole worker
-    via asyncio.gather().
+    via asyncio.gather(). When a bot instance is provided, sends a Telegram
+    alert to the admin chat so crashes aren't silent.
     """
     try:
         await coro
     except asyncio.CancelledError:
         raise  # let shutdown propagate
-    except Exception:
+    except Exception as exc:
         logger.critical(f"Background task '{name}' crashed", exc_info=True)
+
+        if bot:
+            try:
+                await bot.send_message(
+                    chat_id=settings.ADMIN_TELEGRAM_CHAT_ID,
+                    text=(
+                        f"⚠️ *Background task crashed*\n\n"
+                        f"Task: `{name}`\n"
+                        f"Error: `{type(exc).__name__}: {str(exc)[:200]}`\n\n"
+                        f"Worker is still running but this loop has stopped."
+                    ),
+                    parse_mode="Markdown",
+                )
+            except Exception:
+                logger.error(f"Failed to send crash alert for '{name}'", exc_info=True)
 
 
 async def run_scheduler_loop(
@@ -399,6 +415,8 @@ async def main_async():
         lock_service,
         settings_service,
     ]
+    bot = telegram_service.bot
+
     tasks = [
         asyncio.create_task(
             _guarded(
@@ -406,9 +424,12 @@ async def main_async():
                 run_scheduler_loop(
                     scheduler_service, posting_service, settings_service
                 ),
+                bot=bot,
             )
         ),
-        asyncio.create_task(_guarded("lock_cleanup", cleanup_locks_loop(lock_service))),
+        asyncio.create_task(
+            _guarded("lock_cleanup", cleanup_locks_loop(lock_service), bot=bot)
+        ),
         asyncio.create_task(telegram_service.start_polling()),
     ]
 
@@ -420,7 +441,11 @@ async def main_async():
         all_services.append(cloud_service)
         tasks.append(
             asyncio.create_task(
-                _guarded("cloud_cleanup", cleanup_cloud_storage_loop(cloud_service))
+                _guarded(
+                    "cloud_cleanup",
+                    cleanup_cloud_storage_loop(cloud_service),
+                    bot=bot,
+                )
             )
         )
 
@@ -436,13 +461,18 @@ async def main_async():
                         settings_service=settings_service,
                         telegram_service=telegram_service,
                     ),
+                    bot=bot,
                 )
             )
         )
 
     tasks.append(
         asyncio.create_task(
-            _guarded("transaction_cleanup", transaction_cleanup_loop(all_services))
+            _guarded(
+                "transaction_cleanup",
+                transaction_cleanup_loop(all_services),
+                bot=bot,
+            )
         )
     )
 

--- a/tests/src/test_main_scheduler_loop.py
+++ b/tests/src/test_main_scheduler_loop.py
@@ -1,9 +1,11 @@
-"""Tests for the per-tenant scheduler and media sync loops in main.py."""
+"""Tests for the per-tenant scheduler, media sync loops, and _guarded() in main.py."""
+
+import asyncio
 
 import pytest
 from unittest.mock import AsyncMock, Mock, patch
 
-from src.main import run_scheduler_loop, media_sync_loop
+from src.main import _guarded, run_scheduler_loop, media_sync_loop
 
 
 @pytest.mark.unit
@@ -390,3 +392,82 @@ class TestMediaSyncLoop:
 
         # Both should have been attempted
         assert sync_service.sync.call_count == 2
+
+
+@pytest.mark.unit
+class TestGuarded:
+    """Tests for _guarded() crash handling and Telegram alerts."""
+
+    @pytest.mark.asyncio
+    async def test_logs_critical_on_crash(self):
+        """Crashed coroutine is logged at CRITICAL level, not propagated."""
+
+        async def crashing_coro():
+            raise RuntimeError("boom")
+
+        with patch("src.main.logger") as mock_logger:
+            await _guarded("test_task", crashing_coro())
+
+        mock_logger.critical.assert_called_once()
+        assert "test_task" in mock_logger.critical.call_args[0][0]
+
+    @pytest.mark.asyncio
+    async def test_sends_telegram_alert_on_crash(self):
+        """When bot is provided, sends crash alert to admin chat."""
+        mock_bot = AsyncMock()
+
+        async def crashing_coro():
+            raise ValueError("something broke")
+
+        with patch("src.main.settings") as mock_settings:
+            mock_settings.ADMIN_TELEGRAM_CHAT_ID = -100999
+            await _guarded("scheduler", crashing_coro(), bot=mock_bot)
+
+        mock_bot.send_message.assert_called_once()
+        call_kwargs = mock_bot.send_message.call_args.kwargs
+        assert call_kwargs["chat_id"] == -100999
+        assert "scheduler" in call_kwargs["text"]
+        assert "something broke" in call_kwargs["text"]
+
+    @pytest.mark.asyncio
+    async def test_no_alert_when_bot_is_none(self):
+        """When no bot provided, only logs — no Telegram alert."""
+
+        async def crashing_coro():
+            raise RuntimeError("boom")
+
+        with patch("src.main.logger"):
+            # Should not raise — just logs
+            await _guarded("test_task", crashing_coro(), bot=None)
+
+    @pytest.mark.asyncio
+    async def test_alert_failure_does_not_mask_crash_log(self):
+        """If Telegram alert fails, the original crash is still logged."""
+        mock_bot = AsyncMock()
+        mock_bot.send_message.side_effect = Exception("Telegram down")
+
+        async def crashing_coro():
+            raise RuntimeError("original error")
+
+        with (
+            patch("src.main.logger") as mock_logger,
+            patch("src.main.settings") as mock_settings,
+        ):
+            mock_settings.ADMIN_TELEGRAM_CHAT_ID = -100999
+            await _guarded("scheduler", crashing_coro(), bot=mock_bot)
+
+        # Original crash still logged at CRITICAL
+        mock_logger.critical.assert_called_once()
+        assert "scheduler" in mock_logger.critical.call_args[0][0]
+        # Alert failure logged at ERROR
+        mock_logger.error.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_cancelled_error_propagates(self):
+        """CancelledError should propagate (for clean shutdown)."""
+
+        async def cancelled_coro():
+            raise asyncio.CancelledError()
+
+        with pytest.raises(asyncio.CancelledError):
+            await _guarded("test_task", cancelled_coro(), bot=AsyncMock())


### PR DESCRIPTION
## Summary

- **Crash alerts via Telegram** — When `_guarded()` catches an unhandled exception in any background loop, it sends a message to the admin chat: task name, error type, truncated message
- **Alert failures isolated** — If the Telegram notification itself fails, it's logged at ERROR but never masks the original CRITICAL crash log
- **All 5 guarded loops wired up** — scheduler, lock_cleanup, cloud_cleanup, media_sync, transaction_cleanup all pass `bot=telegram_service.bot`
- **5 new tests** — crash logging, alert sending, no-bot fallback, alert failure isolation, CancelledError propagation

## Test plan

- [ ] Kill a background loop (e.g., disconnect DB mid-sync) — verify Telegram alert arrives
- [ ] Verify worker stays alive after one loop crashes
- [ ] Verify alert includes task name and error message
- [ ] Simulate Telegram API down during crash — verify original error still logged

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)