### PR TITLE
feat: category mix drift alerts & dead content report (#176, #177)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Category Mix Drift Alerts (#176)
+
+- **Category drift analytics** — `GET /api/onboarding/analytics/category-drift` compares configured posting ratios against actual ratios over a time window. Flags categories as ok/warning/critical based on drift thresholds (10%/25%).
+- **`get_category_mix_drift()`** in DashboardService — combines `category_post_case_mix` targets with `posting_history` actuals to compute per-category drift.
+
+### Added — Dead Content Report (#177)
+
+- **Dead content analytics** — `GET /api/onboarding/analytics/dead-content` surfaces active media items that have never been posted and are older than a configurable age threshold (default 30 days). Returns per-category breakdown and dead percentage of total pool.
+- **`count_dead_content_by_category()`** in MediaRepository — filters `is_active=True, times_posted=0, created_at <= cutoff` grouped by category.
+
 ### Added — Schedule Optimization Recommendations (#158)
 
 - **Schedule recommendations API** — `GET /api/onboarding/analytics/schedule-recommendations` analyzes posting history to identify optimal posting times. Returns hourly approval rates, day-of-week patterns, and human-readable recommendations (e.g., "Posts at 10:00 have the highest approval rate (94%)").

--- a/src/api/routes/onboarding/dashboard.py
+++ b/src/api/routes/onboarding/dashboard.py
@@ -110,6 +110,32 @@ async def onboarding_analytics_categories(
         return service.get_category_analytics(chat_id, days=days)
 
 
+@router.get("/analytics/category-drift")
+async def onboarding_category_drift(
+    init_data: str,
+    chat_id: int,
+    days: int = Query(default=7, ge=1, le=90),
+):
+    """Return category mix drift — configured vs actual posting ratios."""
+    _validate_request(init_data, chat_id)
+
+    with DashboardService() as service:
+        return service.get_category_mix_drift(chat_id, days=days)
+
+
+@router.get("/analytics/dead-content")
+async def onboarding_dead_content(
+    init_data: str,
+    chat_id: int,
+    min_age_days: int = Query(default=30, ge=1, le=365),
+):
+    """Return dead content report — never-posted media items."""
+    _validate_request(init_data, chat_id)
+
+    with DashboardService() as service:
+        return service.get_dead_content_report(chat_id, min_age_days=min_age_days)
+
+
 @router.get("/analytics")
 async def onboarding_analytics(
     init_data: str,

--- a/src/repositories/media_repository.py
+++ b/src/repositories/media_repository.py
@@ -501,6 +501,33 @@ class MediaRepository(BaseRepository):
             "posted_multiple": buckets.get(2, 0),
         }
 
+    def count_dead_content_by_category(
+        self, min_age_days: int = 30, chat_settings_id: Optional[str] = None
+    ) -> list:
+        """Count active items that have never been posted, grouped by category.
+
+        "Dead content" = is_active=True, times_posted=0, and older than min_age_days.
+        Returns list of {"category": str, "dead_count": int}.
+        """
+        from datetime import timezone
+
+        cutoff = datetime.now(timezone.utc) - timedelta(days=min_age_days)
+        coalesced = func.coalesce(MediaItem.category, "uncategorized")
+        rows = (
+            self._tenant_query(MediaItem, chat_settings_id)
+            .with_entities(coalesced.label("category"), func.count(MediaItem.id))
+            .filter(
+                MediaItem.is_active.is_(True),
+                MediaItem.times_posted == 0,
+                MediaItem.created_at <= cutoff,
+            )
+            .group_by(coalesced)
+            .order_by(coalesced)
+            .all()
+        )
+        self.end_read_transaction()
+        return [{"category": cat, "dead_count": count} for cat, count in rows]
+
     def count_by_category(self, chat_settings_id: Optional[str] = None) -> dict:
         """Count active media grouped by category."""
         rows = (

--- a/src/services/core/dashboard_service.py
+++ b/src/services/core/dashboard_service.py
@@ -233,6 +233,112 @@ class DashboardService(BaseService):
                 "days": days,
             }
 
+    def get_category_mix_drift(self, telegram_chat_id: int, days: int = 7) -> dict:
+        """Compare actual posting ratios against configured targets.
+
+        Returns per-category drift (absolute difference between actual
+        and configured ratios) with warning/critical thresholds.
+        """
+        with self.track_execution(
+            "get_category_mix_drift",
+            input_params={"telegram_chat_id": telegram_chat_id, "days": days},
+        ) as run_id:
+            chat_settings_id = self._resolve_chat_settings_id(telegram_chat_id)
+
+            configured = self.category_mix_repo.get_current_mix_as_dict(
+                chat_settings_id=chat_settings_id
+            )
+            actual_stats = self.history_repo.get_stats_by_category(
+                days=days, chat_settings_id=chat_settings_id
+            )
+
+            total_posted = sum(c.get("posted", 0) for c in actual_stats)
+
+            categories = []
+            max_drift = 0.0
+            for name, target_ratio in configured.items():
+                actual_posted = 0
+                for c in actual_stats:
+                    if c["category"] == name:
+                        actual_posted = c.get("posted", 0)
+                        break
+                actual_ratio = (
+                    round(actual_posted / total_posted, 2) if total_posted else 0
+                )
+                drift = round(abs(actual_ratio - float(target_ratio)), 2)
+                max_drift = max(max_drift, drift)
+
+                status = "ok"
+                if drift >= 0.25:
+                    status = "critical"
+                elif drift >= 0.10:
+                    status = "warning"
+
+                categories.append(
+                    {
+                        "category": name,
+                        "configured_ratio": float(target_ratio),
+                        "actual_ratio": actual_ratio,
+                        "drift": drift,
+                        "status": status,
+                    }
+                )
+
+            healthy = max_drift < 0.10
+            self.set_result_summary(
+                run_id,
+                {
+                    "healthy": healthy,
+                    "max_drift": max_drift,
+                    "categories": len(categories),
+                },
+            )
+            return {
+                "healthy": healthy,
+                "max_drift": max_drift,
+                "categories": categories,
+                "total_posted": total_posted,
+                "days": days,
+            }
+
+    def get_dead_content_report(
+        self, telegram_chat_id: int, min_age_days: int = 30
+    ) -> dict:
+        """Surface media items that have never been posted.
+
+        Returns dead content count and per-category breakdown,
+        alongside total pool stats for context.
+        """
+        with self.track_execution(
+            "get_dead_content_report",
+            input_params={
+                "telegram_chat_id": telegram_chat_id,
+                "min_age_days": min_age_days,
+            },
+        ) as run_id:
+            chat_settings_id = self._resolve_chat_settings_id(telegram_chat_id)
+
+            total_active = self.media_repo.count_active(
+                chat_settings_id=chat_settings_id
+            )
+            dead_by_category = self.media_repo.count_dead_content_by_category(
+                min_age_days=min_age_days, chat_settings_id=chat_settings_id
+            )
+            total_dead = sum(c["dead_count"] for c in dead_by_category)
+            dead_pct = round(total_dead / total_active, 2) if total_active else 0
+
+            self.set_result_summary(
+                run_id,
+                {"total_dead": total_dead, "dead_pct": dead_pct},
+            )
+            return {
+                "total_active": total_active,
+                "total_dead": total_dead,
+                "dead_percentage": dead_pct,
+                "by_category": dead_by_category,
+                "min_age_days": min_age_days,
+            }
+
     def get_schedule_recommendations(
         self, telegram_chat_id: int, days: int = 90
     ) -> dict:

--- a/tests/src/repositories/test_media_repository.py
+++ b/tests/src/repositories/test_media_repository.py
@@ -611,3 +611,36 @@ class TestClearStaleCloudInfo:
         media_repo.clear_stale_cloud_info(retention_hours=24)
 
         mock_db.query.assert_called_with(MediaItem)
+
+
+@pytest.mark.unit
+class TestCountDeadContentByCategory:
+    """Tests for count_dead_content_by_category."""
+
+    def test_returns_per_category_dead_count(self, media_repo, mock_db):
+        """Returns dead content grouped by category."""
+        q = mock_db.query.return_value
+        q.with_entities.return_value = q
+        q.filter.return_value = q
+        q.group_by.return_value = q
+        q.order_by.return_value = q
+        q.all.return_value = [("memes", 15), ("merch", 5)]
+
+        result = media_repo.count_dead_content_by_category(min_age_days=30)
+
+        assert len(result) == 2
+        assert result[0] == {"category": "memes", "dead_count": 15}
+        assert result[1] == {"category": "merch", "dead_count": 5}
+
+    def test_returns_empty_when_no_dead_content(self, media_repo, mock_db):
+        """Returns empty list when all content has been posted."""
+        q = mock_db.query.return_value
+        q.with_entities.return_value = q
+        q.filter.return_value = q
+        q.group_by.return_value = q
+        q.order_by.return_value = q
+        q.all.return_value = []
+
+        result = media_repo.count_dead_content_by_category()
+
+        assert result == []

--- a/tests/src/services/test_dashboard_service.py
+++ b/tests/src/services/test_dashboard_service.py
@@ -587,3 +587,120 @@ class TestGetScheduleRecommendations:
         assert "worst_day" in types
         worst_day_rec = next(r for r in recs if r["type"] == "worst_day")
         assert worst_day_rec["day_name"] == "Sunday"
+
+
+@pytest.mark.unit
+class TestGetCategoryMixDrift:
+    """Tests for get_category_mix_drift."""
+
+    def _setup_service(self):
+        with patch.object(DashboardService, "__init__", lambda self: None):
+            service = DashboardService()
+            service.settings_service = MagicMock()
+            service.history_repo = MagicMock()
+            service.category_mix_repo = MagicMock()
+            service.service_run_repo = MagicMock()
+            service.service_name = "DashboardService"
+            mock_settings = Mock(id="tenant-uuid-1")
+            service.settings_service.get_settings.return_value = mock_settings
+            return service
+
+    def test_detects_drift(self):
+        """Flags categories with significant drift as warning/critical."""
+        from decimal import Decimal
+
+        service = self._setup_service()
+        service.category_mix_repo.get_current_mix_as_dict.return_value = {
+            "memes": Decimal("0.60"),
+            "merch": Decimal("0.40"),
+        }
+        service.history_repo.get_stats_by_category.return_value = [
+            {"category": "memes", "posted": 30},
+            {"category": "merch", "posted": 70},
+        ]
+
+        result = service.get_category_mix_drift(telegram_chat_id=123, days=7)
+
+        assert not result["healthy"]
+        memes = next(c for c in result["categories"] if c["category"] == "memes")
+        assert memes["configured_ratio"] == 0.60
+        assert memes["actual_ratio"] == 0.30
+        assert memes["drift"] == 0.30
+        assert memes["status"] == "critical"
+
+    def test_healthy_when_no_drift(self):
+        """Reports healthy when actual matches configured."""
+        from decimal import Decimal
+
+        service = self._setup_service()
+        service.category_mix_repo.get_current_mix_as_dict.return_value = {
+            "memes": Decimal("0.50"),
+            "merch": Decimal("0.50"),
+        }
+        service.history_repo.get_stats_by_category.return_value = [
+            {"category": "memes", "posted": 50},
+            {"category": "merch", "posted": 50},
+        ]
+
+        result = service.get_category_mix_drift(telegram_chat_id=123)
+
+        assert result["healthy"]
+        assert result["max_drift"] == 0.0
+
+    def test_handles_no_posts(self):
+        """Returns zeros when no posting history."""
+        from decimal import Decimal
+
+        service = self._setup_service()
+        service.category_mix_repo.get_current_mix_as_dict.return_value = {
+            "memes": Decimal("1.0"),
+        }
+        service.history_repo.get_stats_by_category.return_value = []
+
+        result = service.get_category_mix_drift(telegram_chat_id=123)
+
+        assert result["total_posted"] == 0
+        assert result["categories"][0]["actual_ratio"] == 0
+
+
+@pytest.mark.unit
+class TestGetDeadContentReport:
+    """Tests for get_dead_content_report."""
+
+    def _setup_service(self):
+        with patch.object(DashboardService, "__init__", lambda self: None):
+            service = DashboardService()
+            service.settings_service = MagicMock()
+            service.media_repo = MagicMock()
+            service.service_run_repo = MagicMock()
+            service.service_name = "DashboardService"
+            mock_settings = Mock(id="tenant-uuid-1")
+            service.settings_service.get_settings.return_value = mock_settings
+            return service
+
+    def test_returns_dead_content_breakdown(self):
+        """Returns total dead, percentage, and per-category data."""
+        service = self._setup_service()
+        service.media_repo.count_active.return_value = 100
+        service.media_repo.count_dead_content_by_category.return_value = [
+            {"category": "memes", "dead_count": 15},
+            {"category": "merch", "dead_count": 5},
+        ]
+
+        result = service.get_dead_content_report(telegram_chat_id=123)
+
+        assert result["total_active"] == 100
+        assert result["total_dead"] == 20
+        assert result["dead_percentage"] == 0.20
+        assert len(result["by_category"]) == 2
+
+    def test_handles_empty_pool(self):
+        """Returns zeros when no active media."""
+        service = self._setup_service()
+        service.media_repo.count_active.return_value = 0
+        service.media_repo.count_dead_content_by_category.return_value = []
+
+        result = service.get_dead_content_report(telegram_chat_id=123)
+
+        assert result["total_dead"] == 0
+        assert result["dead_percentage"] == 0


### PR DESCRIPTION
## Summary

- **Category mix drift** — `GET /analytics/category-drift` compares configured posting ratios against actual posting ratios over a time window. Per-category drift with ok/warning (>10%)/critical (>25%) status.
- **Dead content report** — `GET /analytics/dead-content` surfaces active media items that have never been posted and are older than a configurable age threshold. Returns per-category breakdown and dead percentage.
- New `count_dead_content_by_category()` method in MediaRepository

Closes #176, closes #177

## Test plan

- [x] 3 new drift tests (drift detection, healthy state, no posts)
- [x] 2 new dead content service tests (breakdown, empty pool)
- [x] 2 new media repo tests (per-category dead count, empty)
- [x] All unit tests pass (1459 passed)
- [x] Lint and format checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)