### PR TITLE
feat: Google Drive token health alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Google Drive Token Health Alerts (#157)
+
+- **Token health check** — `check_gdrive_token_for_chat()` in HealthCheckService checks Google Drive OAuth token expiry per tenant. Warns at <7 days, critical at <1 day, reports expired tokens.
+- **Tenant-scoped token health** — `check_token_health_for_chat()` added to TokenRefreshService for querying tokens by `chat_settings_id` (Google Drive) instead of `instagram_account_id` (Instagram).
+- **Hourly Telegram alerts** — Scheduler loop checks token health hourly alongside pool depletion. Sends alert with expiry countdown, re-auth link, and projected stop date. Throttled to once per 24h per chat.
+- **Alert formatting** — `format_token_alert()` builds user-friendly alert with reconnect URL.
+
 ### Added — Category Performance Insights (#154)
 
 - **Category analytics API endpoint** — `GET /api/onboarding/analytics/categories?chat_id=X&days=30` returns per-category posting performance enriched with configured ratios from category_post_case_mix. Shows actual vs target ratio, skip/reject rates, and success rate per category.

--- a/src/main.py
+++ b/src/main.py
@@ -141,8 +141,8 @@ async def run_scheduler_loop(
     health_check_service = HealthCheckService()
     retention_tick_counter = 0
     pool_check_tick_counter = 0
-    # Track last pool alert time per chat_id to throttle to once per 24h
     pool_alert_last_sent: dict[int, float] = {}
+    token_alert_last_sent: dict[int, float] = {}
 
     while True:
         record_heartbeat("scheduler")
@@ -250,6 +250,41 @@ async def run_scheduler_loop(
                             )
             except Exception as e:
                 logger.warning(f"Pool depletion check failed: {e}")
+            finally:
+                health_check_service.cleanup_transactions()
+
+            # Token health check (same hourly cadence, separate 24h throttle)
+            try:
+                if active_chats and scheduler_service.telegram_service:
+                    now_t = time()
+                    bot = scheduler_service.telegram_service.application.bot
+                    active_ids = {c.telegram_chat_id for c in active_chats}
+                    for stale_id in set(token_alert_last_sent) - active_ids:
+                        del token_alert_last_sent[stale_id]
+
+                    for chat in active_chats:
+                        chat_id = chat.telegram_chat_id
+                        if (
+                            now_t - token_alert_last_sent.get(chat_id, 0)
+                            < POOL_ALERT_COOLDOWN_SECONDS
+                        ):
+                            continue
+
+                        token_info = health_check_service.check_gdrive_token_for_chat(
+                            chat_id, chat_settings=chat
+                        )
+                        alert_text = health_check_service.format_token_alert(
+                            token_info, chat_id
+                        )
+                        if alert_text:
+                            await bot.send_message(chat_id=chat_id, text=alert_text)
+                            token_alert_last_sent[chat_id] = now_t
+                            logger.info(
+                                f"[chat={chat_id}] Sent token health alert: "
+                                f"{token_info.get('message', '')}"
+                            )
+            except Exception as e:
+                logger.warning(f"Token health check failed: {e}")
             finally:
                 health_check_service.cleanup_transactions()
 

--- a/src/services/core/health_check.py
+++ b/src/services/core/health_check.py
@@ -18,6 +18,8 @@ class HealthCheckService(BaseService):
     RECENT_POSTS_WINDOW_HOURS = 48
     POOL_WARNING_DAYS = 7  # Warn when category has < 7 days of runway
     POOL_CRITICAL_DAYS = 2  # Critical when < 2 days of runway
+    TOKEN_WARNING_DAYS = 7  # Warn when token expires in < 7 days
+    TOKEN_CRITICAL_DAYS = 1  # Critical when < 1 day
 
     def __init__(self):
         super().__init__()
@@ -543,3 +545,115 @@ class HealthCheckService(BaseService):
             )
         lines.append("\nAdd more content to Google Drive to keep posting.")
         return "\n".join(lines)
+
+    def check_gdrive_token_for_chat(
+        self, telegram_chat_id: int, *, chat_settings=None
+    ) -> dict:
+        """Check Google Drive token health for a specific chat.
+
+        Returns:
+            Dict with healthy, expires_in_days, needs_refresh, message.
+        """
+        if chat_settings is None:
+            chat_settings = self.settings_service.get_settings(telegram_chat_id)
+
+        chat_settings_id = str(chat_settings.id)
+
+        if not getattr(chat_settings, "media_sync_enabled", False):
+            return {"healthy": True, "message": "Media sync disabled", "enabled": False}
+
+        source_type = getattr(chat_settings, "media_source_type", None)
+        if source_type != "google_drive":
+            return {
+                "healthy": True,
+                "message": f"Source is '{source_type}', not Google Drive",
+                "enabled": False,
+            }
+
+        try:
+            token_health = self.token_service.check_token_health_for_chat(
+                "google_drive", chat_settings_id
+            )
+        except Exception as e:
+            return {"healthy": False, "message": f"Token check error: {str(e)}"}
+
+        if not token_health["exists"]:
+            return {
+                "healthy": False,
+                "message": "No Google Drive token found",
+                "expires_in_days": None,
+            }
+
+        if not token_health["valid"]:
+            return {
+                "healthy": False,
+                "message": "Google Drive token expired",
+                "expires_in_days": 0,
+            }
+
+        expires_in_hours = token_health.get("expires_in_hours")
+        expires_in_days = (
+            round(expires_in_hours / 24, 1) if expires_in_hours is not None else None
+        )
+
+        if expires_in_days is not None and expires_in_days <= self.TOKEN_CRITICAL_DAYS:
+            return {
+                "healthy": False,
+                "message": f"Google Drive token expires in {expires_in_days:.0f} day(s)",
+                "expires_in_days": expires_in_days,
+                "needs_refresh": token_health.get("needs_refresh", False),
+            }
+
+        if expires_in_days is not None and expires_in_days <= self.TOKEN_WARNING_DAYS:
+            return {
+                "healthy": False,
+                "message": f"Google Drive token expires in {expires_in_days:.0f} days",
+                "expires_in_days": expires_in_days,
+                "needs_refresh": token_health.get("needs_refresh", False),
+            }
+
+        return {
+            "healthy": True,
+            "message": (
+                "Google Drive token OK"
+                + (
+                    f" ({expires_in_days:.0f} days remaining)"
+                    if expires_in_days
+                    else ""
+                )
+            ),
+            "expires_in_days": expires_in_days,
+        }
+
+    def format_token_alert(self, token_info: dict, telegram_chat_id: int) -> str | None:
+        """Format a Telegram alert for expiring Google Drive token.
+
+        Returns None if no alert needed (healthy token).
+        """
+        if token_info.get("healthy", True):
+            return None
+
+        expires_in_days = token_info.get("expires_in_days")
+
+        if expires_in_days is not None and expires_in_days > 0:
+            text = f"\u26a0\ufe0f Google Drive token expiring in {expires_in_days:.0f} day(s)."
+        else:
+            text = "\u26a0\ufe0f Google Drive token has expired."
+
+        reconnect_url = None
+        if settings.OAUTH_REDIRECT_BASE_URL:
+            reconnect_url = (
+                f"{settings.OAUTH_REDIRECT_BASE_URL}"
+                f"/auth/google-drive/start?chat_id={telegram_chat_id}"
+            )
+            text += f"\n\nRe-authenticate: {reconnect_url}"
+
+        if expires_in_days is not None and expires_in_days > 0:
+            expiry_date = (
+                datetime.utcnow() + timedelta(days=expires_in_days)
+            ).strftime("%b %d")
+            text += f"\n\nIf ignored, media sync will stop on {expiry_date}."
+        else:
+            text += "\n\nMedia sync is paused until you reconnect."
+
+        return text

--- a/src/services/integrations/token_refresh.py
+++ b/src/services/integrations/token_refresh.py
@@ -449,6 +449,47 @@ class TokenRefreshService(BaseService):
             "error": "Token expired" if db_token.is_expired else None,
         }
 
