### PR TITLE
fix: Schedule recommendations review nits (#169-#172)

### DIFF
--- a/src/repositories/history_repository.py
+++ b/src/repositories/history_repository.py
@@ -2,7 +2,7 @@
 
 from dataclasses import dataclass
 from typing import Optional, List
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from sqlalchemy import func, and_
 
 from src.repositories.base_repository import BaseRepository
@@ -68,7 +68,7 @@ class HistoryRepository(BaseRepository):
             query = query.filter(PostingHistory.status == status)
 
         if days:
-            since = datetime.utcnow() - timedelta(days=days)
+            since = datetime.now(timezone.utc) - timedelta(days=days)
             query = query.filter(PostingHistory.posted_at >= since)
 
         query = query.order_by(PostingHistory.posted_at.desc())
@@ -139,7 +139,7 @@ class HistoryRepository(BaseRepository):
         self, hours: int = 24, chat_settings_id: Optional[str] = None
     ) -> List[PostingHistory]:
         """Get posts from the last N hours."""
-        since = datetime.utcnow() - timedelta(hours=hours)
+        since = datetime.now(timezone.utc) - timedelta(hours=hours)
         result = (
             self._tenant_query(PostingHistory, chat_settings_id)
             .filter(PostingHistory.posted_at >= since)
@@ -207,7 +207,7 @@ class HistoryRepository(BaseRepository):
 
         Returns: {"posted": N, "skipped": N, "rejected": N, "failed": N}
         """
-        since = datetime.utcnow() - timedelta(days=days)
+        since = datetime.now(timezone.utc) - timedelta(days=days)
         rows = (
             self._tenant_query(PostingHistory, chat_settings_id)
             .with_entities(PostingHistory.status, func.count(PostingHistory.id))
@@ -225,7 +225,7 @@ class HistoryRepository(BaseRepository):
 
         Returns: {"instagram_api": N, "telegram_manual": N}
         """
-        since = datetime.utcnow() - timedelta(days=days)
+        since = datetime.now(timezone.utc) - timedelta(days=days)
         rows = (
             self._tenant_query(PostingHistory, chat_settings_id)
             .with_entities(PostingHistory.posting_method, func.count(PostingHistory.id))
@@ -245,7 +245,7 @@ class HistoryRepository(BaseRepository):
         """
         from sqlalchemy import cast, Date
 
-        since = datetime.utcnow() - timedelta(days=days)
+        since = datetime.now(timezone.utc) - timedelta(days=days)
         rows = (
             self._tenant_query(PostingHistory, chat_settings_id)
             .with_entities(
@@ -279,7 +279,7 @@ class HistoryRepository(BaseRepository):
         """
         from sqlalchemy import extract
 
-        since = datetime.utcnow() - timedelta(days=days)
+        since = datetime.now(timezone.utc) - timedelta(days=days)
         rows = (
             self._tenant_query(PostingHistory, chat_settings_id)
             .with_entities(
@@ -304,7 +304,7 @@ class HistoryRepository(BaseRepository):
         """
         from src.models.media_item import MediaItem
 
-        since = datetime.utcnow() - timedelta(days=days)
+        since = datetime.now(timezone.utc) - timedelta(days=days)
         coalesced_category = func.coalesce(MediaItem.category, "uncategorized")
         rows = (
             self._tenant_query(PostingHistory, chat_settings_id)
@@ -346,7 +346,7 @@ class HistoryRepository(BaseRepository):
         """
         from sqlalchemy import extract
 
-        since = datetime.utcnow() - timedelta(days=days)
+        since = datetime.now(timezone.utc) - timedelta(days=days)
         rows = (
             self._tenant_query(PostingHistory, chat_settings_id)
             .with_entities(
@@ -396,7 +396,7 @@ class HistoryRepository(BaseRepository):
             "Saturday",
         ]
 
-        since = datetime.utcnow() - timedelta(days=days)
+        since = datetime.now(timezone.utc) - timedelta(days=days)
         rows = (
             self._tenant_query(PostingHistory, chat_settings_id)
             .with_entities(

--- a/src/services/core/dashboard_service.py
+++ b/src/services/core/dashboard_service.py
@@ -18,6 +18,8 @@ class DashboardService(BaseService):
     repository imports.
     """
 
+    MIN_RECOMMENDATION_DATA_POINTS = 10
+
     def __init__(self):
         super().__init__()
         self.settings_service = SettingsService()
@@ -240,8 +242,6 @@ class DashboardService(BaseService):
         human-readable recommendations based on when posts are most
         frequently approved vs skipped/rejected.
         """
-        MIN_DATA_POINTS = 10
-
         with self.track_execution(
             "get_schedule_recommendations",
             input_params={"telegram_chat_id": telegram_chat_id, "days": days},
@@ -257,7 +257,7 @@ class DashboardService(BaseService):
 
             total_data_points = sum(h.get("total", 0) for h in hourly)
 
-            if total_data_points < MIN_DATA_POINTS:
+            if total_data_points < self.MIN_RECOMMENDATION_DATA_POINTS:
                 self.set_result_summary(
                     run_id,
                     {"status": "insufficient_data", "data_points": total_data_points},
@@ -265,7 +265,7 @@ class DashboardService(BaseService):
                 return {
                     "status": "insufficient_data",
                     "message": (
-                        f"Need at least {MIN_DATA_POINTS} posts to generate "
+                        f"Need at least {self.MIN_RECOMMENDATION_DATA_POINTS} posts to generate "
                         f"recommendations (have {total_data_points})"
                     ),
                     "hourly_rates": [],
@@ -291,6 +291,7 @@ class DashboardService(BaseService):
                 "recommendations": recommendations,
                 "days": days,
                 "data_points": total_data_points,
+                "timezone": "UTC",
             }
 
     @staticmethod
@@ -309,7 +310,7 @@ class DashboardService(BaseService):
                     {
                         "type": "best_hour",
                         "message": (
-                            f"Posts at {best_hour['hour']}:00 have the highest "
+                            f"Posts at {best_hour['hour']}:00 UTC have the highest "
                             f"approval rate ({best_hour['approval_rate']:.0%})"
                         ),
                         "hour": best_hour["hour"],
@@ -322,7 +323,7 @@ class DashboardService(BaseService):
                     {
                         "type": "worst_hour",
                         "message": (
-                            f"Posts at {worst_hour['hour']}:00 have a low "
+                            f"Posts at {worst_hour['hour']}:00 UTC have a low "
                             f"approval rate ({worst_hour['approval_rate']:.0%}) — "
                             f"consider avoiding this time"
                         ),
@@ -347,6 +348,20 @@ class DashboardService(BaseService):
                         ),
                         "day_name": best_day["day_name"],
                         "approval_rate": best_day["approval_rate"],
+                    }
+                )
+
+            if worst_day["approval_rate"] < 0.7 and worst_day["total"] >= 5:
+                recommendations.append(
+                    {
+                        "type": "worst_day",
+                        "message": (
+                            f"{worst_day['day_name']}s have a low approval rate "
+                            f"({worst_day['approval_rate']:.0%}) — "
+                            f"consider reducing posts on this day"
+                        ),
+                        "day_name": worst_day["day_name"],
+                        "approval_rate": worst_day["approval_rate"],
                     }
                 )
 

--- a/tests/src/services/test_dashboard_service.py
+++ b/tests/src/services/test_dashboard_service.py
@@ -580,7 +580,10 @@ class TestGetScheduleRecommendations:
 
         recs = DashboardService._generate_recommendations(hourly, dow)
 
-        assert len(recs) >= 2  # best_hour + worst_hour at minimum
         types = {r["type"] for r in recs}
         assert "best_hour" in types
         assert "worst_hour" in types
+        assert "best_day" in types
+        assert "worst_day" in types
+        worst_day_rec = next(r for r in recs if r["type"] == "worst_day")
+        assert worst_day_rec["day_name"] == "Sunday"


### PR DESCRIPTION
## Summary

Bundled fix for 4 review nits on the schedule recommendations feature:

- **#169** UTC timezone note — Response includes `"timezone": "UTC"` field. Recommendation messages now say "10:00 UTC" instead of bare "10:00".
- **#170** Replace `datetime.utcnow()` — All 9 occurrences in `history_repository.py` replaced with `datetime.now(timezone.utc)` (deprecated in Python 3.12+).
- **#171** Class constant — `MIN_DATA_POINTS` moved from local variable to `DashboardService.MIN_RECOMMENDATION_DATA_POINTS` class constant.
- **#172** Worst day recommendation — Added `worst_day` recommendation type alongside `best_day`. Fires when a day has <70% approval rate with >=5 data points.

## Test plan

- [x] Updated static method test to assert `worst_day` recommendation
- [x] All 1452 unit tests pass
- [x] Ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)