### PR TITLE
feat: startup migration version check (#118)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Startup Migration Version Check (#118)
+
+- **Schema version validation on startup** — Worker (`main.py`) now queries the `schema_version` table at boot and compares against migration files in `scripts/migrations/`. Logs a clear warning if the database is behind (with the exact migration range to apply) or ahead of the deployed code.
+- **Non-blocking** — Mismatches produce warnings, not fatal errors, so the worker can still start while the operator applies pending migrations.
+
 ### Added — Schedule Optimization Recommendations (#158)
 
 - **Schedule recommendations API** — `GET /api/onboarding/analytics/schedule-recommendations` analyzes posting history to identify optimal posting times. Returns hourly approval rates, day-of-week patterns, and human-readable recommendations (e.g., "Posts at 10:00 have the highest approval rate (94%)").

--- a/src/main.py
+++ b/src/main.py
@@ -536,6 +536,9 @@ async def main_async():
 
     logger.info("✓ Configuration validated successfully")
 
+    # Check database schema version
+    ConfigValidator.check_schema_version()
+
     # Initialize services
     from src.services.core.settings_service import SettingsService
 

--- a/src/utils/validators.py
+++ b/src/utils/validators.py
@@ -1,9 +1,26 @@
 """Input validation and configuration validation."""
 
-from typing import List, Tuple
+import re
 from pathlib import Path
+from typing import List, Optional, Tuple
 
 from src.config.settings import settings
+from src.utils.logger import logger
+
+# Derive expected schema version from migration filenames (NNN_description.sql).
+MIGRATIONS_DIR = Path(__file__).resolve().parents[2] / "scripts" / "migrations"
+
+
+def _latest_migration_version() -> Optional[int]:
+    """Return the highest migration version number from scripts/migrations/."""
+    if not MIGRATIONS_DIR.is_dir():
+        return None
+    versions = []
+    for f in MIGRATIONS_DIR.iterdir():
+        m = re.match(r"^(\d+)_", f.name)
+        if m:
+            versions.append(int(m.group(1)))
+    return max(versions) if versions else None
 
 
 class ConfigValidator:
@@ -68,3 +85,45 @@ class ConfigValidator:
 
         is_valid = len(errors) == 0
         return is_valid, errors
+
+    @staticmethod
+    def check_schema_version() -> None:
+        """Check that the database schema matches the latest migration.
+
+        Queries the schema_version table and compares against migration files
+        in scripts/migrations/. Logs a warning on mismatch but does not block
+        startup — the operator is expected to apply migrations manually.
+        """
+        from sqlalchemy import text
+
+        from src.config.database import engine
+
+        expected = _latest_migration_version()
+        if expected is None:
+            logger.warning("Schema version check skipped — no migration files found")
+            return
+
+        try:
+            with engine.connect() as conn:
+                row = conn.execute(
+                    text("SELECT MAX(version) FROM schema_version")
+                ).scalar()
+                db_version = int(row) if row is not None else 0
+        except Exception as exc:
+            logger.warning(f"Schema version check failed: {exc}")
+            return
+
+        if db_version < expected:
+            logger.warning(
+                f"Database schema is behind: DB at version {db_version}, "
+                f"latest migration is {expected}. "
+                f"Run pending migrations ({db_version + 1}–{expected}) before "
+                f"relying on new features."
+            )
+        elif db_version > expected:
+            logger.warning(
+                f"Database schema ({db_version}) is ahead of migration files "
+                f"({expected}) — are migration files missing from this deploy?"
+            )
+        else:
+            logger.info(f"✓ Database schema is up to date (version {db_version})")

--- a/tests/src/utils/test_validators.py
+++ b/tests/src/utils/test_validators.py
@@ -333,3 +333,108 @@ class TestConfigValidator:
 
         assert is_valid is False
         assert len(errors) >= 3  # At least 3 errors
+
+
+@pytest.mark.unit
+class TestLatestMigrationVersion:
+    """Tests for _latest_migration_version helper."""
+
+    def test_reads_real_migrations_dir(self):
+        """Sanity check: finds migrations from the actual scripts/ directory."""
+        from src.utils.validators import _latest_migration_version
+
+        version = _latest_migration_version()
+        assert version is not None
+        assert version >= 22  # current count at time of writing
+
+    @patch("src.utils.validators.MIGRATIONS_DIR")
+    def test_returns_none_when_dir_missing(self, mock_dir):
+        """Returns None when migrations directory doesn't exist."""
+        from src.utils.validators import _latest_migration_version
+
+        mock_dir.is_dir.return_value = False
+        assert _latest_migration_version() is None
+
+    @patch("src.utils.validators.MIGRATIONS_DIR")
+    def test_returns_none_when_no_sql_files(self, mock_dir):
+        """Returns None when directory has no migration files."""
+        from src.utils.validators import _latest_migration_version
+
+        mock_dir.is_dir.return_value = True
+        mock_dir.iterdir.return_value = []
+        assert _latest_migration_version() is None
+
+
+@pytest.mark.unit
+class TestCheckSchemaVersion:
+    """Tests for ConfigValidator.check_schema_version."""
+
+    @patch("src.utils.validators.logger")
+    @patch("src.utils.validators._latest_migration_version", return_value=22)
+    @patch("src.config.database.engine")
+    def test_logs_success_when_versions_match(
+        self, mock_engine, mock_latest, mock_logger
+    ):
+        """Logs success when DB version matches migration files."""
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.scalar.return_value = 22
+        mock_engine.connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        ConfigValidator.check_schema_version()
+
+        mock_logger.info.assert_called_once()
+        assert "up to date (version 22)" in mock_logger.info.call_args[0][0]
+
+    @patch("src.utils.validators.logger")
+    @patch("src.utils.validators._latest_migration_version", return_value=22)
+    @patch("src.config.database.engine")
+    def test_warns_when_db_behind(self, mock_engine, mock_latest, mock_logger):
+        """Warns when DB version is behind migration files."""
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.scalar.return_value = 18
+        mock_engine.connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        ConfigValidator.check_schema_version()
+
+        mock_logger.warning.assert_called_once()
+        msg = mock_logger.warning.call_args[0][0]
+        assert "DB at version 18" in msg
+        assert "latest migration is 22" in msg
+
+    @patch("src.utils.validators.logger")
+    @patch("src.utils.validators._latest_migration_version", return_value=20)
+    @patch("src.config.database.engine")
+    def test_warns_when_db_ahead(self, mock_engine, mock_latest, mock_logger):
+        """Warns when DB version is ahead of migration files."""
+        mock_conn = MagicMock()
+        mock_conn.execute.return_value.scalar.return_value = 25
+        mock_engine.connect.return_value.__enter__ = MagicMock(return_value=mock_conn)
+        mock_engine.connect.return_value.__exit__ = MagicMock(return_value=False)
+
+        ConfigValidator.check_schema_version()
+
+        mock_logger.warning.assert_called_once()
+        assert "ahead of migration files" in mock_logger.warning.call_args[0][0]
+
+    @patch("src.utils.validators.logger")
+    @patch("src.utils.validators._latest_migration_version", return_value=None)
+    def test_skips_when_no_migrations(self, mock_latest, mock_logger):
+        """Skips check when no migration files found."""
+        ConfigValidator.check_schema_version()
+
+        mock_logger.warning.assert_called_once()
+        assert "no migration files found" in mock_logger.warning.call_args[0][0]
+
+    @patch("src.utils.validators.logger")
+    @patch("src.utils.validators._latest_migration_version", return_value=22)
+    @patch("src.config.database.engine")
+    def test_handles_db_error_gracefully(self, mock_engine, mock_latest, mock_logger):
+        """Handles database connection errors without crashing."""
+        mock_engine.connect.side_effect = Exception("Connection refused")
+
+        ConfigValidator.check_schema_version()
+
+        mock_logger.warning.assert_called_once()
+        assert "Schema version check failed" in mock_logger.warning.call_args[0][0]


### PR DESCRIPTION
## Summary

- Adds schema version validation on worker startup — queries `schema_version` table and compares against migration files in `scripts/migrations/`
- Logs a clear warning if the database is behind (with exact migration range to apply) or ahead of the deployed code
- Non-blocking: mismatches produce warnings, not fatal errors, so the worker can still start

Closes #118

## Test plan

- [x] 8 new unit tests covering: version match, DB behind, DB ahead, no migrations dir, DB error handling
- [x] All 1460 existing unit tests pass
- [x] Lint and format checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)