### PR TITLE
feat: Smart auto-approval for previously-approved media

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Smart Auto-Approval (#155)
+
+- **Auto-approve returning media** — When the scheduler selects a media item that has been posted before (`times_posted > 0`), it skips the Telegram approval step and directly records the item as posted. Uses existing `media_items.times_posted` field — no schema changes.
+- **Quiet Telegram notification** — Sends a brief "Auto-approved: filename [category]" message for visibility without requiring user action.
+- **Posting method tracking** — Auto-approved items recorded with `posting_method='auto_reapproval'` in posting_history for analytics distinction.
+- **Only applies to scheduler** — `/next` command and manual flows always go through Telegram approval regardless of prior history.
+
 ### Added — Category Performance Insights (#154)
 
 - **Category analytics API endpoint** — `GET /api/onboarding/analytics/categories?chat_id=X&days=30` returns per-category posting performance enriched with configured ratios from category_post_case_mix. Shows actual vs target ratio, skip/reject rates, and success rate per category.

--- a/src/main.py
+++ b/src/main.py
@@ -178,6 +178,24 @@ async def run_scheduler_loop(
                                 f"[{result.get('category', '?')}]"
                             )
 
+                            # Send quiet notification for auto-approved items
+                            if (
+                                result.get("auto_approved")
+                                and scheduler_service.telegram_service
+                            ):
+                                try:
+                                    bot = scheduler_service.telegram_service.application.bot
+                                    await bot.send_message(
+                                        chat_id=chat_id,
+                                        text=(
+                                            f"\u2705 Auto-approved: "
+                                            f"{result.get('media_file', '?')} "
+                                            f"[{result.get('category', '?')}]"
+                                        ),
+                                    )
+                                except Exception:
+                                    pass
+
                     except GoogleDriveAuthError:
                         logger.error(
                             f"Google Drive auth error for chat {chat_id}",

--- a/src/services/core/scheduler.py
+++ b/src/services/core/scheduler.py
@@ -9,6 +9,7 @@ from src.services.base_service import BaseService
 from src.services.core.settings_service import SettingsService
 from src.repositories.media_repository import MediaRepository
 from src.repositories.queue_repository import QueueRepository
+from src.repositories.history_repository import HistoryRepository
 from src.repositories.lock_repository import LockRepository
 from src.repositories.category_mix_repository import CategoryMixRepository
 from src.config.settings import settings
@@ -30,6 +31,7 @@ class SchedulerService(BaseService):
         super().__init__()
         self.media_repo = MediaRepository()
         self.queue_repo = QueueRepository()
+        self.history_repo = HistoryRepository()
         self.lock_repo = LockRepository()
         self.category_mix_repo = CategoryMixRepository()
         self.settings_service = SettingsService()
@@ -230,6 +232,20 @@ class SchedulerService(BaseService):
                 )
                 return result
 
+            # Auto-approve previously-approved media (skip Telegram)
+            if media_item.times_posted > 0 and triggered_by == "scheduler":
+                result = self._auto_approve(media_item, chat_settings)
+                self.set_result_summary(
+                    run_id,
+                    {
+                        "posted": True,
+                        "auto_approved": True,
+                        "media_file": media_item.file_name,
+                        "category": media_item.category,
+                    },
+                )
+                return result
+
             # Create in-flight queue item
             queue_item = self.queue_repo.create(
                 media_item_id=str(media_item.id),
@@ -308,6 +324,69 @@ class SchedulerService(BaseService):
             except Exception:
                 pass
             return False
+
+    def _auto_approve(self, media_item, chat_settings) -> dict:
+        """Auto-approve a previously-approved media item without Telegram interaction.
+
+        Creates a transient queue item, records history, applies a repost lock,
+        and increments times_posted. Sends a quiet log notification to Telegram.
+        """
+        from src.repositories.history_repository import HistoryCreateParams
+
+        now = datetime.utcnow()
+        media_id = str(media_item.id)
+        cs_id = str(chat_settings.id)
+
+        # Create + immediately delete queue item (needed for history record)
+        queue_item = self.queue_repo.create(
+            media_item_id=media_id,
+            scheduled_for=now,
+            chat_settings_id=cs_id,
+        )
+        queue_id = str(queue_item.id)
+
+        self.history_repo.create(
+            HistoryCreateParams(
+                media_item_id=media_id,
+                queue_item_id=queue_id,
+                queue_created_at=now,
+                queue_deleted_at=now,
+                scheduled_for=now,
+                posted_at=now,
+                status="posted",
+                success=True,
+                posting_method="auto_reapproval",
+                chat_settings_id=cs_id,
+            )
+        )
+
+        self.media_repo.increment_times_posted(media_id)
+
+        from src.services.core.media_lock import MediaLockService
+
+        lock_service = MediaLockService()
+        lock_service.create_lock(media_id)
+
+        self.queue_repo.delete(queue_id)
+
+        self.settings_service.update_last_post_sent_at(
+            chat_settings.telegram_chat_id, now
+        )
+
+        logger.info(
+            f"Auto-approved returning media: {media_item.file_name} "
+            f"[{media_item.category}] (posted {media_item.times_posted}x before)"
+        )
+
+        return {
+            "posted": True,
+            "auto_approved": True,
+            "queue_item_id": queue_id,
+            "media_item": media_item,
+            "media_file": media_item.file_name,
+            "category": media_item.category,
+            "error": None,
+        }
 
     # ------------------------------------------------------------------
     # Internal: slot timing

--- a/tests/src/services/test_scheduler.py
+++ b/tests/src/services/test_scheduler.py
@@ -297,7 +297,9 @@ class TestForceSendNext:
         cs = _make_chat_settings()
         service.settings_service.get_settings.return_value = cs
 
-        mock_media = Mock(id=uuid4(), file_name="force.jpg", category="memes")
+        mock_media = Mock(
+            id=uuid4(), file_name="force.jpg", category="memes", times_posted=0
+        )
         service.media_repo.get_next_eligible_for_posting.return_value = mock_media
 
         mock_queue_item = Mock(id=uuid4())
@@ -332,7 +334,7 @@ class TestForceSendNext:
         cs = _make_chat_settings()
         service.settings_service.get_settings.return_value = cs
 
-        mock_media = Mock(id=uuid4(), file_name="f.jpg", category=None)
+        mock_media = Mock(id=uuid4(), file_name="f.jpg", category=None, times_posted=0)
         service.media_repo.get_next_eligible_for_posting.return_value = mock_media
 
         mock_queue_item = Mock(id=uuid4())
@@ -743,3 +745,117 @@ class TestSchedulerMediaPool:
             category=None, exclude_ids=None
         )
         assert result is None
+
+
+# ------------------------------------------------------------------
+# Auto-approval
+# ------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestAutoApproval:
+    """Tests for smart auto-approval of previously-approved media."""
+
+    @pytest.fixture
+    def scheduler_service(self):
+        with patch.object(SchedulerService, "__init__", lambda self: None):
+            service = SchedulerService()
+            service.media_repo = Mock()
+            service.queue_repo = Mock()
+            service.history_repo = Mock()
+            service.lock_repo = Mock()
+            service.category_mix_repo = Mock()
+            service.settings_service = Mock()
+            service.telegram_service = AsyncMock()
+            service.service_run_repo = Mock()
+            service.service_name = "SchedulerService"
+            service.SCHEDULE_JITTER_MINUTES = 30
+            service.track_execution = mock_track_execution
+            service.set_result_summary = Mock()
+            return service
+
+    async def test_auto_approves_previously_posted_media(self, scheduler_service):
+        """Media with times_posted > 0 is auto-approved without Telegram."""
+        media = Mock(id=uuid4(), file_name="meme.jpg", category="memes", times_posted=3)
+        scheduler_service.media_repo.get_next_eligible_for_posting.return_value = media
+
+        queue_item = Mock(id=uuid4())
+        scheduler_service.queue_repo.create.return_value = queue_item
+
+        cs = _make_chat_settings()
+
+        with patch("src.services.core.media_lock.MediaLockService"):
+            result = await scheduler_service._select_and_send(
+                cs, category=None, triggered_by="scheduler"
+            )
+
+        assert result["posted"] is True
+        assert result["auto_approved"] is True
+        assert result["media_file"] == "meme.jpg"
+        # History should be created with auto_reapproval method
+        scheduler_service.history_repo.create.assert_called_once()
+        params = scheduler_service.history_repo.create.call_args[0][0]
+        assert params.posting_method == "auto_reapproval"
+        assert params.status == "posted"
+        # Telegram notification should NOT have been sent
+        scheduler_service.telegram_service.send_notification.assert_not_called()
+
+    async def test_new_media_goes_to_telegram(self, scheduler_service):
+        """Media with times_posted == 0 goes through normal Telegram flow."""
+        media = Mock(id=uuid4(), file_name="new.jpg", category="memes", times_posted=0)
+        scheduler_service.media_repo.get_next_eligible_for_posting.return_value = media
+
+        queue_item = Mock(id=uuid4())
+        scheduler_service.queue_repo.create.return_value = queue_item
+        scheduler_service.telegram_service.send_notification = AsyncMock(
+            return_value=True
+        )
+
+        cs = _make_chat_settings()
+
+        result = await scheduler_service._select_and_send(
+            cs, category=None, triggered_by="scheduler"
+        )
+
+        assert result["posted"] is True
+        assert "auto_approved" not in result
+        scheduler_service.telegram_service.send_notification.assert_called_once()
+
+    async def test_force_next_skips_auto_approval(self, scheduler_service):
+        """Manual /next command always goes to Telegram, even for returning media."""
+        media = Mock(id=uuid4(), file_name="old.jpg", category="merch", times_posted=5)
+        scheduler_service.media_repo.get_next_eligible_for_posting.return_value = media
+
+        queue_item = Mock(id=uuid4())
+        scheduler_service.queue_repo.create.return_value = queue_item
+        scheduler_service.telegram_service.send_notification = AsyncMock(
+            return_value=True
+        )
+
+        cs = _make_chat_settings()
+
+        result = await scheduler_service._select_and_send(
+            cs, category=None, triggered_by="telegram"
+        )
+
+        assert result["posted"] is True
+        assert "auto_approved" not in result
+        scheduler_service.telegram_service.send_notification.assert_called_once()
+
+    async def test_auto_approve_creates_lock_and_history(self, scheduler_service):
+        """Auto-approve creates history record, lock, and increments times_posted."""
+        media = Mock(id=uuid4(), file_name="test.jpg", category="memes", times_posted=2)
+        queue_item = Mock(id=uuid4())
+        scheduler_service.queue_repo.create.return_value = queue_item
+        cs = _make_chat_settings()
+
+        with patch("src.services.core.media_lock.MediaLockService") as MockLock:
+            result = scheduler_service._auto_approve(media, cs)
+
+        assert result["posted"] is True
+        assert result["auto_approved"] is True
+        scheduler_service.history_repo.create.assert_called_once()
+        scheduler_service.media_repo.increment_times_posted.assert_called_once()
+        MockLock.return_value.create_lock.assert_called_once()
+        scheduler_service.queue_repo.delete.assert_called_once()


### PR DESCRIPTION
## Summary

Closes #155. Automatically approves media that has been posted before, reducing manual Telegram approval clicks for returning content. Part of the Zero-Touch Posting compound play (#151).

**Architecture decision:** Uses existing `media_items.times_posted > 0` as the approval signal instead of querying posting_history or adding new tables. This was chosen via /weigh-development-paths analysis because:
- Zero schema changes (mission doc requires approval for schema changes)
- O(1) lookup on an already-loaded field
- `times_posted` is already incremented on every successful post

**How it works:**
- Scheduler selects media → checks `times_posted > 0` → if previously posted, calls `_auto_approve()` instead of sending to Telegram
- `_auto_approve()` creates history record (`posting_method='auto_reapproval'`), applies repost lock, increments counter
- Quiet Telegram notification sent for audit visibility
- Only applies to scheduler-initiated slots — `/next` command always goes through manual approval
- Users can reject items to create permanent locks, preventing future auto-approval

No database schema changes.

## Test plan

- [x] 4 new tests: auto-approval fires, new media goes to Telegram, /next bypasses auto-approval, lock+history creation
- [x] 2 existing tests updated (mock media needed times_posted attribute)
- [x] All 1429 existing unit tests pass
- [x] Ruff lint + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)