+    def check_token_health_for_chat(self, service: str, chat_settings_id: str) -> dict:
+        """Check token status for a per-tenant service (e.g., google_drive).
+
+        Unlike check_token_health() which queries by instagram_account_id,
+        this queries by chat_settings_id for tenant-scoped tokens.
+
+        Returns same dict shape as check_token_health().
+        """
+        db_token = self.token_repo.get_token_for_chat(
+            service, "oauth_access", chat_settings_id
+        )
+
+        if not db_token:
+            return {
+                "valid": False,
+                "exists": False,
+                "source": None,
+                "expires_at": None,
+                "expires_in_hours": None,
+                "needs_refresh": False,
+                "last_refreshed": None,
+                "error": f"No {service} token found for this chat",
+            }
+
+        expires_in_hours = db_token.hours_until_expiry()
+        needs_refresh = (
+            expires_in_hours is not None
+            and expires_in_hours <= self.REFRESH_BUFFER_HOURS
+        )
+
+        return {
+            "valid": not db_token.is_expired,
+            "exists": True,
+            "source": "database",
+            "expires_at": db_token.expires_at,
+            "expires_in_hours": expires_in_hours,
+            "needs_refresh": needs_refresh,
+            "last_refreshed": db_token.last_refreshed_at,
+            "error": "Token expired" if db_token.is_expired else None,
+        }
+
     def get_tokens_needing_refresh(self) -> list:
         """Get all tokens that need to be refreshed soon."""
         return self.token_repo.get_expiring_tokens(

--- a/tests/src/services/test_health_check.py
+++ b/tests/src/services/test_health_check.py
@@ -569,3 +569,142 @@ class TestHealthCheckService:
         result = pool_service.format_pool_alert(pool_info)
 
         assert result is None
+
+    # ==================== Google Drive Token Health Tests ====================
+
+    @pytest.fixture
+    def token_service(self):
+        """Create HealthCheckService with mocked token dependencies."""
+        service = HealthCheckService()
+        service.queue_repo = Mock()
+        service.history_repo = Mock()
+        service._settings_service = Mock()
+        service._token_service = Mock()
+        return service
+
+    def _gdrive_chat(self):
+        """Create a mock chat configured for Google Drive."""
+        chat = Mock()
+        chat.id = 1
+        chat.telegram_chat_id = -123
+        chat.media_sync_enabled = True
+        chat.media_source_type = "google_drive"
+        return chat
+
+    def test_gdrive_token_healthy(self, token_service):
+        """Returns healthy when token has plenty of time left."""
+        chat = self._gdrive_chat()
+        token_service._token_service.check_token_health_for_chat.return_value = {
+            "valid": True,
+            "exists": True,
+            "expires_in_hours": 30 * 24,  # 30 days
+            "needs_refresh": False,
+            "error": None,
+        }
+
+        result = token_service.check_gdrive_token_for_chat(-123, chat_settings=chat)
+
+        assert result["healthy"] is True
+        assert result["expires_in_days"] == 30.0
+
+    def test_gdrive_token_warning(self, token_service):
+        """Returns unhealthy when token expires within warning threshold."""
+        chat = self._gdrive_chat()
+        token_service._token_service.check_token_health_for_chat.return_value = {
+            "valid": True,
+            "exists": True,
+            "expires_in_hours": 3 * 24,  # 3 days
+            "needs_refresh": True,
+            "error": None,
+        }
+
+        result = token_service.check_gdrive_token_for_chat(-123, chat_settings=chat)
+
+        assert result["healthy"] is False
+        assert result["expires_in_days"] == 3.0
+        assert "3 days" in result["message"]
+
+    def test_gdrive_token_expired(self, token_service):
+        """Returns unhealthy when token is already expired."""
+        chat = self._gdrive_chat()
+        token_service._token_service.check_token_health_for_chat.return_value = {
+            "valid": False,
+            "exists": True,
+            "expires_in_hours": 0,
+            "needs_refresh": False,
+            "error": "Token expired",
+        }
+
+        result = token_service.check_gdrive_token_for_chat(-123, chat_settings=chat)
+
+        assert result["healthy"] is False
+        assert "expired" in result["message"]
+
+    def test_gdrive_token_not_found(self, token_service):
+        """Returns unhealthy when no token exists."""
+        chat = self._gdrive_chat()
+        token_service._token_service.check_token_health_for_chat.return_value = {
+            "valid": False,
+            "exists": False,
+            "expires_in_hours": None,
+            "needs_refresh": False,
+            "error": "No google_drive token found for this chat",
+        }
+
+        result = token_service.check_gdrive_token_for_chat(-123, chat_settings=chat)
+
+        assert result["healthy"] is False
+        assert "No Google Drive token" in result["message"]
+
+    def test_gdrive_token_sync_disabled(self, token_service):
+        """Returns healthy with enabled=False when sync is disabled."""
+        chat = Mock()
+        chat.media_sync_enabled = False
+
+        result = token_service.check_gdrive_token_for_chat(-123, chat_settings=chat)
+
+        assert result["healthy"] is True
+        assert result["enabled"] is False
+
+    def test_gdrive_token_local_source(self, token_service):
+        """Returns healthy with enabled=False when source is local."""
+        chat = Mock()
+        chat.media_sync_enabled = True
+        chat.media_source_type = "local"
+
+        result = token_service.check_gdrive_token_for_chat(-123, chat_settings=chat)
+
+        assert result["healthy"] is True
+        assert result["enabled"] is False
+
+    def test_format_token_alert_expiring(self, token_service):
+        """Format alert includes expiry countdown and re-auth link."""
+        token_info = {"healthy": False, "expires_in_days": 3}
+
+        with patch("src.services.core.health_check.settings") as mock_settings:
+            mock_settings.OAUTH_REDIRECT_BASE_URL = "https://example.com"
+            result = token_service.format_token_alert(token_info, -123)
+
+        assert result is not None
+        assert "3 day" in result
+        assert "/auth/google-drive/start?chat_id=-123" in result
+
+    def test_format_token_alert_expired(self, token_service):
+        """Format alert for already-expired token."""
+        token_info = {"healthy": False, "expires_in_days": 0}
+
+        with patch("src.services.core.health_check.settings") as mock_settings:
+            mock_settings.OAUTH_REDIRECT_BASE_URL = "https://example.com"
+            result = token_service.format_token_alert(token_info, -123)
+
+        assert result is not None
+        assert "expired" in result
+        assert "paused" in result
+
+    def test_format_token_alert_healthy(self, token_service):
+        """Format alert returns None for healthy token."""
+        token_info = {"healthy": True, "expires_in_days": 30}
+
+        result = token_service.format_token_alert(token_info, -123)
+
+        assert result is None


### PR DESCRIPTION
## Summary

Closes #157. Proactively alerts users before Google Drive OAuth tokens expire, preventing the most common silent failure mode ("why did my posts stop?").

- **TokenRefreshService.check_token_health_for_chat()** — Queries tokens by `chat_settings_id` (Google Drive) instead of `instagram_account_id` (Instagram). Returns same dict shape as existing `check_token_health()`.
- **HealthCheckService.check_gdrive_token_for_chat()** — Per-tenant Google Drive token health with warning (<7 days) and critical (<1 day) thresholds. Skips check when sync is disabled or source is local.
- **format_token_alert()** — Builds user-friendly alert with expiry countdown, re-auth link (`/auth/google-drive/start?chat_id=X`), and projected stop date.
- **Scheduler loop integration** — Hourly check alongside pool depletion, 24h throttle per chat, stale entry pruning.

No database schema changes.

## Test plan

- [x] 9 new unit tests: healthy token, warning threshold, expired, not found, sync disabled, local source, alert formatting (expiring, expired, healthy)
- [x] All 1434 existing unit tests pass
- [x] Ruff lint + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)