### PR TITLE
Add loop-liveness tracking to health check (#134)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Loop Liveness Tracking (#134)
+
+- **Heartbeat tracking for all background loops** — Each loop (scheduler, lock_cleanup, cloud_cleanup, media_sync, transaction_cleanup) records a timestamp on every tick. The health check reports loops as stale if they haven't ticked in 2x their expected interval. Visible via `check-health` CLI and `/status` health checks.
+
 ### Added — Telegram Crash Alerts (#132)
 
 - **Send Telegram alert when a background task crashes** — `_guarded()` now sends a message to the admin chat when any background loop (scheduler, lock cleanup, cloud cleanup, media sync, transaction cleanup) crashes. The worker stays alive but the user is immediately notified which loop stopped. Alert failures are caught separately so they never mask the original crash.

--- a/src/main.py
+++ b/src/main.py
@@ -216,10 +216,10 @@ async def cleanup_locks_loop(lock_service: MediaLockService):
     logger.info("Starting cleanup loop...")
 
     while True:
+        record_heartbeat("lock_cleanup")
         try:
             # Wait 1 hour
             await asyncio.sleep(3600)
-            record_heartbeat("lock_cleanup")
 
             # Cleanup expired locks
             count = lock_service.cleanup_expired_locks()
@@ -246,9 +246,9 @@ async def cleanup_cloud_storage_loop(cloud_service):
     logger.info("Starting cloud storage cleanup loop...")
 
     while True:
+        record_heartbeat("cloud_cleanup")
         try:
             await asyncio.sleep(3600)
-            record_heartbeat("cloud_cleanup")
 
             cloud_count = cloud_service.cleanup_expired(folder=CLOUD_UPLOAD_FOLDER)
             db_count = media_repo.clear_stale_cloud_info(
@@ -281,8 +281,8 @@ async def transaction_cleanup_loop(services: list):
     from src.utils.resilience import log_pool_status
 
     while True:
-        await asyncio.sleep(30)  # Run every 30 seconds
         record_heartbeat("transaction_cleanup")
+        await asyncio.sleep(30)  # Run every 30 seconds
 
         # Log pool status for monitoring
         log_pool_status()

--- a/src/main.py
+++ b/src/main.py
@@ -29,6 +29,55 @@ SERVICE_RUNS_RETENTION_DAYS = 7
 # Run retention once per hour (60 ticks at 1-minute intervals)
 RETENTION_INTERVAL_TICKS = 60
 
+# Loop liveness tracking — each loop updates its timestamp on every tick.
+# Expected intervals (seconds) per loop, used to detect stalls.
+LOOP_EXPECTED_INTERVALS: dict[str, int] = {
+    "scheduler": 60,
+    "lock_cleanup": 3600,
+    "cloud_cleanup": 3600,
+    "media_sync": 300,
+    "transaction_cleanup": 30,
+}
+# In-memory heartbeat timestamps (UTC). Updated by loops, read by health check.
+loop_heartbeats: dict[str, float] = {}
+
+
+def record_heartbeat(name: str) -> None:
+    """Record a heartbeat for a named loop."""
+    loop_heartbeats[name] = time()
+
+
+def get_loop_liveness() -> dict[str, dict]:
+    """Return liveness status for all registered loops.
+
+    Each loop is reported as alive or stale based on whether its last
+    heartbeat is within 2x its expected interval. Loops that have never
+    sent a heartbeat are reported as not started.
+    """
+    now = time()
+    result = {}
+    for name, expected_interval in LOOP_EXPECTED_INTERVALS.items():
+        last_beat = loop_heartbeats.get(name)
+        if last_beat is None:
+            result[name] = {
+                "alive": False,
+                "message": "Not started",
+                "expected_interval_s": expected_interval,
+            }
+        else:
+            elapsed = now - last_beat
+            threshold = expected_interval * 2
+            alive = elapsed <= threshold
+            result[name] = {
+                "alive": alive,
+                "last_heartbeat_s_ago": round(elapsed),
+                "expected_interval_s": expected_interval,
+                "message": "OK"
+                if alive
+                else f"Stale ({round(elapsed)}s since last tick)",
+            }
+    return result
+
 
 async def _guarded(name: str, coro: Coroutine, *, bot=None) -> None:
     """Run a coroutine and log (not propagate) unhandled exceptions.
@@ -87,6 +136,7 @@ async def run_scheduler_loop(
     retention_tick_counter = 0
 
     while True:
+        record_heartbeat("scheduler")
         try:
             # Discard queue items abandoned in 'processing' for over 24h.
             # Items enter 'processing' when sent to Telegram — they stay
@@ -169,6 +219,7 @@ async def cleanup_locks_loop(lock_service: MediaLockService):
         try:
             # Wait 1 hour
             await asyncio.sleep(3600)
+            record_heartbeat("lock_cleanup")
 
             # Cleanup expired locks
             count = lock_service.cleanup_expired_locks()
@@ -197,6 +248,7 @@ async def cleanup_cloud_storage_loop(cloud_service):
     while True:
         try:
             await asyncio.sleep(3600)
+            record_heartbeat("cloud_cleanup")
 
             cloud_count = cloud_service.cleanup_expired(folder=CLOUD_UPLOAD_FOLDER)
             db_count = media_repo.clear_stale_cloud_info(
@@ -230,6 +282,7 @@ async def transaction_cleanup_loop(services: list):
 
     while True:
         await asyncio.sleep(30)  # Run every 30 seconds
+        record_heartbeat("transaction_cleanup")
 
         # Log pool status for monitoring
         log_pool_status()
@@ -271,6 +324,7 @@ async def media_sync_loop(
     last_error_notified = None
 
     while True:
+        record_heartbeat("media_sync")
         try:
             # Multi-tenant: sync each tenant with media_sync_enabled=True
             sync_enabled_chats = []

--- a/src/services/core/health_check.py
+++ b/src/services/core/health_check.py
@@ -351,6 +351,7 @@ class HealthCheckService(BaseService):
         records a heartbeat on every iteration; a loop is stale if its
         last heartbeat exceeds 2x its expected interval.
         """
+        # Inline import: src.main imports services, so a top-level import would be circular
         from src.main import get_loop_liveness
 
         liveness = get_loop_liveness()

--- a/src/services/core/health_check.py
+++ b/src/services/core/health_check.py
@@ -58,6 +58,7 @@ class HealthCheckService(BaseService):
             "queue": self._check_queue(),
             "recent_posts": self._check_recent_posts(),
             "media_sync": self._check_media_sync(),
+            "loop_liveness": self._check_loop_liveness(),
         }
 
         # Determine overall status
@@ -342,3 +343,28 @@ class HealthCheckService(BaseService):
                 "message": f"Sync check error: {str(e)}",
                 "enabled": True,
             }
