### PR TITLE
feat: Schedule optimization recommendations from posting history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Schedule Optimization Recommendations (#158)
+
+- **Schedule recommendations API** — `GET /api/onboarding/analytics/schedule-recommendations` analyzes posting history to identify optimal posting times. Returns hourly approval rates, day-of-week patterns, and human-readable recommendations (e.g., "Posts at 10:00 have the highest approval rate (94%)").
+- **Hourly approval rates** — `get_hourly_approval_rates()` in HistoryRepository groups posts by hour with full status breakdown and approval rate calculation.
+- **Day-of-week analysis** — `get_dow_approval_rates()` identifies which days have the highest/lowest approval rates over a 90-day window.
+- **Graceful degradation** — Returns "insufficient_data" status when fewer than 10 posts exist, preventing misleading recommendations from sparse data.
+
 ### Added — Batch Approval in Telegram (#160)
 
 - **`/approveall` command** — Shows pending item count with category breakdown and a confirmation button. On confirm, marks all pending queue items as posted with history records and repost-prevention locks.

--- a/src/api/routes/onboarding/dashboard.py
+++ b/src/api/routes/onboarding/dashboard.py
@@ -84,6 +84,19 @@ async def onboarding_accounts(
         return {"accounts": items, "active_account_id": active_account_id}
 
 
+@router.get("/analytics/schedule-recommendations")
+async def onboarding_schedule_recommendations(
+    init_data: str,
+    chat_id: int,
+    days: int = Query(default=90, ge=7, le=365),
+):
+    """Return posting time recommendations based on approval patterns."""
+    _validate_request(init_data, chat_id)
+
+    with DashboardService() as service:
+        return service.get_schedule_recommendations(chat_id, days=days)
+
+
 @router.get("/analytics/categories")
 async def onboarding_analytics_categories(
     init_data: str,

--- a/src/repositories/history_repository.py
+++ b/src/repositories/history_repository.py
@@ -336,3 +336,92 @@ class HistoryRepository(BaseRepository):
             cat_data["success_rate"] = round(posted / total, 2) if total else 0
 
         return list(by_category.values())
+
+    def get_hourly_approval_rates(
+        self, days: int = 30, chat_settings_id: Optional[str] = None
+    ) -> list:
+        """Count posts by hour of day grouped by status.
+
+        Returns list of {"hour": 0-23, "posted": N, "skipped": N, ..., "total": N, "approval_rate": float}
+        """
+        from sqlalchemy import extract
+
+        since = datetime.utcnow() - timedelta(days=days)
+        rows = (
+            self._tenant_query(PostingHistory, chat_settings_id)
+            .with_entities(
+                extract("hour", PostingHistory.posted_at).label("hour"),
+                PostingHistory.status,
+                func.count(PostingHistory.id),
+            )
+            .filter(PostingHistory.posted_at >= since)
+            .group_by("hour", PostingHistory.status)
+            .order_by("hour")
+            .all()
+        )
+        self.end_read_transaction()
+
+        by_hour: dict = {}
+        for hour, status, count in rows:
+            h = int(hour)
+            if h not in by_hour:
+                by_hour[h] = {"hour": h}
+            by_hour[h][status] = count
+
+        for hour_data in by_hour.values():
+            total = sum(v for k, v in hour_data.items() if k != "hour")
+            posted = hour_data.get("posted", 0)
+            hour_data["total"] = total
+            hour_data["approval_rate"] = round(posted / total, 2) if total else 0
+
+        return [by_hour[h] for h in sorted(by_hour)]
+
+    def get_dow_approval_rates(
+        self, days: int = 90, chat_settings_id: Optional[str] = None
+    ) -> list:
+        """Count posts by day of week grouped by status.
+
+        Uses extract('dow') which returns 0=Sunday through 6=Saturday.
+        Returns list of {"dow": 0-6, "day_name": str, "posted": N, ..., "approval_rate": float}
+        """
+        from sqlalchemy import extract
+
+        day_names = [
+            "Sunday",
+            "Monday",
+            "Tuesday",
+            "Wednesday",
+            "Thursday",
+            "Friday",
+            "Saturday",
+        ]
+
+        since = datetime.utcnow() - timedelta(days=days)
+        rows = (
+            self._tenant_query(PostingHistory, chat_settings_id)
+            .with_entities(
+                extract("dow", PostingHistory.posted_at).label("dow"),
+                PostingHistory.status,
+                func.count(PostingHistory.id),
+            )
+            .filter(PostingHistory.posted_at >= since)
+            .group_by("dow", PostingHistory.status)
+            .order_by("dow")
+            .all()
+        )
+        self.end_read_transaction()
+
+        by_dow: dict = {}
+        for dow, status, count in rows:
+            d = int(dow)
+            if d not in by_dow:
+                by_dow[d] = {"dow": d, "day_name": day_names[d]}
+            by_dow[d][status] = count
+
+        for dow_data in by_dow.values():
+            total = sum(v for k, v in dow_data.items() if k not in ("dow", "day_name"))
+            posted = dow_data.get("posted", 0)
+            dow_data["total"] = total
+            dow_data["approval_rate"] = round(posted / total, 2) if total else 0
+
+        return [by_dow[d] for d in sorted(by_dow)]

--- a/src/services/core/dashboard_service.py
+++ b/src/services/core/dashboard_service.py
@@ -231,6 +231,127 @@ class DashboardService(BaseService):
                 "days": days,
             }
 
+    def get_schedule_recommendations(
+        self, telegram_chat_id: int, days: int = 90
+    ) -> dict:
+        """Analyze posting history to recommend optimal posting times.
+
+        Returns hourly approval rates, day-of-week patterns, and
+        human-readable recommendations based on when posts are most
+        frequently approved vs skipped/rejected.
+        """
+        MIN_DATA_POINTS = 10
+
+        with self.track_execution(
+            "get_schedule_recommendations",
+            input_params={"telegram_chat_id": telegram_chat_id, "days": days},
+        ) as run_id:
+            chat_settings_id = self._resolve_chat_settings_id(telegram_chat_id)
+
+            hourly = self.history_repo.get_hourly_approval_rates(
+                days=days, chat_settings_id=chat_settings_id
+            )
+            dow = self.history_repo.get_dow_approval_rates(
+                days=days, chat_settings_id=chat_settings_id
+            )
+
+            total_data_points = sum(h.get("total", 0) for h in hourly)
+
+            if total_data_points < MIN_DATA_POINTS:
+                self.set_result_summary(
+                    run_id,
+                    {"status": "insufficient_data", "data_points": total_data_points},
+                )
+                return {
+                    "status": "insufficient_data",
+                    "message": (
+                        f"Need at least {MIN_DATA_POINTS} posts to generate "
+                        f"recommendations (have {total_data_points})"
+                    ),
+                    "hourly_rates": [],
+                    "dow_rates": [],
+                    "recommendations": [],
+                    "days": days,
+                }
+
+            recommendations = self._generate_recommendations(hourly, dow)
+
+            self.set_result_summary(
+                run_id,
+                {
+                    "status": "ok",
+                    "data_points": total_data_points,
+                    "recommendation_count": len(recommendations),
+                },
+            )
+            return {
+                "status": "ok",
+                "hourly_rates": hourly,
+                "dow_rates": dow,
+                "recommendations": recommendations,
+                "days": days,
+                "data_points": total_data_points,
+            }
+
+    @staticmethod
+    def _generate_recommendations(hourly: list, dow: list) -> list:
+        """Generate human-readable schedule recommendations from patterns."""
+        recommendations = []
+
+        # Find best and worst hours (need at least some data per hour)
+        hours_with_data = [h for h in hourly if h.get("total", 0) >= 3]
+        if hours_with_data:
+            best_hour = max(hours_with_data, key=lambda h: h["approval_rate"])
+            worst_hour = min(hours_with_data, key=lambda h: h["approval_rate"])
+
+            if best_hour["approval_rate"] > worst_hour["approval_rate"] + 0.1:
+                recommendations.append(
+                    {
+                        "type": "best_hour",
+                        "message": (
+                            f"Posts at {best_hour['hour']}:00 have the highest "
+                            f"approval rate ({best_hour['approval_rate']:.0%})"
+                        ),
+                        "hour": best_hour["hour"],
+                        "approval_rate": best_hour["approval_rate"],
+                    }
+                )
+
+            if worst_hour["approval_rate"] < 0.7 and worst_hour["total"] >= 5:
+                recommendations.append(
+                    {
+                        "type": "worst_hour",
+                        "message": (
+                            f"Posts at {worst_hour['hour']}:00 have a low "
+                            f"approval rate ({worst_hour['approval_rate']:.0%}) — "
+                            f"consider avoiding this time"
+                        ),
+                        "hour": worst_hour["hour"],
+                        "approval_rate": worst_hour["approval_rate"],
+                    }
+                )
+
+        # Find best and worst days
+        days_with_data = [d for d in dow if d.get("total", 0) >= 3]
+        if days_with_data:
+            best_day = max(days_with_data, key=lambda d: d["approval_rate"])
+            worst_day = min(days_with_data, key=lambda d: d["approval_rate"])
+
+            if best_day["approval_rate"] > worst_day["approval_rate"] + 0.1:
+                recommendations.append(
+                    {
+                        "type": "best_day",
+                        "message": (
+                            f"{best_day['day_name']}s have the highest approval rate "
+                            f"({best_day['approval_rate']:.0%})"
+                        ),
+                        "day_name": best_day["day_name"],
+                        "approval_rate": best_day["approval_rate"],
+                    }
+                )
+
+        return recommendations
+
     def get_pending_queue_items(self, chat_settings_id: Optional[str] = None) -> list:
         """Return pending queue items with media details.
 

--- a/tests/src/repositories/test_history_repository.py
+++ b/tests/src/repositories/test_history_repository.py
@@ -472,3 +472,62 @@ class TestAnalyticsAggregations:
         result = history_repo.get_stats_by_category(days=30)
 
         assert result == []
+
+    def test_get_hourly_approval_rates(self, history_repo, mock_db):
+        """Returns hourly approval rates with status breakdown."""
+        q = self._make_chainable_query(mock_db)
+        q.all.return_value = [
+            (10, "posted", 8),
+            (10, "skipped", 2),
+            (14, "posted", 5),
+            (14, "skipped", 5),
+        ]
+
+        result = history_repo.get_hourly_approval_rates(days=30)
+
+        assert len(result) == 2
+        assert result[0]["hour"] == 10
+        assert result[0]["posted"] == 8
+        assert result[0]["skipped"] == 2
+        assert result[0]["total"] == 10
+        assert result[0]["approval_rate"] == 0.8
+        assert result[1]["hour"] == 14
+        assert result[1]["approval_rate"] == 0.5
+
+    def test_get_hourly_approval_rates_empty(self, history_repo, mock_db):
+        """Returns empty list when no data."""
+        q = self._make_chainable_query(mock_db)
+        q.all.return_value = []
+
+        result = history_repo.get_hourly_approval_rates(days=7)
+
+        assert result == []
+
+    def test_get_dow_approval_rates(self, history_repo, mock_db):
+        """Returns day-of-week approval rates with day names."""
+        q = self._make_chainable_query(mock_db)
+        q.all.return_value = [
+            (1, "posted", 20),  # Monday
+            (1, "skipped", 5),
+            (6, "posted", 10),  # Saturday
+            (6, "skipped", 10),
+        ]
+
+        result = history_repo.get_dow_approval_rates(days=90)
+
+        assert len(result) == 2
+        assert result[0]["dow"] == 1
+        assert result[0]["day_name"] == "Monday"
+        assert result[0]["approval_rate"] == 0.8
+        assert result[1]["dow"] == 6
+        assert result[1]["day_name"] == "Saturday"
+        assert result[1]["approval_rate"] == 0.5
+
+    def test_get_dow_approval_rates_empty(self, history_repo, mock_db):
+        """Returns empty list when no data."""
+        q = self._make_chainable_query(mock_db)
+        q.all.return_value = []
+
+        result = history_repo.get_dow_approval_rates(days=90)
+
+        assert result == []

--- a/tests/src/services/test_dashboard_service.py
+++ b/tests/src/services/test_dashboard_service.py
@@ -439,3 +439,148 @@ class TestGetCategoryAnalytics:
 
         assert result["total_posts"] == 0
         assert result["categories"] == []
+
+
+@pytest.mark.unit
+class TestGetScheduleRecommendations:
+    """Tests for schedule recommendation generation."""
+
+    def _setup_service(self):
+        """Create DashboardService with mocked dependencies."""
+        with patch.object(DashboardService, "__init__", lambda self: None):
+            service = DashboardService()
+            service.settings_service = MagicMock()
+            service.queue_repo = MagicMock()
+            service.history_repo = MagicMock()
+            service.media_repo = MagicMock()
+            service.category_mix_repo = MagicMock()
+            service.service_run_repo = MagicMock()
+            service.service_name = "DashboardService"
+
+            mock_settings = Mock(id="tenant-uuid-1")
+            service.settings_service.get_settings.return_value = mock_settings
+            return service
+
+    def test_returns_recommendations_with_sufficient_data(self):
+        """Generates recommendations when enough data exists."""
+        service = self._setup_service()
+
+        service.history_repo.get_hourly_approval_rates.return_value = [
+            {
+                "hour": 10,
+                "posted": 15,
+                "skipped": 1,
+                "total": 16,
+                "approval_rate": 0.94,
+            },
+            {"hour": 14, "posted": 8, "skipped": 7, "total": 15, "approval_rate": 0.53},
+            {
+                "hour": 18,
+                "posted": 10,
+                "skipped": 2,
+                "total": 12,
+                "approval_rate": 0.83,
+            },
+        ]
+        service.history_repo.get_dow_approval_rates.return_value = [
+            {
+                "dow": 1,
+                "day_name": "Monday",
+                "posted": 20,
+                "skipped": 2,
+                "total": 22,
+                "approval_rate": 0.91,
+            },
+            {
+                "dow": 6,
+                "day_name": "Saturday",
+                "posted": 5,
+                "skipped": 5,
+                "total": 10,
+                "approval_rate": 0.50,
+            },
+        ]
+
+        result = service.get_schedule_recommendations(telegram_chat_id=123)
+
+        assert result["status"] == "ok"
+        assert len(result["hourly_rates"]) == 3
+        assert len(result["dow_rates"]) == 2
+        assert len(result["recommendations"]) >= 1
+        # Should recommend hour 10 as best
+        best_hour_rec = next(
+            (r for r in result["recommendations"] if r["type"] == "best_hour"), None
+        )
+        assert best_hour_rec is not None
+        assert best_hour_rec["hour"] == 10
+
+    def test_returns_insufficient_data_when_too_few_posts(self):
+        """Returns insufficient_data status with fewer than 10 posts."""
+        service = self._setup_service()
+
+        service.history_repo.get_hourly_approval_rates.return_value = [
+            {"hour": 10, "posted": 3, "total": 3, "approval_rate": 1.0},
+        ]
+        service.history_repo.get_dow_approval_rates.return_value = []
+
+        result = service.get_schedule_recommendations(telegram_chat_id=123)
+
+        assert result["status"] == "insufficient_data"
+        assert result["recommendations"] == []
+
+    def test_no_recommendations_when_all_hours_similar(self):
+        """No best/worst hour recommendation when rates are close."""
+        service = self._setup_service()
+
+        service.history_repo.get_hourly_approval_rates.return_value = [
+            {"hour": 10, "posted": 9, "skipped": 1, "total": 10, "approval_rate": 0.90},
+            {"hour": 14, "posted": 8, "skipped": 2, "total": 10, "approval_rate": 0.80},
+        ]
+        service.history_repo.get_dow_approval_rates.return_value = [
+            {
+                "dow": 1,
+                "day_name": "Monday",
+                "posted": 9,
+                "skipped": 1,
+                "total": 10,
+                "approval_rate": 0.90,
+            },
+        ]
+
+        result = service.get_schedule_recommendations(telegram_chat_id=123)
+
+        assert result["status"] == "ok"
+        # Difference is only 0.10 — at threshold, shouldn't crash regardless of outcome
+        assert isinstance(result["recommendations"], list)
+
+    def test_generate_recommendations_static_method(self):
+        """_generate_recommendations works as a pure function."""
+        hourly = [
+            {"hour": 9, "posted": 20, "skipped": 0, "total": 20, "approval_rate": 1.0},
+            {"hour": 22, "posted": 3, "skipped": 7, "total": 10, "approval_rate": 0.3},
+        ]
+        dow = [
+            {
+                "dow": 2,
+                "day_name": "Tuesday",
+                "posted": 15,
+                "skipped": 0,
+                "total": 15,
+                "approval_rate": 1.0,
+            },
+            {
+                "dow": 0,
+                "day_name": "Sunday",
+                "posted": 3,
+                "skipped": 4,
+                "total": 7,
+                "approval_rate": 0.43,
+            },
+        ]
+
+        recs = DashboardService._generate_recommendations(hourly, dow)
+
+        assert len(recs) >= 2  # best_hour + worst_hour at minimum
+        types = {r["type"] for r in recs}
+        assert "best_hour" in types
+        assert "worst_hour" in types


### PR DESCRIPTION
## Summary

Closes #158. Analyzes posting history to identify optimal posting times, completing the Content Intelligence compound play (#150). Phase 1: recommendations API only, no scheduler behavior changes.

- **2 new HistoryRepository methods** — `get_hourly_approval_rates()` groups posts by hour with full status breakdown and approval rate; `get_dow_approval_rates()` does the same by day of week over a 90-day window.
- **DashboardService.get_schedule_recommendations()** — Orchestrates analysis, generates human-readable recommendations (e.g., "Posts at 10:00 have the highest approval rate (94%)"), and handles insufficient data gracefully.
- **`_generate_recommendations()` static method** — Pure function that finds best/worst hours and days, only recommending when patterns are statistically meaningful (>10% difference, >=3 data points per slot).
- **API endpoint** — `GET /api/onboarding/analytics/schedule-recommendations?chat_id=X&days=90`

No database schema changes. No changes to scheduler behavior (Phase 2 — adaptive scheduling — is a separate feature).

## Test plan

- [x] 4 repo tests: hourly rates, DOW rates, empty cases
- [x] 4 service tests: sufficient data, insufficient data, similar rates, static method
- [x] All 1452 existing unit tests pass
- [x] Ruff lint + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)