### PR TITLE
feat: Pool depletion warnings with Telegram alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Pool Depletion Warnings (#156)
+
+- **Media pool health check** — New `_check_media_pool()` in HealthCheckService monitors content supply per category. Calculates days of runway (eligible items / posts per day share) and reports warnings at <7 days and critical at <2 days. Included in `check_all()` and the `/system-status` dashboard API.
+- **Per-chat pool detail** — `check_media_pool_for_chat()` provides per-category breakdown with eligible counts, post rate share, and runway estimates.
+- **Hourly Telegram alerts** — Scheduler loop checks pool health every hour and sends a Telegram alert when any category drops below the warning threshold. Alerts are throttled to once per 24 hours per chat to prevent spam.
+
 ### Added — Loop Liveness Tracking (#134)
 
 - **Heartbeat tracking for all background loops** — Each loop (scheduler, lock_cleanup, cloud_cleanup, media_sync, transaction_cleanup) records a timestamp on every tick. The health check reports loops as stale if they haven't ticked in 2x their expected interval. Visible via `check-health` CLI and `/status` health checks.

--- a/src/main.py
+++ b/src/main.py
@@ -15,6 +15,7 @@ from src.services.core.scheduler import SchedulerService
 from src.services.core.telegram_service import TelegramService
 from src.services.core.media_lock import MediaLockService
 from src.services.core.media_sync import MediaSyncService
+from src.services.core.health_check import HealthCheckService
 from src.repositories.queue_repository import QueueRepository
 from src.repositories.service_run_repository import ServiceRunRepository
 from src.exceptions.google_drive import GoogleDriveAuthError
@@ -28,6 +29,10 @@ shutdown_in_progress = False
 SERVICE_RUNS_RETENTION_DAYS = 7
 # Run retention once per hour (60 ticks at 1-minute intervals)
 RETENTION_INTERVAL_TICKS = 60
+# Pool depletion check interval (hourly, same cadence as retention)
+POOL_CHECK_INTERVAL_TICKS = 60
+# Throttle pool alerts to once per 24h per chat
+POOL_ALERT_COOLDOWN_SECONDS = 86400
 
 # Loop liveness tracking — each loop updates its timestamp on every tick.
 # Expected intervals (seconds) per loop, used to detect stalls.
@@ -133,7 +138,11 @@ async def run_scheduler_loop(
 
     queue_repo = QueueRepository()
     service_run_repo = ServiceRunRepository()
+    health_check_service = HealthCheckService()
     retention_tick_counter = 0
+    pool_check_tick_counter = 0
+    # Track last pool alert time per chat_id to throttle to once per 24h
+    pool_alert_last_sent: dict[int, float] = {}
 
     while True:
         record_heartbeat("scheduler")
@@ -206,6 +215,43 @@ async def run_scheduler_loop(
                 logger.warning(f"Service runs retention cleanup failed: {e}")
             finally:
                 service_run_repo.end_read_transaction()
+
+        # Hourly pool depletion check: alert when categories are running low
+        pool_check_tick_counter += 1
+        if pool_check_tick_counter >= POOL_CHECK_INTERVAL_TICKS:
+            pool_check_tick_counter = 0
+            try:
+                if active_chats and scheduler_service.telegram_service:
+                    now = time()
+                    bot = scheduler_service.telegram_service.application.bot
+                    # Prune stale entries for chats no longer active
+                    active_ids = {c.telegram_chat_id for c in active_chats}
+                    for stale_id in set(pool_alert_last_sent) - active_ids:
+                        del pool_alert_last_sent[stale_id]
+
+                    for chat in active_chats:
+                        chat_id = chat.telegram_chat_id
+                        if (
+                            now - pool_alert_last_sent.get(chat_id, 0)
+                            < POOL_ALERT_COOLDOWN_SECONDS
+                        ):
+                            continue
+
+                        pool_info = health_check_service.check_media_pool_for_chat(
+                            chat_id, chat_settings=chat
+                        )
+                        alert_text = health_check_service.format_pool_alert(pool_info)
+                        if alert_text:
+                            await bot.send_message(chat_id=chat_id, text=alert_text)
+                            pool_alert_last_sent[chat_id] = now
+                            logger.info(
+                                f"[chat={chat_id}] Sent pool depletion alert: "
+                                f"{len(pool_info['warnings'])} warning(s)"
+                            )
+            except Exception as e:
+                logger.warning(f"Pool depletion check failed: {e}")
+            finally:
+                health_check_service.cleanup_transactions()
 
         # Wait 1 minute before next check
         await asyncio.sleep(60)

--- a/src/services/core/health_check.py
+++ b/src/services/core/health_check.py
@@ -16,6 +16,8 @@ class HealthCheckService(BaseService):
     QUEUE_BACKLOG_THRESHOLD = 10  # JIT queue is 0-5 items; 10+ indicates a problem
     MAX_PENDING_AGE_HOURS = 4  # JIT items should be acted on within hours, not days
     RECENT_POSTS_WINDOW_HOURS = 48
+    POOL_WARNING_DAYS = 7  # Warn when category has < 7 days of runway
+    POOL_CRITICAL_DAYS = 2  # Critical when < 2 days of runway
 
     def __init__(self):
         super().__init__()
@@ -25,6 +27,9 @@ class HealthCheckService(BaseService):
         # Lazy-loaded services for Instagram checks
         self._token_service = None
         self._instagram_service = None
+
+        self._media_repo = None
+        self._settings_service = None
 
     @property
     def token_service(self):
@@ -44,6 +49,24 @@ class HealthCheckService(BaseService):
             self._instagram_service = InstagramAPIService()
         return self._instagram_service
 
+    @property
+    def media_repo(self):
+        """Lazy-load media repository."""
+        if self._media_repo is None:
+            from src.repositories.media_repository import MediaRepository
+
+            self._media_repo = MediaRepository()
+        return self._media_repo
+
+    @property
+    def settings_service(self):
+        """Lazy-load settings service."""
+        if self._settings_service is None:
+            from src.services.core.settings_service import SettingsService
+
+            self._settings_service = SettingsService()
+        return self._settings_service
+
     def check_all(self) -> dict:
         """
         Run all health checks.
@@ -58,6 +81,7 @@ class HealthCheckService(BaseService):
             "queue": self._check_queue(),
             "recent_posts": self._check_recent_posts(),
             "media_sync": self._check_media_sync(),
+            "media_pool": self._check_media_pool(),
             "loop_liveness": self._check_loop_liveness(),
         }
 
@@ -369,3 +393,153 @@ class HealthCheckService(BaseService):
             "message": f"All {len(liveness)} loops alive",
             "loops": liveness,
         }
+
+    def _check_media_pool(self) -> dict:
+        """Check media pool health across all active tenants.
+
+        Reports the lowest-runway category across all tenants.
+        For per-tenant detail, use check_media_pool_for_chat().
+        """
+        try:
+            active_chats = self.settings_service.get_all_active_chats()
+            if not active_chats:
+                return {"healthy": True, "message": "No active chats configured"}
+
+            worst_runway = float("inf")
+            worst_detail = None
+
+            for chat in active_chats:
+                pool_info = self.check_media_pool_for_chat(
+                    chat.telegram_chat_id, chat_settings=chat
+                )
+                for cat_info in pool_info.get("categories", []):
+                    if cat_info["runway_days"] < worst_runway:
+                        worst_runway = cat_info["runway_days"]
+                        worst_detail = cat_info
+
+            if worst_detail is None:
+                return {"healthy": True, "message": "No categories configured"}
+
+            if worst_runway <= self.POOL_CRITICAL_DAYS:
+                return {
+                    "healthy": False,
+                    "message": (
+                        f"Critical: '{worst_detail['category']}' has "
+                        f"{worst_detail['eligible']} items "
+                        f"({worst_detail['runway_days']:.0f} days remaining)"
+                    ),
+                    "worst_category": worst_detail,
+                }
+
+            if worst_runway <= self.POOL_WARNING_DAYS:
+                return {
+                    "healthy": False,
+                    "message": (
+                        f"Low pool: '{worst_detail['category']}' has "
+                        f"{worst_detail['eligible']} items "
+                        f"({worst_detail['runway_days']:.0f} days remaining)"
+                    ),
+                    "worst_category": worst_detail,
+                }
+
+            return {
+                "healthy": True,
+                "message": f"All categories have >{self.POOL_WARNING_DAYS} days of runway",
+            }
+
+        except Exception as e:
+            logger.error(f"Media pool check failed: {e}", exc_info=True)
+            return {"healthy": False, "message": f"Pool check error: {str(e)}"}
+
+    def check_media_pool_for_chat(
+        self, telegram_chat_id: int, *, chat_settings=None
+    ) -> dict:
+        """Check media pool health for a specific chat.
+
+        Returns per-category breakdown with eligible counts and runway estimates.
+
+        Args:
+            telegram_chat_id: The tenant's Telegram chat ID.
+            chat_settings: Pre-loaded ChatSettings (avoids extra DB lookup).
+
+        Returns:
+            Dict with categories list, each containing: category, eligible,
+            posts_per_day_share, runway_days.
+        """
+        if chat_settings is None:
+            chat_settings = self.settings_service.get_settings(telegram_chat_id)
+
+        chat_settings_id = str(chat_settings.id)
+        posts_per_day = chat_settings.posts_per_day or 1
+
+        eligible_by_category = self.media_repo.count_eligible_by_category(
+            chat_settings_id
+        )
+
+        if not eligible_by_category:
+            return {
+                "total_eligible": 0,
+                "posts_per_day": posts_per_day,
+                "categories": [],
+                "warnings": ["No eligible media in any category"],
+            }
+
+        num_categories = len(eligible_by_category)
+        categories = []
+        warnings = []
+
+        for category, eligible in sorted(eligible_by_category.items()):
+            posts_per_day_share = posts_per_day / num_categories
+            runway_days = (
+                eligible / posts_per_day_share if posts_per_day_share else float("inf")
+            )
+
+            cat_info = {
+                "category": category,
+                "eligible": eligible,
+                "posts_per_day_share": round(posts_per_day_share, 2),
+                "runway_days": round(runway_days, 1),
+            }
+            categories.append(cat_info)
+
+            if runway_days <= self.POOL_CRITICAL_DAYS:
+                warnings.append(
+                    f"CRITICAL: '{category}' has {eligible} items "
+                    f"(< {self.POOL_CRITICAL_DAYS} days remaining)"
+                )
+            elif runway_days <= self.POOL_WARNING_DAYS:
+                warnings.append(
+                    f"LOW: '{category}' has {eligible} items "
+                    f"({runway_days:.0f} days remaining)"
+                )
+
+        total_eligible = sum(eligible_by_category.values())
+        return {
+            "total_eligible": total_eligible,
+            "posts_per_day": posts_per_day,
+            "categories": categories,
+            "warnings": warnings,
+        }
+
+    def format_pool_alert(self, pool_info: dict) -> str | None:
+        """Format a Telegram alert message from pool check results.
+
+        Returns None if no categories are below the warning threshold.
+        """
+        low_categories = [
+            c
+            for c in pool_info.get("categories", [])
+            if c["runway_days"] <= self.POOL_WARNING_DAYS
+        ]
+        if not low_categories:
+            return None
+
+        lines = ["\u26a0\ufe0f Content pool alert:"]
+        for cat in low_categories:
+            lines.append(
+                f"  \u2022 {cat['category']}: "
+                f"{cat['eligible']} items left "
+                f"({cat['runway_days']:.0f} days remaining)"
+            )
+        lines.append("\nAdd more content to Google Drive to keep posting.")
+        return "\n".join(lines)

--- a/tests/src/services/test_health_check.py
+++ b/tests/src/services/test_health_check.py
@@ -166,10 +166,20 @@ class TestHealthCheckService:
         mock_post = Mock(success=True)
         health_service.history_repo.get_recent_posts.return_value = [mock_post]
 
+        # Mock media pool: no active chats → healthy
+        health_service._settings_service = Mock()
+        health_service._settings_service.get_all_active_chats.return_value = []
+
         # Mock loop liveness so all loops report alive
         all_alive = {
             name: {"alive": True, "message": "OK", "expected_interval_s": 60}
-            for name in ["scheduler", "lock_cleanup", "cloud_cleanup", "media_sync", "transaction_cleanup"]
+            for name in [
+                "scheduler",
+                "lock_cleanup",
+                "cloud_cleanup",
+                "media_sync",
+                "transaction_cleanup",
+            ]
         }
         with patch("src.main.get_loop_liveness", return_value=all_alive):
             result = health_service.check_all()
@@ -181,6 +191,7 @@ class TestHealthCheckService:
         assert "queue" in result["checks"]
         assert "recent_posts" in result["checks"]
         assert "media_sync" in result["checks"]
+        assert "media_pool" in result["checks"]
         assert "loop_liveness" in result["checks"]
         assert "timestamp" in result
 
@@ -398,3 +409,163 @@ class TestHealthCheckService:
         assert result["healthy"] is False
         assert "failed" in result["message"].lower()
         assert result["source_type"] == "local"
+
+    # ==================== Media Pool Health Check Tests ====================
+
+    @pytest.fixture
+    def pool_service(self):
+        """Create HealthCheckService with mocked pool dependencies."""
+        service = HealthCheckService()
+        service.queue_repo = Mock()
+        service.history_repo = Mock()
+        service._media_repo = Mock()
+        service._settings_service = Mock()
+        return service
+
+    @pytest.fixture
+    def mock_chat(self):
+        """Create a mock chat_settings for pool tests."""
+        chat = Mock()
+        chat.id = 1
+        chat.posts_per_day = 4
+        chat.telegram_chat_id = -123
+        return chat
+
+    def test_check_media_pool_for_chat_healthy(self, pool_service, mock_chat):
+        """Pool check returns healthy when all categories have plenty of runway."""
+        pool_service._media_repo.count_eligible_by_category.return_value = {
+            "memes": 50,
+            "merch": 30,
+        }
+
+        result = pool_service.check_media_pool_for_chat(-123, chat_settings=mock_chat)
+
+        assert result["total_eligible"] == 80
+        assert result["posts_per_day"] == 4
+        assert len(result["categories"]) == 2
+        assert result["warnings"] == []
+        # 2 categories, 4 posts/day -> 2 posts/day each
+        # memes: 50/2 = 25 days, merch: 30/2 = 15 days
+        memes_cat = next(c for c in result["categories"] if c["category"] == "memes")
+        assert memes_cat["runway_days"] == 25.0
+        assert memes_cat["eligible"] == 50
+
+    def test_check_media_pool_for_chat_warning(self, pool_service, mock_chat):
+        """Pool check returns warnings when a category is running low."""
+        pool_service._media_repo.count_eligible_by_category.return_value = {
+            "memes": 10,  # 10/2 = 5 days -> warning
+            "merch": 30,  # 30/2 = 15 days -> OK
+        }
+
+        result = pool_service.check_media_pool_for_chat(-123, chat_settings=mock_chat)
+
+        assert len(result["warnings"]) == 1
+        assert "memes" in result["warnings"][0]
+        assert "LOW" in result["warnings"][0]
+
+    def test_check_media_pool_for_chat_critical(self, pool_service, mock_chat):
+        """Pool check returns critical warning when category nearly empty."""
+        pool_service._media_repo.count_eligible_by_category.return_value = {
+            "memes": 2,  # 2/2 = 1 day -> critical
+            "merch": 30,
+        }
+
+        result = pool_service.check_media_pool_for_chat(-123, chat_settings=mock_chat)
+
+        assert len(result["warnings"]) == 1
+        assert "CRITICAL" in result["warnings"][0]
+        assert "memes" in result["warnings"][0]
+
+    def test_check_media_pool_for_chat_empty(self, pool_service, mock_chat):
+        """Pool check handles no eligible media gracefully."""
+        pool_service._media_repo.count_eligible_by_category.return_value = {}
+
+        result = pool_service.check_media_pool_for_chat(-123, chat_settings=mock_chat)
+
+        assert result["total_eligible"] == 0
+        assert len(result["categories"]) == 0
+        assert "No eligible media" in result["warnings"][0]
+
+    def test_check_media_pool_for_chat_single_category(self, pool_service):
+        """Pool check works with single category (full posts_per_day allocation)."""
+        mock_chat = Mock()
+        mock_chat.id = 1
+        mock_chat.posts_per_day = 3
+        mock_chat.telegram_chat_id = -123
+
+        pool_service._media_repo.count_eligible_by_category.return_value = {
+            "memes": 15,  # 15/3 = 5 days -> warning
+        }
+
+        result = pool_service.check_media_pool_for_chat(-123, chat_settings=mock_chat)
+
+        assert len(result["categories"]) == 1
+        cat = result["categories"][0]
+        assert cat["posts_per_day_share"] == 3.0
+        assert cat["runway_days"] == 5.0
+        assert len(result["warnings"]) == 1
+
+    def test_check_media_pool_aggregated_healthy(self, pool_service, mock_chat):
+        """Aggregated pool check returns healthy across all tenants."""
+        mock_chat.posts_per_day = 2
+        pool_service._settings_service.get_all_active_chats.return_value = [mock_chat]
+        pool_service._media_repo.count_eligible_by_category.return_value = {
+            "memes": 50,
+        }
+
+        result = pool_service._check_media_pool()
+
+        assert result["healthy"] is True
+        assert ">" in result["message"]
+
+    def test_check_media_pool_aggregated_warning(self, pool_service, mock_chat):
+        """Aggregated pool check returns unhealthy when worst category is low."""
+        pool_service._settings_service.get_all_active_chats.return_value = [mock_chat]
+        pool_service._media_repo.count_eligible_by_category.return_value = {
+            "memes": 5,  # 5/4 = 1.25 days -> critical
+        }
+
+        result = pool_service._check_media_pool()
+
+        assert result["healthy"] is False
+        assert "Critical" in result["message"]
+        assert result["worst_category"]["category"] == "memes"
+
+    def test_check_media_pool_no_active_chats(self, pool_service):
+        """Aggregated pool check handles no active chats."""
+        pool_service._settings_service.get_all_active_chats.return_value = []
+
+        result = pool_service._check_media_pool()
+
+        assert result["healthy"] is True
+        assert "No active chats" in result["message"]
+
+    def test_format_pool_alert_with_warnings(self, pool_service):
+        """Format alert returns text when categories are low."""
+        pool_info = {
+            "categories": [
+                {"category": "memes", "eligible": 3, "runway_days": 1.5},
+                {"category": "merch", "eligible": 50, "runway_days": 25.0},
+            ],
+            "warnings": ["LOW: 'memes'..."],
+        }
+
+        result = pool_service.format_pool_alert(pool_info)
+
+        assert result is not None
+        assert "memes" in result
+        assert "3 items left" in result
+        assert "merch" not in result  # merch is above threshold
+
+    def test_format_pool_alert_no_warnings(self, pool_service):
+        """Format alert returns None when all categories are healthy."""
+        pool_info = {
+            "categories": [
+                {"category": "memes", "eligible": 50, "runway_days": 25.0},
+            ],
+            "warnings": [],
+        }
+
+        result = pool_service.format_pool_alert(pool_info)
+
+        assert result is None


### PR DESCRIPTION
## Summary

Closes #156. Adds media pool health monitoring that proactively alerts users when content supply runs low per category, preventing silent posting failures.

- **Health check integration** — New `_check_media_pool()` in HealthCheckService calculates days of runway per category (eligible items / posts per day share). Reports warnings at <7 days and critical at <2 days. Included in `check_all()` and the `/system-status` dashboard API.
- **Per-chat pool detail** — `check_media_pool_for_chat()` provides per-category breakdown with eligible counts, post rate share, and runway estimates.
- **Hourly Telegram alerts** — Scheduler loop checks pool health every hour and sends a formatted Telegram alert when any category drops below the warning threshold. Alerts throttled to once per 24h per chat.
- **Alert text encapsulation** — `format_pool_alert()` keeps presentation logic in the service layer, not the scheduler loop.
- **Memory cleanup** — Stale throttle entries pruned when chats become inactive.

No database schema changes required — uses existing `count_eligible_by_category()` and `posts_per_day` settings.

## Test plan

- [x] 10 new unit tests covering: healthy pool, warning threshold, critical threshold, empty pool, single category, aggregated checks, alert formatting
- [x] All 1408 existing unit tests still pass
- [x] Ruff lint + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>