### PR TITLE
feat: Batch approval in Telegram with /approveall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Batch Approval in Telegram (#160)
+
+- **`/approveall` command** — Shows pending item count with category breakdown and a confirmation button. On confirm, marks all pending queue items as posted with history records and repost-prevention locks.
+- **Batch callback handlers** — `batch_approve` and `batch_approve_cancel` callbacks registered in dispatch table. Sequential per-item processing with continue-on-error pattern.
+- **Bot menu updated** — `/approveall` added to Telegram command autocomplete and `/help` text.
+
 ### Added — Category Performance Insights (#154)
 
 - **Category analytics API endpoint** — `GET /api/onboarding/analytics/categories?chat_id=X&days=30` returns per-category posting performance enriched with configured ratios from category_post_case_mix. Shows actual vs target ratio, skip/reject rates, and success rate per category.

--- a/src/services/core/telegram_callbacks.py
+++ b/src/services/core/telegram_callbacks.py
@@ -763,3 +763,91 @@ class TelegramCallbackHandlers:
                 "❌ Error clearing queue. Please try again.",
                 parse_mode="Markdown",
             )
+
+    async def handle_batch_approve(self, data, user, query):
+        """Handle batch_approve:{chat_settings_id} callback — approve all pending items.
+
+        Marks each item as posted, creates history records, and applies
+        repost-prevention locks. Processes sequentially so one failure
+        doesn't affect others.
+        """
+        cs_id = data
+        chat_id = query.message.chat_id
+
+        try:
+            await query.edit_message_reply_markup(reply_markup=InlineKeyboardMarkup([]))
+        except Exception:
+            pass
+
+        pending = self.service.queue_repo.get_all_with_media(
+            status="pending", chat_settings_id=cs_id
+        )
+        processing = self.service.queue_repo.get_all_with_media(
+            status="processing", chat_settings_id=cs_id
+        )
+        all_items = pending + processing
+
+        if not all_items:
+            await telegram_edit_with_retry(
+                query.edit_message_text,
+                "📭 No pending items to approve.",
+                parse_mode="Markdown",
+            )
+            return
+
+        await telegram_edit_with_retry(
+            query.edit_message_text,
+            f"⏳ *Batch approving {len(all_items)} items...*",
+            parse_mode="Markdown",
+        )
+
+        approved = 0
+        failed = 0
+
+        for queue_item, file_name, category in all_items:
+            queue_id = str(queue_item.id)
+            try:
+                claimed = self.service.queue_repo.claim_for_processing(queue_id)
+                if not claimed:
+                    failed += 1
+                    continue
+                self._execute_complete_db_ops(queue_id, claimed, user, "posted", True)
+                approved += 1
+            except Exception as e:
+                logger.error(
+                    f"Batch approve failed for {queue_id[:8]}: {type(e).__name__}: {e}"
+                )
+                failed += 1
+
+        result_text = (
+            f"✅ *Batch Approve Complete*\n\n📤 {approved} items marked as posted\n"
+        )
+        if failed > 0:
+            result_text += f"⚠️ {failed} items failed\n"
+
+        await telegram_edit_with_retry(
+            query.edit_message_text,
+            result_text,
+            parse_mode="Markdown",
+        )
+
+        self.service.interaction_service.log_callback(
+            user_id=str(user.id),
+            callback_name="batch_approve",
+            context={"approved": approved, "failed": failed},
+            telegram_chat_id=chat_id,
+            telegram_message_id=query.message.message_id,
+        )
+
+        logger.info(
+            f"Batch approve by {self.service._get_display_name(user)}: "
+            f"{approved} approved, {failed} failed"
+        )
+
+    async def handle_batch_approve_cancel(self, data, user, query):
+        """Handle batch_approve_cancel callback — cancel batch approval."""
+        await telegram_edit_with_retry(
+            query.edit_message_text,
+            "❌ *Batch approval cancelled.*",
+            parse_mode="Markdown",
+        )

--- a/src/services/core/telegram_callbacks.py
+++ b/src/services/core/telegram_callbacks.py
@@ -819,11 +819,11 @@ class TelegramCallbackHandlers:
                 )
                 failed += 1
 