+
+    def _check_loop_liveness(self) -> dict:
+        """Check if background loops are still ticking.
+
+        Uses in-memory heartbeat timestamps from src.main. Each loop
+        records a heartbeat on every iteration; a loop is stale if its
+        last heartbeat exceeds 2x its expected interval.
+        """
+        from src.main import get_loop_liveness
+
+        liveness = get_loop_liveness()
+        stale = [name for name, info in liveness.items() if not info["alive"]]
+
+        if stale:
+            return {
+                "healthy": False,
+                "message": f"Stale loops: {', '.join(stale)}",
+                "loops": liveness,
+            }
+
+        return {
+            "healthy": True,
+            "message": f"All {len(liveness)} loops alive",
+            "loops": liveness,
+        }

--- a/tests/src/services/test_health_check.py
+++ b/tests/src/services/test_health_check.py
@@ -166,7 +166,13 @@ class TestHealthCheckService:
         mock_post = Mock(success=True)
         health_service.history_repo.get_recent_posts.return_value = [mock_post]
 
-        result = health_service.check_all()
+        # Mock loop liveness so all loops report alive
+        all_alive = {
+            name: {"alive": True, "message": "OK", "expected_interval_s": 60}
+            for name in ["scheduler", "lock_cleanup", "cloud_cleanup", "media_sync", "transaction_cleanup"]
+        }
+        with patch("src.main.get_loop_liveness", return_value=all_alive):
+            result = health_service.check_all()
 
         assert result["status"] == "healthy"
         assert "database" in result["checks"]
