### PR TITLE
feat: Posting analytics dashboard API endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Posting Analytics Dashboard (#153)
+
+- **Analytics API endpoint** — `GET /api/onboarding/analytics?chat_id=X&days=30` returns aggregated posting statistics: total posts, success rate, avg per day, method breakdown, daily counts, hourly distribution, and category performance.
+- **Repository aggregation methods** — `get_stats_by_status()`, `get_stats_by_method()`, `get_daily_counts()`, `get_hourly_distribution()`, and `get_stats_by_category()` in HistoryRepository, all with multi-tenant scoping.
+- **DashboardService orchestration** — `get_analytics()` combines all aggregations into a single response with execution tracking.
+
 ### Added — Loop Liveness Tracking (#134)
 
 - **Heartbeat tracking for all background loops** — Each loop (scheduler, lock_cleanup, cloud_cleanup, media_sync, transaction_cleanup) records a timestamp on every tick. The health check reports loops as stale if they haven't ticked in 2x their expected interval. Visible via `check-health` CLI and `/status` health checks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Category Performance Insights (#154)
+
+- **Category analytics API endpoint** — `GET /api/onboarding/analytics/categories?chat_id=X&days=30` returns per-category posting performance enriched with configured ratios from category_post_case_mix. Shows actual vs target ratio, skip/reject rates, and success rate per category.
+- **DashboardService.get_category_analytics()** — Combines posting history stats with configured category mix ratios for performance comparison.
+
 ### Added — Posting Analytics Dashboard (#153)
 
 - **Analytics API endpoint** — `GET /api/onboarding/analytics?chat_id=X&days=30` returns aggregated posting statistics: total posts, success rate, avg per day, method breakdown, daily counts, hourly distribution, and category performance.

--- a/src/api/routes/onboarding/dashboard.py
+++ b/src/api/routes/onboarding/dashboard.py
@@ -84,6 +84,19 @@ async def onboarding_accounts(
         return {"accounts": items, "active_account_id": active_account_id}
 
 
+@router.get("/analytics")
+async def onboarding_analytics(
+    init_data: str,
+    chat_id: int,
+    days: int = Query(default=30, ge=1, le=365),
+):
+    """Return aggregated posting analytics for the dashboard."""
+    _validate_request(init_data, chat_id)
+
+    with DashboardService() as service:
+        return service.get_analytics(chat_id, days=days)
+
+
 @router.get("/system-status")
 async def onboarding_system_status(
     init_data: str,

--- a/src/api/routes/onboarding/dashboard.py
+++ b/src/api/routes/onboarding/dashboard.py
@@ -84,6 +84,19 @@ async def onboarding_accounts(
         return {"accounts": items, "active_account_id": active_account_id}
 
 
+@router.get("/analytics/categories")
+async def onboarding_analytics_categories(
+    init_data: str,
+    chat_id: int,
+    days: int = Query(default=30, ge=1, le=365),
+):
+    """Return per-category performance with configured vs actual ratios."""
+    _validate_request(init_data, chat_id)
+
+    with DashboardService() as service:
+        return service.get_category_analytics(chat_id, days=days)
+
+
 @router.get("/analytics")
 async def onboarding_analytics(
     init_data: str,

--- a/src/repositories/history_repository.py
+++ b/src/repositories/history_repository.py
@@ -305,17 +305,18 @@ class HistoryRepository(BaseRepository):
         from src.models.media_item import MediaItem
 
         since = datetime.utcnow() - timedelta(days=days)
+        coalesced_category = func.coalesce(MediaItem.category, "uncategorized")
         rows = (
             self._tenant_query(PostingHistory, chat_settings_id)
             .outerjoin(MediaItem, PostingHistory.media_item_id == MediaItem.id)
             .with_entities(
-                func.coalesce(MediaItem.category, "uncategorized"),
+                coalesced_category,
                 PostingHistory.status,
                 func.count(PostingHistory.id),
             )
             .filter(PostingHistory.posted_at >= since)
-            .group_by(MediaItem.category, PostingHistory.status)
-            .order_by(MediaItem.category)
+            .group_by(coalesced_category, PostingHistory.status)
+            .order_by(coalesced_category)
             .all()
         )
         self.end_read_transaction()

--- a/src/repositories/history_repository.py
+++ b/src/repositories/history_repository.py
@@ -195,3 +195,143 @@ class HistoryRepository(BaseRepository):
         )
         self.end_read_transaction()
         return result
+
+    # ------------------------------------------------------------------
+    # Analytics aggregations
+    # ------------------------------------------------------------------
+
+    def get_stats_by_status(
+        self, days: int = 30, chat_settings_id: Optional[str] = None
+    ) -> dict:
+        """Count posts grouped by status within the given time window.
+
+        Returns: {"posted": N, "skipped": N, "rejected": N, "failed": N}
+        """
+        since = datetime.utcnow() - timedelta(days=days)
+        rows = (
+            self._tenant_query(PostingHistory, chat_settings_id)
+            .with_entities(PostingHistory.status, func.count(PostingHistory.id))
+            .filter(PostingHistory.posted_at >= since)
+            .group_by(PostingHistory.status)
+            .all()
+        )
+        self.end_read_transaction()
+        return {status: count for status, count in rows}
+
+    def get_stats_by_method(
+        self, days: int = 30, chat_settings_id: Optional[str] = None
+    ) -> dict:
+        """Count successful posts grouped by posting method.
+
+        Returns: {"instagram_api": N, "telegram_manual": N}
+        """
+        since = datetime.utcnow() - timedelta(days=days)
+        rows = (
+            self._tenant_query(PostingHistory, chat_settings_id)
+            .with_entities(PostingHistory.posting_method, func.count(PostingHistory.id))
+            .filter(PostingHistory.posted_at >= since, PostingHistory.success)
+            .group_by(PostingHistory.posting_method)
+            .all()
+        )
+        self.end_read_transaction()
+        return {method or "unknown": count for method, count in rows}
+
+    def get_daily_counts(
+        self, days: int = 30, chat_settings_id: Optional[str] = None
+    ) -> list:
+        """Count posts per day grouped by status.
+
+        Returns list of {"date": "YYYY-MM-DD", "posted": N, "skipped": N, ...}
+        """
+        from sqlalchemy import cast, Date
+
+        since = datetime.utcnow() - timedelta(days=days)
+        rows = (
+            self._tenant_query(PostingHistory, chat_settings_id)
+            .with_entities(
+                cast(PostingHistory.posted_at, Date).label("day"),
+                PostingHistory.status,
+                func.count(PostingHistory.id),
+            )
+            .filter(PostingHistory.posted_at >= since)
+            .group_by("day", PostingHistory.status)
+            .order_by("day")
+            .all()
+        )
+        self.end_read_transaction()
+
+        # Pivot into {date: {status: count}} then flatten
+        by_day: dict = {}
+        for day, status, count in rows:
+            day_str = day.isoformat()
+            if day_str not in by_day:
+                by_day[day_str] = {"date": day_str}
+            by_day[day_str][status] = count
+
+        return list(by_day.values())
+
+    def get_hourly_distribution(
+        self, days: int = 30, chat_settings_id: Optional[str] = None
+    ) -> list:
+        """Count successful posts by hour of day.
+
+        Returns list of {"hour": 0-23, "count": N}
+        """
+        from sqlalchemy import extract
+
+        since = datetime.utcnow() - timedelta(days=days)
+        rows = (
+            self._tenant_query(PostingHistory, chat_settings_id)
+            .with_entities(
+                extract("hour", PostingHistory.posted_at).label("hour"),
+                func.count(PostingHistory.id),
+            )
+            .filter(PostingHistory.posted_at >= since, PostingHistory.success)
+            .group_by("hour")
+            .order_by("hour")
+            .all()
+        )
+        self.end_read_transaction()
+        return [{"hour": int(hour), "count": count} for hour, count in rows]
+
+    def get_stats_by_category(
+        self, days: int = 30, chat_settings_id: Optional[str] = None
+    ) -> list:
+        """Count posts grouped by media category and status.
+
+        Joins with media_items to get category.
+        Returns list of {"category": str, "posted": N, "skipped": N, ...}
+        """
+        from src.models.media_item import MediaItem
+
+        since = datetime.utcnow() - timedelta(days=days)
+        rows = (
+            self._tenant_query(PostingHistory, chat_settings_id)
+            .outerjoin(MediaItem, PostingHistory.media_item_id == MediaItem.id)
+            .with_entities(
+                func.coalesce(MediaItem.category, "uncategorized"),
+                PostingHistory.status,
+                func.count(PostingHistory.id),
+            )
+            .filter(PostingHistory.posted_at >= since)
+            .group_by(MediaItem.category, PostingHistory.status)
+            .order_by(MediaItem.category)
+            .all()
+        )
+        self.end_read_transaction()
+
+        # Pivot into {category: {status: count}}
+        by_category: dict = {}
+        for category, status, count in rows:
+            if category not in by_category:
+                by_category[category] = {"category": category}
+            by_category[category][status] = count
+
+        # Add total and success_rate
+        for cat_data in by_category.values():
+            total = sum(v for k, v in cat_data.items() if k != "category")
+            posted = cat_data.get("posted", 0)
+            cat_data["total"] = total
+            cat_data["success_rate"] = round(posted / total, 2) if total else 0
+
+        return list(by_category.values())

--- a/src/services/core/dashboard_service.py
+++ b/src/services/core/dashboard_service.py
@@ -157,7 +157,6 @@ class DashboardService(BaseService):
 
             total = sum(status_counts.values())
             posted = status_counts.get("posted", 0)
-            num_days = max(len(daily_counts), 1)
 
             result = {
                 "summary": {
@@ -167,7 +166,7 @@ class DashboardService(BaseService):
                     "rejected": status_counts.get("rejected", 0),
                     "failed": status_counts.get("failed", 0),
                     "success_rate": round(posted / total, 2) if total else 0,
-                    "avg_per_day": round(total / num_days, 1),
+                    "avg_per_day": round(total / days, 1),
                 },
                 "method_breakdown": method_counts,
                 "daily_counts": daily_counts,

--- a/src/services/core/dashboard_service.py
+++ b/src/services/core/dashboard_service.py
@@ -7,6 +7,7 @@ from src.services.core.settings_service import SettingsService
 from src.repositories.history_repository import HistoryRepository
 from src.repositories.media_repository import MediaRepository
 from src.repositories.queue_repository import QueueRepository
+from src.repositories.category_mix_repository import CategoryMixRepository
 
 
 class DashboardService(BaseService):
@@ -23,6 +24,7 @@ class DashboardService(BaseService):
         self.queue_repo = QueueRepository()
         self.history_repo = HistoryRepository()
         self.media_repo = MediaRepository()
+        self.category_mix_repo = CategoryMixRepository()
 
     def _resolve_chat_settings_id(self, telegram_chat_id: int) -> str:
         chat_settings = self.settings_service.get_settings(telegram_chat_id)
@@ -176,6 +178,59 @@ class DashboardService(BaseService):
 
             self.set_result_summary(run_id, {"total_posts": total, "days": days})
             return result
+
+    def get_category_analytics(self, telegram_chat_id: int, days: int = 30) -> dict:
+        """Return per-category performance with configured vs actual ratios.
+
+        Enriches posting history stats with the configured category mix
+        ratios, showing how actual posting patterns compare to the target.
+        """
+        with self.track_execution(
+            "get_category_analytics",
+            input_params={"telegram_chat_id": telegram_chat_id, "days": days},
+        ) as run_id:
+            chat_settings_id = self._resolve_chat_settings_id(telegram_chat_id)
+
+            # Posting performance by category
+            category_stats = self.history_repo.get_stats_by_category(
+                days=days, chat_settings_id=chat_settings_id
+            )
+
+            # Configured ratios from category_post_case_mix
+            configured_ratios = self.category_mix_repo.get_current_mix_as_dict(
+                chat_settings_id=chat_settings_id
+            )
+
+            # Compute actual ratios and enrich with configured targets
+            total_all = sum(c.get("total", 0) for c in category_stats)
+            categories = []
+            for cat_data in category_stats:
+                name = cat_data["category"]
+                total = cat_data.get("total", 0)
+                actual_ratio = round(total / total_all, 2) if total_all else 0
+                configured = configured_ratios.get(name)
+
+                entry = {
+                    "category": name,
+                    "posted": cat_data.get("posted", 0),
+                    "skipped": cat_data.get("skipped", 0),
+                    "rejected": cat_data.get("rejected", 0),
+                    "failed": cat_data.get("failed", 0),
+                    "total": total,
+                    "success_rate": cat_data.get("success_rate", 0),
+                    "actual_ratio": actual_ratio,
+                    "configured_ratio": float(configured) if configured else None,
+                }
+                categories.append(entry)
+
+            self.set_result_summary(
+                run_id, {"categories": len(categories), "days": days}
+            )
+            return {
+                "categories": categories,
+                "total_posts": total_all,
+                "days": days,
+            }
 
     def get_pending_queue_items(self, chat_settings_id: Optional[str] = None) -> list:
         """Return pending queue items with media details.

--- a/src/services/core/dashboard_service.py
+++ b/src/services/core/dashboard_service.py
@@ -124,6 +124,59 @@ class DashboardService(BaseService):
             "categories": categories,
         }
 
+    def get_analytics(self, telegram_chat_id: int, days: int = 30) -> dict:
+        """Return aggregated posting analytics for the dashboard.
+
+        Combines status breakdown, method breakdown, daily counts,
+        hourly distribution, and category performance into a single
+        response.
+        """
+        with self.track_execution(
+            "get_analytics",
+            input_params={"telegram_chat_id": telegram_chat_id, "days": days},
+        ) as run_id:
+            chat_settings_id = self._resolve_chat_settings_id(telegram_chat_id)
+
+            status_counts = self.history_repo.get_stats_by_status(
+                days=days, chat_settings_id=chat_settings_id
+            )
+            method_counts = self.history_repo.get_stats_by_method(
+                days=days, chat_settings_id=chat_settings_id
+            )
+            daily_counts = self.history_repo.get_daily_counts(
+                days=days, chat_settings_id=chat_settings_id
+            )
+            hourly_dist = self.history_repo.get_hourly_distribution(
+                days=days, chat_settings_id=chat_settings_id
+            )
+            category_stats = self.history_repo.get_stats_by_category(
+                days=days, chat_settings_id=chat_settings_id
+            )
+
+            total = sum(status_counts.values())
+            posted = status_counts.get("posted", 0)
+            num_days = max(len(daily_counts), 1)
+
+            result = {
+                "summary": {
+                    "total_posts": total,
+                    "posted": posted,
+                    "skipped": status_counts.get("skipped", 0),
+                    "rejected": status_counts.get("rejected", 0),
+                    "failed": status_counts.get("failed", 0),
+                    "success_rate": round(posted / total, 2) if total else 0,
+                    "avg_per_day": round(total / num_days, 1),
+                },
+                "method_breakdown": method_counts,
+                "daily_counts": daily_counts,
+                "hourly_distribution": hourly_dist,
+                "category_breakdown": category_stats,
+                "days": days,
+            }
+
+            self.set_result_summary(run_id, {"total_posts": total, "days": days})
+            return result
+
     def get_pending_queue_items(self, chat_settings_id: Optional[str] = None) -> list:
         """Return pending queue items with media details.
 

--- a/tests/src/repositories/test_history_repository.py
+++ b/tests/src/repositories/test_history_repository.py
@@ -322,3 +322,153 @@ class TestGetByQueueItemId:
         result = history_repo.get_by_queue_item_id("nonexistent")
 
         assert result is None
+
+
+@pytest.mark.unit
+class TestAnalyticsAggregations:
+    """Tests for analytics aggregation methods."""
+
+    def _make_chainable_query(self, mock_db):
+        """Set up a fully chainable mock query."""
+        q = mock_db.query.return_value
+        q.with_entities.return_value = q
+        q.filter.return_value = q
+        q.group_by.return_value = q
+        q.order_by.return_value = q
+        q.outerjoin.return_value = q
+        q.scalar.return_value = 0
+        return q
+
+    def test_get_stats_by_status(self, history_repo, mock_db):
+        """Returns counts grouped by status."""
+        q = self._make_chainable_query(mock_db)
+        q.all.return_value = [("posted", 80), ("skipped", 10), ("rejected", 5)]
+
+        result = history_repo.get_stats_by_status(days=30)
+
+        assert result == {"posted": 80, "skipped": 10, "rejected": 5}
+
+    def test_get_stats_by_status_empty(self, history_repo, mock_db):
+        """Returns empty dict when no history."""
+        q = self._make_chainable_query(mock_db)
+        q.all.return_value = []
+
+        result = history_repo.get_stats_by_status(days=7)
+
+        assert result == {}
+
+    def test_get_stats_by_method(self, history_repo, mock_db):
+        """Returns successful post counts grouped by method."""
+        q = self._make_chainable_query(mock_db)
+        q.all.return_value = [("instagram_api", 60), ("telegram_manual", 20)]
+
+        result = history_repo.get_stats_by_method(days=30)
+
+        assert result == {"instagram_api": 60, "telegram_manual": 20}
+
+    def test_get_stats_by_method_null_method(self, history_repo, mock_db):
+        """Null posting_method is reported as 'unknown'."""
+        q = self._make_chainable_query(mock_db)
+        q.all.return_value = [(None, 5)]
+
+        result = history_repo.get_stats_by_method(days=30)
+
+        assert result == {"unknown": 5}
+
+    def test_get_daily_counts(self, history_repo, mock_db):
+        """Returns daily counts pivoted by status."""
+        from datetime import date
+
+        q = self._make_chainable_query(mock_db)
+        q.all.return_value = [
+            (date(2026, 4, 10), "posted", 4),
+            (date(2026, 4, 10), "skipped", 1),
+            (date(2026, 4, 11), "posted", 5),
+        ]
+
+        result = history_repo.get_daily_counts(days=30)
+
+        assert len(result) == 2
+        day1 = result[0]
+        assert day1["date"] == "2026-04-10"
+        assert day1["posted"] == 4
+        assert day1["skipped"] == 1
+        day2 = result[1]
+        assert day2["date"] == "2026-04-11"
+        assert day2["posted"] == 5
+        assert "skipped" not in day2
+
+    def test_get_daily_counts_empty(self, history_repo, mock_db):
+        """Returns empty list when no history."""
+        q = self._make_chainable_query(mock_db)
+        q.all.return_value = []
+
+        result = history_repo.get_daily_counts(days=7)
+
+        assert result == []
+
+    def test_get_hourly_distribution(self, history_repo, mock_db):
+        """Returns successful post counts by hour."""
+        q = self._make_chainable_query(mock_db)
+        q.all.return_value = [(10, 15), (14, 20), (18, 8)]
+
+        result = history_repo.get_hourly_distribution(days=30)
+
+        assert len(result) == 3
+        assert result[0] == {"hour": 10, "count": 15}
+        assert result[1] == {"hour": 14, "count": 20}
+        assert result[2] == {"hour": 18, "count": 8}
+
+    def test_get_hourly_distribution_empty(self, history_repo, mock_db):
+        """Returns empty list when no successful posts."""
+        q = self._make_chainable_query(mock_db)
+        q.all.return_value = []
+
+        result = history_repo.get_hourly_distribution(days=7)
+
+        assert result == []
+
+    def test_get_stats_by_category(self, history_repo, mock_db):
+        """Returns category stats with totals and success rates."""
+        q = self._make_chainable_query(mock_db)
+        q.all.return_value = [
+            ("memes", "posted", 70),
+            ("memes", "skipped", 5),
+            ("memes", "rejected", 3),
+            ("merch", "posted", 18),
+            ("merch", "skipped", 2),
+        ]
+
+        result = history_repo.get_stats_by_category(days=30)
+
+        assert len(result) == 2
+        memes = next(c for c in result if c["category"] == "memes")
+        assert memes["posted"] == 70
+        assert memes["skipped"] == 5
+        assert memes["rejected"] == 3
+        assert memes["total"] == 78
+        assert memes["success_rate"] == 0.9  # 70/78
+
+        merch = next(c for c in result if c["category"] == "merch")
+        assert merch["posted"] == 18
+        assert merch["total"] == 20
+        assert merch["success_rate"] == 0.9
+
+    def test_get_stats_by_category_empty(self, history_repo, mock_db):
+        """Returns empty list when no history."""
+        q = self._make_chainable_query(mock_db)
+        q.all.return_value = []
+
+        result = history_repo.get_stats_by_category(days=7)
+
+        assert result == []
+
+    def test_get_stats_by_category_zero_total(self, history_repo, mock_db):
+        """Handles zero-total edge case without division error."""
+        q = self._make_chainable_query(mock_db)
+        # Unlikely but defensive: a category with no status counts
+        q.all.return_value = []
+
+        result = history_repo.get_stats_by_category(days=30)
+
+        assert result == []

--- a/tests/src/services/test_dashboard_service.py
+++ b/tests/src/services/test_dashboard_service.py
@@ -347,3 +347,95 @@ class TestGetAnalytics:
         service.history_repo.get_daily_counts.assert_called_once_with(
             days=7, chat_settings_id="tenant-uuid-1"
         )
+
+
+@pytest.mark.unit
+class TestGetCategoryAnalytics:
+    """Tests for get_category_analytics with configured vs actual ratios."""
+
+    def _setup_service(self):
+        """Create DashboardService with mocked dependencies."""
+        with patch.object(DashboardService, "__init__", lambda self: None):
+            service = DashboardService()
+            service.settings_service = MagicMock()
+            service.queue_repo = MagicMock()
+            service.history_repo = MagicMock()
+            service.media_repo = MagicMock()
+            service.category_mix_repo = MagicMock()
+            service.service_run_repo = MagicMock()
+            service.service_name = "DashboardService"
+
+            mock_settings = Mock(id="tenant-uuid-1")
+            service.settings_service.get_settings.return_value = mock_settings
+            return service
+
+    def test_enriches_with_configured_ratios(self):
+        """Category analytics includes configured vs actual ratios."""
+        service = self._setup_service()
+
+        service.history_repo.get_stats_by_category.return_value = [
+            {
+                "category": "memes",
+                "posted": 70,
+                "skipped": 5,
+                "rejected": 3,
+                "total": 78,
+                "success_rate": 0.9,
+            },
+            {
+                "category": "merch",
+                "posted": 18,
+                "skipped": 2,
+                "rejected": 0,
+                "total": 20,
+                "success_rate": 0.9,
+            },
+        ]
+        from decimal import Decimal
+
+        service.category_mix_repo.get_current_mix_as_dict.return_value = {
+            "memes": Decimal("0.70"),
+            "merch": Decimal("0.30"),
+        }
+
+        result = service.get_category_analytics(telegram_chat_id=123, days=30)
+
+        assert result["total_posts"] == 98
+        assert len(result["categories"]) == 2
+
+        memes = next(c for c in result["categories"] if c["category"] == "memes")
+        assert memes["posted"] == 70
+        assert memes["skipped"] == 5
+        assert memes["rejected"] == 3
+        assert memes["success_rate"] == 0.9
+        assert memes["actual_ratio"] == 0.8  # 78/98
+        assert memes["configured_ratio"] == 0.7
+
+        merch = next(c for c in result["categories"] if c["category"] == "merch")
+        assert merch["actual_ratio"] == 0.2  # 20/98
+        assert merch["configured_ratio"] == 0.3
+
+    def test_handles_missing_configured_ratio(self):
+        """Categories without a configured ratio get None."""
+        service = self._setup_service()
+
+        service.history_repo.get_stats_by_category.return_value = [
+            {"category": "memes", "posted": 10, "total": 10, "success_rate": 1.0},
+        ]
+        service.category_mix_repo.get_current_mix_as_dict.return_value = {}
+
+        result = service.get_category_analytics(telegram_chat_id=123)
+
+        assert result["categories"][0]["configured_ratio"] is None
+
+    def test_handles_empty_history(self):
+        """Category analytics handles no posting history gracefully."""
+        service = self._setup_service()
+
+        service.history_repo.get_stats_by_category.return_value = []
+        service.category_mix_repo.get_current_mix_as_dict.return_value = {}
+
+        result = service.get_category_analytics(telegram_chat_id=123)
+
+        assert result["total_posts"] == 0
+        assert result["categories"] == []

--- a/tests/src/services/test_dashboard_service.py
+++ b/tests/src/services/test_dashboard_service.py
@@ -302,7 +302,7 @@ class TestGetAnalytics:
         assert result["summary"]["total_posts"] == 100
         assert result["summary"]["posted"] == 80
         assert result["summary"]["success_rate"] == 0.8
-        assert result["summary"]["avg_per_day"] == 50.0  # 100 / 2 days
+        assert result["summary"]["avg_per_day"] == 3.3  # 100 / 30 days
         assert result["method_breakdown"]["instagram_api"] == 60
         assert len(result["daily_counts"]) == 2
         assert len(result["hourly_distribution"]) == 2

--- a/tests/src/services/test_dashboard_service.py
+++ b/tests/src/services/test_dashboard_service.py
@@ -244,3 +244,106 @@ class TestGetPendingQueueItems:
         result = dashboard_service.get_pending_queue_items()
 
         assert result == []
+
+
+@pytest.mark.unit
+class TestGetAnalytics:
+    """Tests for get_analytics aggregation."""
+
+    def _setup_analytics_service(self):
+        """Create DashboardService with mocked dependencies for analytics."""
+        with patch.object(DashboardService, "__init__", lambda self: None):
+            service = DashboardService()
+            service.settings_service = MagicMock()
+            service.queue_repo = MagicMock()
+            service.history_repo = MagicMock()
+            service.media_repo = MagicMock()
+            service.service_run_repo = MagicMock()
+            service.service_name = "DashboardService"
+
+            mock_settings = Mock(id="tenant-uuid-1")
+            service.settings_service.get_settings.return_value = mock_settings
+            return service
+
+    def test_returns_complete_analytics(self):
+        """get_analytics returns all expected sections."""
+        service = self._setup_analytics_service()
+
+        service.history_repo.get_stats_by_status.return_value = {
+            "posted": 80,
+            "skipped": 10,
+            "rejected": 5,
+            "failed": 5,
+        }
+        service.history_repo.get_stats_by_method.return_value = {
+            "instagram_api": 60,
+            "telegram_manual": 20,
+        }
+        service.history_repo.get_daily_counts.return_value = [
+            {"date": "2026-04-10", "posted": 4, "skipped": 1},
+            {"date": "2026-04-11", "posted": 5},
+        ]
+        service.history_repo.get_hourly_distribution.return_value = [
+            {"hour": 10, "count": 15},
+            {"hour": 14, "count": 20},
+        ]
+        service.history_repo.get_stats_by_category.return_value = [
+            {
+                "category": "memes",
+                "posted": 50,
+                "skipped": 8,
+                "total": 58,
+                "success_rate": 0.86,
+            },
+        ]
+
+        result = service.get_analytics(telegram_chat_id=123, days=30)
+
+        assert result["summary"]["total_posts"] == 100
+        assert result["summary"]["posted"] == 80
+        assert result["summary"]["success_rate"] == 0.8
+        assert result["summary"]["avg_per_day"] == 50.0  # 100 / 2 days
+        assert result["method_breakdown"]["instagram_api"] == 60
+        assert len(result["daily_counts"]) == 2
+        assert len(result["hourly_distribution"]) == 2
+        assert len(result["category_breakdown"]) == 1
+        assert result["days"] == 30
+
+    def test_handles_empty_history(self):
+        """get_analytics handles no posting history gracefully."""
+        service = self._setup_analytics_service()
+
+        service.history_repo.get_stats_by_status.return_value = {}
+        service.history_repo.get_stats_by_method.return_value = {}
+        service.history_repo.get_daily_counts.return_value = []
+        service.history_repo.get_hourly_distribution.return_value = []
+        service.history_repo.get_stats_by_category.return_value = []
+
+        result = service.get_analytics(telegram_chat_id=123)
+
+        assert result["summary"]["total_posts"] == 0
+        assert result["summary"]["success_rate"] == 0
+        assert result["summary"]["avg_per_day"] == 0
+        assert result["daily_counts"] == []
+
+    def test_passes_days_and_tenant(self):
+        """get_analytics passes days and chat_settings_id to all repo methods."""
+        service = self._setup_analytics_service()
+
+        service.history_repo.get_stats_by_status.return_value = {}
+        service.history_repo.get_stats_by_method.return_value = {}
+        service.history_repo.get_daily_counts.return_value = []
+        service.history_repo.get_hourly_distribution.return_value = []
+        service.history_repo.get_stats_by_category.return_value = []
+
+        service.get_analytics(telegram_chat_id=123, days=7)
+
+        service.history_repo.get_stats_by_status.assert_called_once_with(
+            days=7, chat_settings_id="tenant-uuid-1"
+        )
+        service.history_repo.get_stats_by_method.assert_called_once_with(
+            days=7, chat_settings_id="tenant-uuid-1"
+        )
+        service.history_repo.get_daily_counts.assert_called_once_with(
+            days=7, chat_settings_id="tenant-uuid-1"
+        )


### PR DESCRIPTION
## Summary

Closes #153. Surfaces existing posting_history data as aggregated analytics, implementing the first component of the Content Intelligence compound play (#150).

- **5 new HistoryRepository methods** — `get_stats_by_status()`, `get_stats_by_method()`, `get_daily_counts()`, `get_hourly_distribution()`, `get_stats_by_category()`. All multi-tenant scoped, using SQL GROUP BY aggregations (no N+1 queries).
- **DashboardService.get_analytics()** — Orchestrates all 5 repo methods into a single response with summary stats (total, success rate, avg/day), method breakdown, daily time series, hourly distribution, and category performance.
- **API endpoint** — `GET /api/onboarding/analytics?chat_id=X&days=30` with configurable time window (1-365 days).

No database schema changes — uses existing posting_history + media_items tables.

## Test plan

- [x] 3 new unit tests: complete analytics response, empty history handling, parameter passthrough
- [x] All 1401 existing unit tests still pass
- [x] Ruff lint + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>