-        result_text = (
-            f"✅ *Batch Approve Complete*\n\n📤 {approved} items marked as posted\n"
-        )
+        item_word = "item" if approved == 1 else "items"
+        result_text = f"✅ *Batch Approve Complete*\n\n📤 {approved} {item_word} marked as posted\n"
         if failed > 0:
-            result_text += f"⚠️ {failed} items failed\n"
+            fail_word = "item" if failed == 1 else "items"
+            result_text += f"⚠️ {failed} {fail_word} failed\n"
 
         await telegram_edit_with_retry(
             query.edit_message_text,

--- a/src/services/core/telegram_commands.py
+++ b/src/services/core/telegram_commands.py
@@ -373,6 +373,7 @@ class TelegramCommandHandlers:
             "/start - Open dashboard & settings\n"
             "/status - System health & overview\n"
             "/next - Send next post now\n"
+            "/approveall - Approve all pending posts\n"
             "/setup - Quick settings & toggles\n"
             "/cleanup - Delete recent bot messages\n"
             "/help - Show this help\n\n"
@@ -462,6 +463,88 @@ class TelegramCommandHandlers:
             await update.message.delete()  # Also delete the user's /cleanup command
         except Exception as e:
             logger.debug(f"Could not auto-delete cleanup messages: {e}")
+
+    async def handle_approveall(self, update, context):
+        """Handle /approveall command — batch approve all pending queue items.
+
+        Shows a summary of pending items and a confirmation button.
+        On confirmation, processes each item via auto-post (if Instagram API
+        enabled) or marks as posted (manual mode).
+        """
+        user = self.service._get_or_create_user(update.effective_user)
+        chat_id = update.effective_chat.id
+
+        chat_settings = self.service.settings_service.get_settings(chat_id)
+        cs_id = str(chat_settings.id)
+
+        # Get all pending queue items with media info
+        pending_rows = self.service.queue_repo.get_all_with_media(
+            status="pending", chat_settings_id=cs_id
+        )
+        processing_rows = self.service.queue_repo.get_all_with_media(
+            status="processing", chat_settings_id=cs_id
+        )
+        all_items = pending_rows + processing_rows
+
+        if not all_items:
+            await update.message.reply_text(
+                "📭 *No Pending Posts*\n\nThere are no items waiting for approval.",
+                parse_mode="Markdown",
+            )
+            return
+
+        # Build summary by category
+        category_counts: dict[str, int] = {}
+        for _item, _file_name, category in all_items:
+            cat = category or "uncategorized"
+            category_counts[cat] = category_counts.get(cat, 0) + 1
+
+        summary_parts = [
+            f"{count} {cat}" for cat, count in sorted(category_counts.items())
+        ]
+        summary = ", ".join(summary_parts)
+
+        mode = (
+            "auto-post via Instagram API"
+            if chat_settings.enable_instagram_api
+            else "mark as posted"
+        )
+
+        text = (
+            f"📋 *Batch Approve — {len(all_items)} pending posts*\n\n"
+            f"Categories: {summary}\n"
+            f"Mode: {mode}\n\n"
+            f"Approve all {len(all_items)} items?"
+        )
+
+        keyboard = InlineKeyboardMarkup(
+            [
+                [
+                    InlineKeyboardButton(
+                        f"✅ Approve All ({len(all_items)})",
+                        callback_data=f"batch_approve:{cs_id}",
+                    ),
+                    InlineKeyboardButton(
+                        "❌ Cancel", callback_data="batch_approve_cancel"
+                    ),
+                ],
+            ]
+        )
+
+        await update.message.reply_text(
+            text, parse_mode="Markdown", reply_markup=keyboard
+        )
+
+        self.service.interaction_service.log_command(
+            user_id=str(user.id),
+            command="/approveall",
+            context={
+                "pending_count": len(all_items),
+                "categories": category_counts,
+            },
+            telegram_chat_id=chat_id,
+            telegram_message_id=update.message.message_id,
+        )
 
     async def handle_removed_command(self, update, context):
         """Handle removed commands with a helpful redirect message."""

--- a/src/services/core/telegram_commands.py
+++ b/src/services/core/telegram_commands.py
@@ -468,8 +468,7 @@ class TelegramCommandHandlers:
         """Handle /approveall command — batch approve all pending queue items.
 
         Shows a summary of pending items and a confirmation button.
-        On confirmation, processes each item via auto-post (if Instagram API
-        enabled) or marks as posted (manual mode).
+        On confirmation, marks each item as posted with history and lock creation.
         """
         user = self.service._get_or_create_user(update.effective_user)
         chat_id = update.effective_chat.id
@@ -504,16 +503,10 @@ class TelegramCommandHandlers:
         ]
         summary = ", ".join(summary_parts)
 
