### PR TITLE
Centralize API base URL constants (#119)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed — Centralize API Base URL Constants (#119)
+
+- **Centralize Instagram Login API base URLs** — `IG_LOGIN_GRAPH_BASE` and `IG_LOGIN_API_BASE` constants added to `src/config/constants.py`. Eliminates hardcoded `graph.instagram.com` and `api.instagram.com` URLs in `instagram_login_oauth.py` and `token_refresh.py`. Meta Graph API base was already centralized via `settings.meta_graph_base`.
+
 ### Added — Telegram Crash Alerts (#132)
 
 - **Send Telegram alert when a background task crashes** — `_guarded()` now sends a message to the admin chat when any background loop (scheduler, lock cleanup, cloud cleanup, media sync, transaction cleanup) crashes. The worker stays alive but the user is immediately notified which loop stopped. Alert failures are caught separately so they never mask the original crash.

--- a/src/config/constants.py
+++ b/src/config/constants.py
@@ -10,3 +10,8 @@ MIN_POSTS_PER_DAY = 1
 MAX_POSTS_PER_DAY = 50
 MIN_POSTING_HOUR = 0
 MAX_POSTING_HOUR = 23
+
+# Instagram Login API base URLs (unversioned, separate from Meta Graph API)
+# Used by instagram_login_oauth.py and token_refresh.py
+IG_LOGIN_GRAPH_BASE = "https://graph.instagram.com"
+IG_LOGIN_API_BASE = "https://api.instagram.com"

--- a/src/services/integrations/instagram_login_oauth.py
+++ b/src/services/integrations/instagram_login_oauth.py
@@ -13,6 +13,8 @@ from datetime import datetime, timedelta
 from typing import Optional
 
 import httpx
+
+from src.config.constants import IG_LOGIN_API_BASE, IG_LOGIN_GRAPH_BASE
 from telegram import Bot
 
 from src.config.settings import settings
@@ -35,10 +37,10 @@ class InstagramLoginOAuthService(BaseService):
     - Notifying Telegram after success/failure
     """
 
-    INSTAGRAM_AUTH_URL = "https://api.instagram.com/oauth/authorize"
-    INSTAGRAM_TOKEN_URL = "https://api.instagram.com/oauth/access_token"
-    INSTAGRAM_LONG_LIVED_URL = "https://graph.instagram.com/access_token"
-    INSTAGRAM_USER_URL = "https://graph.instagram.com/me"
+    INSTAGRAM_AUTH_URL = f"{IG_LOGIN_API_BASE}/oauth/authorize"
+    INSTAGRAM_TOKEN_URL = f"{IG_LOGIN_API_BASE}/oauth/access_token"
+    INSTAGRAM_LONG_LIVED_URL = f"{IG_LOGIN_GRAPH_BASE}/access_token"
+    INSTAGRAM_USER_URL = f"{IG_LOGIN_GRAPH_BASE}/me"
     STATE_TTL_SECONDS = 600  # 10 minutes
 
     REQUIRED_SCOPES = [

--- a/src/services/integrations/token_refresh.py
+++ b/src/services/integrations/token_refresh.py
@@ -9,6 +9,7 @@ from src.services.base_service import BaseService
 from src.repositories.token_repository import TokenRepository
 from src.repositories.instagram_account_repository import InstagramAccountRepository
 from src.utils.encryption import TokenEncryption
+from src.config.constants import IG_LOGIN_GRAPH_BASE
 from src.config.settings import settings
 from src.exceptions import TokenExpiredError
 from src.utils.logger import logger
@@ -37,7 +38,7 @@ class TokenRefreshService(BaseService):
     """
 
     # Instagram Login token refresh endpoint (different from Facebook Login)
-    IG_LOGIN_REFRESH_ENDPOINT = "https://graph.instagram.com/refresh_access_token"
+    IG_LOGIN_REFRESH_ENDPOINT = f"{IG_LOGIN_GRAPH_BASE}/refresh_access_token"
 
     # Refresh buffer: refresh tokens this many hours before expiry
     REFRESH_BUFFER_HOURS = 168  # 7 days


### PR DESCRIPTION
## Summary

- **Add `IG_LOGIN_GRAPH_BASE` and `IG_LOGIN_API_BASE` to `constants.py`** — Eliminates hardcoded `graph.instagram.com` and `api.instagram.com` URLs in `instagram_login_oauth.py` and `token_refresh.py`
- **Meta Graph API base already centralized** — `settings.meta_graph_base` (computed from `META_GRAPH_API_VERSION`) handles all `graph.facebook.com` URLs. No changes needed there.
- **Grep verification**: No remaining hardcoded API base URLs in source (only in comments)

## Test plan

- [ ] `grep -rn "graph\.instagram\.com\|api\.instagram\.com" src/ --include="*.py"` — only constants.py and comments
- [ ] `grep -rn "graph\.facebook\.com" src/ --include="*.py"` — only settings.py and comments
- [ ] All 1459 tests pass

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)