@@ -175,6 +181,7 @@ class TestHealthCheckService:
         assert "queue" in result["checks"]
         assert "recent_posts" in result["checks"]
         assert "media_sync" in result["checks"]
+        assert "loop_liveness" in result["checks"]
         assert "timestamp" in result
 
     @patch("src.services.core.health_check.BaseRepository")

--- a/tests/src/test_main_scheduler_loop.py
+++ b/tests/src/test_main_scheduler_loop.py
@@ -5,7 +5,14 @@ import asyncio
 import pytest
 from unittest.mock import AsyncMock, Mock, patch
 
-from src.main import _guarded, run_scheduler_loop, media_sync_loop
+from src.main import (
+    _guarded,
+    get_loop_liveness,
+    loop_heartbeats,
+    record_heartbeat,
+    run_scheduler_loop,
+    media_sync_loop,
+)
 
 
 @pytest.mark.unit
@@ -471,3 +478,54 @@ class TestGuarded:
 
         with pytest.raises(asyncio.CancelledError):
             await _guarded("test_task", cancelled_coro(), bot=AsyncMock())
+
+
+@pytest.mark.unit
+class TestLoopLiveness:
+    """Tests for loop heartbeat tracking and liveness detection."""
+
+    def setup_method(self):
+        """Clear heartbeats before each test."""
+        loop_heartbeats.clear()
+
+    def test_record_heartbeat_stores_timestamp(self):
+        """record_heartbeat() stores a float timestamp."""
+        record_heartbeat("scheduler")
+        assert "scheduler" in loop_heartbeats
+        assert isinstance(loop_heartbeats["scheduler"], float)
+
+    def test_unstarted_loop_reported_as_not_alive(self):
+        """Loops that never sent a heartbeat are reported as not started."""
+        result = get_loop_liveness()
+        assert "scheduler" in result
+        assert result["scheduler"]["alive"] is False
+        assert "Not started" in result["scheduler"]["message"]
+
+    def test_fresh_heartbeat_reported_as_alive(self):
+        """A loop with a recent heartbeat is reported as alive."""
+        record_heartbeat("scheduler")
+        result = get_loop_liveness()
+        assert result["scheduler"]["alive"] is True
+        assert result["scheduler"]["message"] == "OK"
+
+    def test_stale_heartbeat_reported_as_not_alive(self):
+        """A loop whose heartbeat is older than 2x its interval is stale."""
+        from time import time
+
+        # Set heartbeat to 200s ago (scheduler interval is 60s, threshold 120s)
+        loop_heartbeats["scheduler"] = time() - 200
+        result = get_loop_liveness()
+        assert result["scheduler"]["alive"] is False
+        assert "Stale" in result["scheduler"]["message"]
+
+    def test_all_registered_loops_included(self):
+        """get_loop_liveness() reports on all registered loops."""
+        result = get_loop_liveness()
+        expected = {
+            "scheduler",
+            "lock_cleanup",
+            "cloud_cleanup",
+            "media_sync",
+            "transaction_cleanup",
+        }
+        assert set(result.keys()) == expected


### PR DESCRIPTION
## Summary

- **Heartbeat tracking for all 5 background loops** — Each loop records a timestamp on every tick via `record_heartbeat()`. In-memory dict, no DB needed.
- **Health check detects stale loops** — `_check_loop_liveness()` flags any loop that hasn't ticked in 2x its expected interval. Included in `check_all()` so `check-health` CLI and `/status` get it automatically.
- **Expected intervals**: scheduler (60s), lock_cleanup (3600s), cloud_cleanup (3600s), media_sync (300s), transaction_cleanup (30s)
- **5 new tests** — heartbeat storage, fresh/stale detection, unstarted loop handling, all registered loops included

## Test plan

- [ ] Start worker — verify `check-health` shows all loops as "alive" after first tick
- [ ] Kill a background loop — verify health check reports it as stale after threshold
- [ ] Verify unstarted loops (e.g. cloud_cleanup when Cloudinary not configured) show "Not started"

Closes #134

🤖 Generated with [Claude Code](https://claude.com/claude-code)