-        mode = (
-            "auto-post via Instagram API"
-            if chat_settings.enable_instagram_api
-            else "mark as posted"
-        )
-
         text = (
             f"📋 *Batch Approve — {len(all_items)} pending posts*\n\n"
             f"Categories: {summary}\n"
-            f"Mode: {mode}\n\n"
+            f"Mode: mark as posted\n\n"
             f"Approve all {len(all_items)} items?"
         )
 

--- a/src/services/core/telegram_service.py
+++ b/src/services/core/telegram_service.py
@@ -152,6 +152,7 @@ class TelegramService(BaseService):
             "status": self.commands.handle_status,
             "next": self.commands.handle_next,
             "cleanup": self.commands.handle_cleanup,
+            "approveall": self.commands.handle_approveall,
             "help": self.commands.handle_help,
             "settings": self.settings_handler.handle_settings,
             "setup": self.settings_handler.handle_settings,
@@ -187,6 +188,7 @@ class TelegramService(BaseService):
             BotCommand("status", "System health & media overview"),
             BotCommand("setup", "Quick settings & toggles"),
             BotCommand("next", "Send next post now"),
+            BotCommand("approveall", "Approve all pending posts"),
             BotCommand("cleanup", "Delete recent bot messages"),
             BotCommand("help", "Show available commands"),
         ]
@@ -213,6 +215,8 @@ class TelegramService(BaseService):
             "cancel_reject": self.callbacks.handle_cancel_reject,
             "resume": self.callbacks.handle_resume_callback,
             "clear": self.callbacks.handle_reset_callback,  # Legacy name for reset
+            "batch_approve": self.callbacks.handle_batch_approve,
+            "batch_approve_cancel": self.callbacks.handle_batch_approve_cancel,
             # Auto-post (telegram_autopost.py)
             "autopost": self.autopost.handle_autopost,
             # Settings (telegram_settings.py)

--- a/tests/src/services/test_telegram_callbacks.py
+++ b/tests/src/services/test_telegram_callbacks.py
@@ -684,8 +684,8 @@ class TestEarlyProcessingFeedback:
 
         # Track call order
         call_order = []
