### PR TITLE
feat: Category performance insights with configured vs actual ratios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Category Performance Insights (#154)
+
+- **Category analytics API endpoint** — `GET /api/onboarding/analytics/categories?chat_id=X&days=30` returns per-category posting performance enriched with configured ratios from category_post_case_mix. Shows actual vs target ratio, skip/reject rates, and success rate per category.
+- **DashboardService.get_category_analytics()** — Combines posting history stats with configured category mix ratios for performance comparison.
+
 ### Added — Posting Analytics Dashboard (#153)
 
 - **Analytics API endpoint** — `GET /api/onboarding/analytics?chat_id=X&days=30` returns aggregated posting statistics: total posts, success rate, avg per day, method breakdown, daily counts, hourly distribution, and category performance.

--- a/src/api/routes/onboarding/dashboard.py
+++ b/src/api/routes/onboarding/dashboard.py
@@ -84,6 +84,19 @@ async def onboarding_accounts(
         return {"accounts": items, "active_account_id": active_account_id}
 
 
+@router.get("/analytics/categories")
+async def onboarding_analytics_categories(
+    init_data: str,
+    chat_id: int,
+    days: int = Query(default=30, ge=1, le=365),
+):
+    """Return per-category performance with configured vs actual ratios."""
+    _validate_request(init_data, chat_id)
+
+    with DashboardService() as service:
+        return service.get_category_analytics(chat_id, days=days)
+
+
 @router.get("/analytics")
 async def onboarding_analytics(
     init_data: str,

--- a/src/services/core/dashboard_service.py
+++ b/src/services/core/dashboard_service.py
@@ -7,6 +7,7 @@ from src.services.core.settings_service import SettingsService
 from src.repositories.history_repository import HistoryRepository
 from src.repositories.media_repository import MediaRepository
 from src.repositories.queue_repository import QueueRepository
+from src.repositories.category_mix_repository import CategoryMixRepository
 
 
 class DashboardService(BaseService):
@@ -23,6 +24,7 @@ class DashboardService(BaseService):
         self.queue_repo = QueueRepository()
         self.history_repo = HistoryRepository()
         self.media_repo = MediaRepository()
+        self.category_mix_repo = CategoryMixRepository()
 
     def _resolve_chat_settings_id(self, telegram_chat_id: int) -> str:
         chat_settings = self.settings_service.get_settings(telegram_chat_id)
@@ -176,6 +178,59 @@ class DashboardService(BaseService):
 
             self.set_result_summary(run_id, {"total_posts": total, "days": days})
             return result
+
+    def get_category_analytics(self, telegram_chat_id: int, days: int = 30) -> dict:
+        """Return per-category performance with configured vs actual ratios.
+
+        Enriches posting history stats with the configured category mix
+        ratios, showing how actual posting patterns compare to the target.
+        """
+        with self.track_execution(
+            "get_category_analytics",
+            input_params={"telegram_chat_id": telegram_chat_id, "days": days},
+        ) as run_id:
+            chat_settings_id = self._resolve_chat_settings_id(telegram_chat_id)
+
+            # Posting performance by category
+            category_stats = self.history_repo.get_stats_by_category(
+                days=days, chat_settings_id=chat_settings_id
+            )
+
+            # Configured ratios from category_post_case_mix
+            configured_ratios = self.category_mix_repo.get_current_mix_as_dict(
+                chat_settings_id=chat_settings_id
+            )
+
+            # Compute actual ratios and enrich with configured targets
+            total_all = sum(c.get("total", 0) for c in category_stats)
+            categories = []
+            for cat_data in category_stats:
+                name = cat_data["category"]
+                total = cat_data.get("total", 0)
+                actual_ratio = round(total / total_all, 2) if total_all else 0
+                configured = configured_ratios.get(name)
+
+                entry = {
+                    "category": name,
+                    "posted": cat_data.get("posted", 0),
+                    "skipped": cat_data.get("skipped", 0),
+                    "rejected": cat_data.get("rejected", 0),
+                    "failed": cat_data.get("failed", 0),
+                    "total": total,
+                    "success_rate": cat_data.get("success_rate", 0),
+                    "actual_ratio": actual_ratio,
+                    "configured_ratio": float(configured) if configured else None,
+                }
+                categories.append(entry)
+
+            self.set_result_summary(
+                run_id, {"categories": len(categories), "days": days}
+            )
+            return {
+                "categories": categories,
+                "total_posts": total_all,
+                "days": days,
+            }
 
     def get_pending_queue_items(self, chat_settings_id: Optional[str] = None) -> list:
         """Return pending queue items with media details.

--- a/tests/src/services/test_dashboard_service.py
+++ b/tests/src/services/test_dashboard_service.py
@@ -347,3 +347,95 @@ class TestGetAnalytics:
         service.history_repo.get_daily_counts.assert_called_once_with(
             days=7, chat_settings_id="tenant-uuid-1"
         )
+
+
+@pytest.mark.unit
+class TestGetCategoryAnalytics:
+    """Tests for get_category_analytics with configured vs actual ratios."""
+
+    def _setup_service(self):
+        """Create DashboardService with mocked dependencies."""
+        with patch.object(DashboardService, "__init__", lambda self: None):
+            service = DashboardService()
+            service.settings_service = MagicMock()
+            service.queue_repo = MagicMock()
+            service.history_repo = MagicMock()
+            service.media_repo = MagicMock()
+            service.category_mix_repo = MagicMock()
+            service.service_run_repo = MagicMock()
+            service.service_name = "DashboardService"
+
+            mock_settings = Mock(id="tenant-uuid-1")
+            service.settings_service.get_settings.return_value = mock_settings
+            return service
+
+    def test_enriches_with_configured_ratios(self):
+        """Category analytics includes configured vs actual ratios."""
+        service = self._setup_service()
+
+        service.history_repo.get_stats_by_category.return_value = [
+            {
+                "category": "memes",
+                "posted": 70,
+                "skipped": 5,
+                "rejected": 3,
+                "total": 78,
+                "success_rate": 0.9,
+            },
+            {
+                "category": "merch",
+                "posted": 18,
+                "skipped": 2,
+                "rejected": 0,
+                "total": 20,
+                "success_rate": 0.9,
+            },
+        ]
+        from decimal import Decimal
+
+        service.category_mix_repo.get_current_mix_as_dict.return_value = {
+            "memes": Decimal("0.70"),
+            "merch": Decimal("0.30"),
+        }
+
+        result = service.get_category_analytics(telegram_chat_id=123, days=30)
+
+        assert result["total_posts"] == 98
+        assert len(result["categories"]) == 2
+
+        memes = next(c for c in result["categories"] if c["category"] == "memes")
+        assert memes["posted"] == 70
+        assert memes["skipped"] == 5
+        assert memes["rejected"] == 3
+        assert memes["success_rate"] == 0.9
+        assert memes["actual_ratio"] == 0.8  # 78/98
+        assert memes["configured_ratio"] == 0.7
+
+        merch = next(c for c in result["categories"] if c["category"] == "merch")
+        assert merch["actual_ratio"] == 0.2  # 20/98
+        assert merch["configured_ratio"] == 0.3
+
+    def test_handles_missing_configured_ratio(self):
+        """Categories without a configured ratio get None."""
+        service = self._setup_service()
+
+        service.history_repo.get_stats_by_category.return_value = [
+            {"category": "memes", "posted": 10, "total": 10, "success_rate": 1.0},
+        ]
+        service.category_mix_repo.get_current_mix_as_dict.return_value = {}
+
+        result = service.get_category_analytics(telegram_chat_id=123)
+
+        assert result["categories"][0]["configured_ratio"] is None
+
+    def test_handles_empty_history(self):
+        """Category analytics handles no posting history gracefully."""
+        service = self._setup_service()
+
+        service.history_repo.get_stats_by_category.return_value = []
+        service.category_mix_repo.get_current_mix_as_dict.return_value = {}
+
+        result = service.get_category_analytics(telegram_chat_id=123)
+
+        assert result["total_posts"] == 0
+        assert result["categories"] == []


### PR DESCRIPTION
## Summary

Closes #154. Adds per-category analytics that compare actual posting patterns against configured ratios from category_post_case_mix. Part of the Content Intelligence compound play (#150).

**Base:** `feature/posting-analytics-dashboard` (#163) — merge that first.

- **`GET /api/onboarding/analytics/categories`** — Returns per-category breakdown with: posted/skipped/rejected/failed counts, success rate, actual posting ratio, and configured target ratio.
- **DashboardService.get_category_analytics()** — Enriches posting history stats with category_post_case_mix ratios. Shows where actual distribution diverges from configured targets.

No database schema changes — uses existing posting_history + media_items + category_post_case_mix tables.

## Test plan

- [x] 3 new unit tests: ratio enrichment, missing config handling, empty history
- [x] All 1404 existing unit tests still pass
- [x] Ruff lint + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>