-        mock_query.edit_message_reply_markup.side_effect = (
-            lambda **kw: call_order.append("remove_keyboard")
+        mock_query.edit_message_reply_markup.side_effect = lambda **kw: (
+            call_order.append("remove_keyboard")
         )
         service.history_repo.create.side_effect = lambda *a, **kw: call_order.append(
             "history_create"
@@ -778,8 +778,8 @@ class TestEarlyProcessingFeedback:
         mock_query.message = Mock(chat_id=-100123, message_id=1)
 
         call_order = []
-        mock_query.edit_message_reply_markup.side_effect = (
-            lambda **kw: call_order.append("remove_keyboard")
+        mock_query.edit_message_reply_markup.side_effect = lambda **kw: (
+            call_order.append("remove_keyboard")
         )
         service.history_repo.create.side_effect = lambda *a, **kw: call_order.append(
             "history_create"
@@ -1549,3 +1549,121 @@ class TestSharedSessionAtomicity:
 
         # After exiting, commit should be restored
         assert mock_session.commit is original_commit
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestBatchApprove:
+    """Tests for batch approve callback handlers."""
+
+    async def test_batch_approve_processes_all_items(self, mock_callback_handlers):
+        """Batch approve marks all pending items as posted."""
+        handlers = mock_callback_handlers
+        service = handlers.service
+
+        cs_id = str(uuid4())
+        queue_id_1 = uuid4()
+        queue_id_2 = uuid4()
+
+        item1 = Mock(
+            id=queue_id_1,
+            media_item_id=uuid4(),
+            chat_settings_id=cs_id,
+            created_at=datetime.utcnow(),
+            scheduled_for=datetime.utcnow(),
+        )
+        item2 = Mock(
+            id=queue_id_2,
+            media_item_id=uuid4(),
+            chat_settings_id=cs_id,
+            created_at=datetime.utcnow(),
+            scheduled_for=datetime.utcnow(),
+        )
+
+        service.queue_repo.get_all_with_media.side_effect = [
+            [(item1, "meme.jpg", "memes")],
+            [(item2, "merch.jpg", "merch")],
+        ]
+        service.queue_repo.claim_for_processing.side_effect = [item1, item2]
+        service.media_repo.get_by_id.return_value = Mock()
+
+        mock_query = AsyncMock()
+        mock_query.message.chat_id = -100123
+        mock_query.message.message_id = 1
+        mock_user = Mock(id=uuid4(), telegram_username="test")
+
+        mock_session = Mock()
+        mock_session.commit = Mock()
+        mock_session.flush = Mock()
+        service.history_repo.db = mock_session
+        for repo in [
+            service.history_repo,
+            service.media_repo,
+            service.queue_repo,
+            service.user_repo,
+            service.lock_service.lock_repo,
+        ]:
+            repo._db = Mock()
+
+        await handlers.handle_batch_approve(cs_id, mock_user, mock_query)
+
+        assert service.queue_repo.claim_for_processing.call_count == 2
+        final_call = mock_query.edit_message_text.call_args_list[-1]
+        assert "2 items marked as posted" in final_call[0][0]
+
+    async def test_batch_approve_empty_queue(self, mock_callback_handlers):
+        """Batch approve with no pending items shows empty message."""
+        handlers = mock_callback_handlers
+        service = handlers.service
+
+        service.queue_repo.get_all_with_media.return_value = []
+
+        mock_query = AsyncMock()
+        mock_query.message.chat_id = -100123
+        mock_user = Mock(id=uuid4())
+
+        await handlers.handle_batch_approve("cs-id", mock_user, mock_query)
+
+        final_text = mock_query.edit_message_text.call_args[0][0]
+        assert "No pending items" in final_text
+
+    async def test_batch_approve_handles_claim_failure(self, mock_callback_handlers):
+        """Batch approve continues when individual items fail to claim."""
+        handlers = mock_callback_handlers
+        service = handlers.service
+
+        item1 = Mock(
+            id=uuid4(),
+            media_item_id=uuid4(),
+            chat_settings_id="cs",
+            created_at=datetime.utcnow(),
+            scheduled_for=datetime.utcnow(),
+        )
+
+        service.queue_repo.get_all_with_media.side_effect = [
+            [(item1, "file.jpg", "cat")],
+            [],
+        ]
+        service.queue_repo.claim_for_processing.return_value = None
+
+        mock_query = AsyncMock()
+        mock_query.message.chat_id = -100123
+        mock_query.message.message_id = 1
+        mock_user = Mock(id=uuid4())
+
+        await handlers.handle_batch_approve("cs-id", mock_user, mock_query)
+
+        final_text = mock_query.edit_message_text.call_args[0][0]
+        assert "0 items marked as posted" in final_text
+        assert "1 items failed" in final_text
+
+    async def test_batch_approve_cancel(self, mock_callback_handlers):
+        """Batch approve cancel shows cancelled message."""
+        handlers = mock_callback_handlers
+        mock_query = AsyncMock()
+        mock_user = Mock(id=uuid4())
+
+        await handlers.handle_batch_approve_cancel("", mock_user, mock_query)
+
+        final_text = mock_query.edit_message_text.call_args[0][0]
+        assert "cancelled" in final_text

--- a/tests/src/services/test_telegram_callbacks.py
+++ b/tests/src/services/test_telegram_callbacks.py
@@ -1655,7 +1655,7 @@ class TestBatchApprove:
 
         final_text = mock_query.edit_message_text.call_args[0][0]
         assert "0 items marked as posted" in final_text
-        assert "1 items failed" in final_text
+        assert "1 item failed" in final_text
 
     async def test_batch_approve_cancel(self, mock_callback_handlers):
         """Batch approve cancel shows cancelled message."""

--- a/tests/src/services/test_telegram_commands.py
+++ b/tests/src/services/test_telegram_commands.py
@@ -1409,3 +1409,76 @@ class TestStartCommand:
         service.interaction_service.log_command.assert_called_once()
         call_kwargs = service.interaction_service.log_command.call_args[1]
         assert call_kwargs["command"] == "/start"
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestApproveAllCommand:
+    """Tests for /approveall command - batch approve pending posts."""
+
+    async def test_approveall_shows_summary_and_confirm(self, mock_command_handlers):
+        """Test /approveall shows pending count and confirmation button."""
+        handlers = mock_command_handlers
+        service = handlers.service
+
+        mock_user = Mock()
+        mock_user.id = uuid4()
+        service.user_repo.get_by_telegram_id.return_value = mock_user
+
+        mock_chat_settings = Mock()
+        mock_chat_settings.id = uuid4()
+        mock_chat_settings.enable_instagram_api = False
+        service.settings_service.get_settings.return_value = mock_chat_settings
+
+        mock_item1 = Mock(id=uuid4())
+        mock_item2 = Mock(id=uuid4())
+        service.queue_repo.get_all_with_media.side_effect = [
+            [(mock_item1, "meme.jpg", "memes"), (mock_item2, "merch.jpg", "merch")],
+            [],  # processing = empty
+        ]
+
+        mock_update = AsyncMock()
+        mock_update.effective_user.id = 123
+        mock_update.effective_user.first_name = "Test"
+        mock_update.effective_user.username = "test"
+        mock_update.effective_chat.id = -100123
+        mock_update.message.message_id = 1
+
+        await handlers.handle_approveall(mock_update, Mock())
+
+        mock_update.message.reply_text.assert_called_once()
+        call_args = mock_update.message.reply_text.call_args
+        text = call_args[0][0]
+        assert "2 pending posts" in text
+        assert "memes" in text
+        assert "merch" in text
+        # Check confirmation button exists
+        keyboard = call_args[1]["reply_markup"]
+        assert keyboard is not None
+
+    async def test_approveall_empty_queue(self, mock_command_handlers):
+        """Test /approveall with no pending items."""
+        handlers = mock_command_handlers
+        service = handlers.service
+
+        mock_user = Mock()
+        mock_user.id = uuid4()
+        service.user_repo.get_by_telegram_id.return_value = mock_user
+
+        mock_chat_settings = Mock()
+        mock_chat_settings.id = uuid4()
+        service.settings_service.get_settings.return_value = mock_chat_settings
+
+        service.queue_repo.get_all_with_media.return_value = []
+
+        mock_update = AsyncMock()
+        mock_update.effective_user.id = 123
+        mock_update.effective_user.first_name = "Test"
+        mock_update.effective_user.username = "test"
+        mock_update.effective_chat.id = -100123
+        mock_update.message.message_id = 1
+
+        await handlers.handle_approveall(mock_update, Mock())
+
+        call_text = mock_update.message.reply_text.call_args[0][0]
+        assert "No Pending Posts" in call_text


### PR DESCRIPTION
## Summary

Closes #160. Adds `/approveall` command to approve all pending queue items at once, reducing daily friction from N individual button taps to 1 confirmation. Part of the Zero-Touch Posting compound play (#151).

- **`/approveall` command** — Shows pending count with category breakdown (e.g., "3 memes, 2 merch"), confirms mode (mark as posted), and presents Approve All / Cancel buttons.
- **Batch callback** — On confirmation, processes each item sequentially: claim → history record → lock → queue delete. Continue-on-error so one failure doesn't block others.
- **Bot menu** — `/approveall` registered in Telegram autocomplete and `/help` text.

Architecture decision: Uses the manual "posted" callback flow (not auto-post via Instagram API) because the autopost handler is tightly coupled to per-item Telegram callback queries. Auto-post integration can be a follow-up.

No database schema changes.

## Test plan

- [x] 2 command tests: summary with items, empty queue
- [x] 4 callback tests: batch processing, empty queue, claim failure, cancel
- [x] All 1431 existing unit tests pass
- [x] Ruff lint + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)