### PR TITLE
feat: schedule preview, content reuse insights, service health (#178, #179, #180)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Post Preview Window (#178)
+
+- **Schedule preview** — `GET /api/onboarding/analytics/schedule-preview` shows upcoming N slots with predicted times and categories. Uses the same interval and category weighting logic as the scheduler. Informational only — does not pre-select media.
+
+### Added — Content Reuse Insights (#179)
+
+- **Content reuse analytics** — `GET /api/onboarding/analytics/content-reuse` classifies the media pool into never_posted, posted_once, and posted_multiple tiers. Includes per-category breakdown and overall reuse rate.
+
+### Added — Service Health Dashboard (#180)
+
+- **Service telemetry** — `GET /api/onboarding/analytics/service-health` aggregates service_runs table into per-service call counts, error rates, and avg execution duration over a configurable time window.
+- **`get_health_stats()`** in ServiceRunRepository — groups completed/failed runs by service name with aggregation.
+
 ### Added — Schedule Optimization Recommendations (#158)
 
 - **Schedule recommendations API** — `GET /api/onboarding/analytics/schedule-recommendations` analyzes posting history to identify optimal posting times. Returns hourly approval rates, day-of-week patterns, and human-readable recommendations (e.g., "Posts at 10:00 have the highest approval rate (94%)").

--- a/src/api/routes/onboarding/dashboard.py
+++ b/src/api/routes/onboarding/dashboard.py
@@ -138,11 +138,17 @@ async def onboarding_content_reuse(
 @router.get("/analytics/service-health")
 async def onboarding_service_health(
     init_data: str,
-    chat_id: int,
     hours: int = Query(default=24, ge=1, le=168),
 ):
-    """Return service execution telemetry from service_runs table."""
-    _validate_request(init_data, chat_id)
+    """Return service execution telemetry from service_runs table.
+
+    Global view — service_runs are system-level, not per-tenant.
+    Requires valid init_data for authentication but does not scope by chat.
+    """
+    # Auth-only validation (no chat_id scoping — service runs are global)
+    from src.utils.webapp_auth import validate_init_data
+
+    validate_init_data(init_data)
 
     with DashboardService() as service:
         return service.get_service_health_stats(hours=hours)

--- a/src/api/routes/onboarding/dashboard.py
+++ b/src/api/routes/onboarding/dashboard.py
@@ -110,6 +110,44 @@ async def onboarding_analytics_categories(
         return service.get_category_analytics(chat_id, days=days)
 
 
+@router.get("/analytics/schedule-preview")
+async def onboarding_schedule_preview(
+    init_data: str,
+    chat_id: int,
+    slots: int = Query(default=10, ge=1, le=50),
+):
+    """Return upcoming scheduled slots with predicted categories."""
+    _validate_request(init_data, chat_id)
+
+    with DashboardService() as service:
+        return service.get_schedule_preview(chat_id, slots=slots)
+
+
+@router.get("/analytics/content-reuse")
+async def onboarding_content_reuse(
+    init_data: str,
+    chat_id: int,
+):
+    """Return content reuse insights — evergreen vs one-shot media."""
+    _validate_request(init_data, chat_id)
+
+    with DashboardService() as service:
+        return service.get_content_reuse_insights(chat_id)
+
+
+@router.get("/analytics/service-health")
+async def onboarding_service_health(
+    init_data: str,
+    chat_id: int,
+    hours: int = Query(default=24, ge=1, le=168),
+):
+    """Return service execution telemetry from service_runs table."""
+    _validate_request(init_data, chat_id)
+
+    with DashboardService() as service:
+        return service.get_service_health_stats(hours=hours)
+
+
 @router.get("/analytics")
 async def onboarding_analytics(
     init_data: str,

--- a/src/repositories/service_run_repository.py
+++ b/src/repositories/service_run_repository.py
@@ -3,6 +3,7 @@
 from typing import Optional, List
 from datetime import datetime, timedelta
 
+
 from src.repositories.base_repository import BaseRepository
 from src.models.service_run import ServiceRun
 
@@ -135,3 +136,45 @@ class ServiceRunRepository(BaseRepository):
         )
         self.end_read_transaction()
         return result
+
+    def get_health_stats(self, hours: int = 24) -> list:
+        """Aggregate service run stats per service over a time window.
+
+        Returns per-service: call_count, success_count, failure_count,
+        error_rate, avg_duration_ms.
+        """
+        from sqlalchemy import case, func
+
+        since = datetime.utcnow() - timedelta(hours=hours)
+        rows = (
+            self.db.query(
+                ServiceRun.service_name,
+                func.count(ServiceRun.id).label("call_count"),
+                func.sum(case((ServiceRun.status == "completed", 1), else_=0)).label(
+                    "success_count"
+                ),
+                func.sum(case((ServiceRun.status == "failed", 1), else_=0)).label(
+                    "failure_count"
+                ),
+                func.avg(ServiceRun.duration_ms).label("avg_duration_ms"),
+            )
+            .filter(ServiceRun.started_at >= since)
+            .group_by(ServiceRun.service_name)
+            .order_by(func.count(ServiceRun.id).desc())
+            .all()
+        )
+        self.end_read_transaction()
+
+        return [
+            {
+                "service_name": r.service_name,
+                "call_count": r.call_count,
+                "success_count": r.success_count or 0,
+                "failure_count": r.failure_count or 0,
+                "error_rate": round((r.failure_count or 0) / r.call_count, 2)
+                if r.call_count
+                else 0,
+                "avg_duration_ms": round(r.avg_duration_ms) if r.avg_duration_ms else 0,
+            }
+            for r in rows
+        ]

--- a/src/repositories/service_run_repository.py
+++ b/src/repositories/service_run_repository.py
@@ -1,8 +1,9 @@
 """Service run repository - CRUD operations for service runs."""
 
 from typing import Optional, List
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
+from sqlalchemy import case, func
 
 from src.repositories.base_repository import BaseRepository
 from src.models.service_run import ServiceRun
@@ -143,9 +144,7 @@ class ServiceRunRepository(BaseRepository):
         Returns per-service: call_count, success_count, failure_count,
         error_rate, avg_duration_ms.
         """
-        from sqlalchemy import case, func
-
-        since = datetime.utcnow() - timedelta(hours=hours)
+        since = datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(hours=hours)
         rows = (
             self.db.query(
                 ServiceRun.service_name,

--- a/src/services/core/dashboard_service.py
+++ b/src/services/core/dashboard_service.py
@@ -367,6 +367,119 @@ class DashboardService(BaseService):
 
         return recommendations
 
+    def get_schedule_preview(self, telegram_chat_id: int, slots: int = 10) -> dict:
+        """Show upcoming scheduled slots with predicted categories.
+
+        Computes future slot times from the posting interval and
+        assigns categories using weighted random (same logic as the
+        scheduler).  Does NOT select specific media items.
+        """
+        import random
+        from datetime import datetime, timedelta
+
+        chat_settings = self.settings_service.get_settings(telegram_chat_id)
+
+        if chat_settings.is_paused:
+            return {"status": "paused", "slots": []}
+
+        ppd = chat_settings.posts_per_day
+        start_h = chat_settings.posting_hours_start
+        end_h = chat_settings.posting_hours_end
+        window_hours = (24 - start_h + end_h) if end_h < start_h else (end_h - start_h)
+        interval_seconds = (window_hours * 3600) / ppd if ppd else 3600
+
+        # Start from last_post or now
+        now = datetime.utcnow()
+        last = chat_settings.last_post_sent_at
+        if last and last.tzinfo:
+            last = last.replace(tzinfo=None)
+        next_time = last + timedelta(seconds=interval_seconds) if last else now
+
+        # Get category weights
+        configured = self.category_mix_repo.get_current_mix_as_dict(
+            chat_settings_id=str(chat_settings.id)
+        )
+        categories = list(configured.keys()) if configured else []
+        weights = [float(r) for r in configured.values()] if configured else []
+
+        result_slots = []
+        for _ in range(slots):
+            if next_time < now:
+                next_time = now
+
+            predicted_cat = (
+                random.choices(categories, weights=weights, k=1)[0]
+                if categories
+                else None
+            )
+            result_slots.append(
+                {
+                    "slot_time": next_time.isoformat() + "Z",
+                    "predicted_category": predicted_cat,
+                }
+            )
+            next_time += timedelta(seconds=interval_seconds)
+
+        return {
+            "status": "ok",
+            "slots": result_slots,
+            "interval_minutes": round(interval_seconds / 60, 1),
+            "posts_per_day": ppd,
+            "timezone": "UTC",
+        }
+
+    def get_content_reuse_insights(self, telegram_chat_id: int) -> dict:
+        """Classify media pool into reuse tiers.
+
+        Uses existing count_by_posting_status() which buckets items
+        into never_posted / posted_once / posted_multiple.  Adds
+        per-category breakdown of never-posted items.
+        """
+        with self.track_execution(
+            "get_content_reuse_insights",
+            input_params={"telegram_chat_id": telegram_chat_id},
+        ) as run_id:
+            chat_settings_id = self._resolve_chat_settings_id(telegram_chat_id)
+
+            posting_status = self.media_repo.count_by_posting_status(
+                chat_settings_id=chat_settings_id
+            )
+            total = sum(posting_status.values())
+            category_counts = self.media_repo.count_by_category(
+                chat_settings_id=chat_settings_id
+            )
+
+            self.set_result_summary(run_id, {"total": total, **posting_status})
+            return {
+                "total_active": total,
+                "never_posted": posting_status["never_posted"],
+                "posted_once": posting_status["posted_once"],
+                "posted_multiple": posting_status["posted_multiple"],
+                "reuse_rate": round(posting_status["posted_multiple"] / total, 2)
+                if total
+                else 0,
+                "categories": category_counts,
+            }
+
+    def get_service_health_stats(self, hours: int = 24) -> dict:
+        """Aggregate service_runs telemetry for an ops dashboard.
+
+        Returns per-service call counts, error rates, and avg duration.
+        """
+        stats = self.service_run_repo.get_health_stats(hours=hours)
+        total_calls = sum(s["call_count"] for s in stats)
+        total_failures = sum(s["failure_count"] for s in stats)
+
+        return {
+            "services": stats,
+            "total_calls": total_calls,
+            "total_failures": total_failures,
+            "overall_error_rate": round(total_failures / total_calls, 2)
+            if total_calls
+            else 0,
+            "hours": hours,
+        }
+
     def get_pending_queue_items(self, chat_settings_id: Optional[str] = None) -> list:
         """Return pending queue items with media details.
 

--- a/src/services/core/dashboard_service.py
+++ b/src/services/core/dashboard_service.py
@@ -372,68 +372,95 @@ class DashboardService(BaseService):
 
         Computes future slot times from the posting interval and
         assigns categories using weighted random (same logic as the
-        scheduler).  Does NOT select specific media items.
+        scheduler).  Does NOT select specific media items.  Slot times
+        are clamped to the configured posting window — if a computed
+        slot falls outside the window, it advances to the next open.
         """
         import random
         from datetime import datetime, timedelta
 
-        chat_settings = self.settings_service.get_settings(telegram_chat_id)
+        with self.track_execution(
+            "get_schedule_preview",
+            input_params={"telegram_chat_id": telegram_chat_id, "slots": slots},
+        ) as run_id:
+            chat_settings = self.settings_service.get_settings(telegram_chat_id)
 
-        if chat_settings.is_paused:
-            return {"status": "paused", "slots": []}
+            if chat_settings.is_paused:
+                self.set_result_summary(run_id, {"status": "paused"})
+                return {"status": "paused", "slots": []}
 
-        ppd = chat_settings.posts_per_day
-        start_h = chat_settings.posting_hours_start
-        end_h = chat_settings.posting_hours_end
-        window_hours = (24 - start_h + end_h) if end_h < start_h else (end_h - start_h)
-        interval_seconds = (window_hours * 3600) / ppd if ppd else 3600
-
-        # Start from last_post or now
-        now = datetime.utcnow()
-        last = chat_settings.last_post_sent_at
-        if last and last.tzinfo:
-            last = last.replace(tzinfo=None)
-        next_time = last + timedelta(seconds=interval_seconds) if last else now
-
-        # Get category weights
-        configured = self.category_mix_repo.get_current_mix_as_dict(
-            chat_settings_id=str(chat_settings.id)
-        )
-        categories = list(configured.keys()) if configured else []
-        weights = [float(r) for r in configured.values()] if configured else []
-
-        result_slots = []
-        for _ in range(slots):
-            if next_time < now:
-                next_time = now
-
-            predicted_cat = (
-                random.choices(categories, weights=weights, k=1)[0]
-                if categories
-                else None
+            ppd = chat_settings.posts_per_day
+            start_h = chat_settings.posting_hours_start
+            end_h = chat_settings.posting_hours_end
+            window_hours = (
+                (24 - start_h + end_h) if end_h < start_h else (end_h - start_h)
             )
-            result_slots.append(
-                {
-                    "slot_time": next_time.isoformat() + "Z",
-                    "predicted_category": predicted_cat,
-                }
-            )
-            next_time += timedelta(seconds=interval_seconds)
+            interval_seconds = (window_hours * 3600) / ppd if ppd else 3600
 
-        return {
-            "status": "ok",
-            "slots": result_slots,
-            "interval_minutes": round(interval_seconds / 60, 1),
-            "posts_per_day": ppd,
-            "timezone": "UTC",
-        }
+            now = datetime.utcnow()
+            last = chat_settings.last_post_sent_at
+            if last and last.tzinfo:
+                last = last.replace(tzinfo=None)
+            next_time = last + timedelta(seconds=interval_seconds) if last else now
+
+            configured = self.category_mix_repo.get_current_mix_as_dict(
+                chat_settings_id=str(chat_settings.id)
+            )
+            categories = list(configured.keys()) if configured else []
+            weights = [float(r) for r in configured.values()] if configured else []
+
+            def _clamp_to_window(dt: datetime) -> datetime:
+                """Advance dt to the next posting window open if outside."""
+                hour = dt.hour + dt.minute / 60.0
+                if end_h < start_h:
+                    in_window = hour >= start_h or hour < end_h
+                else:
+                    in_window = start_h <= hour < end_h
+                if in_window:
+                    return dt
+                # Advance to start_h today or tomorrow
+                candidate = dt.replace(hour=start_h, minute=0, second=0, microsecond=0)
+                if candidate <= dt:
+                    candidate += timedelta(days=1)
+                return candidate
+
+            result_slots = []
+            for _ in range(slots):
+                if next_time < now:
+                    next_time = now
+                next_time = _clamp_to_window(next_time)
+
+                predicted_cat = (
+                    random.choices(categories, weights=weights, k=1)[0]
+                    if categories
+                    else None
+                )
+                result_slots.append(
+                    {
+                        "slot_time": next_time.isoformat() + "Z",
+                        "predicted_category": predicted_cat,
+                    }
+                )
+                next_time += timedelta(seconds=interval_seconds)
+
+            self.set_result_summary(
+                run_id, {"slots": len(result_slots), "status": "ok"}
+            )
+            return {
+                "status": "ok",
+                "slots": result_slots,
+                "interval_minutes": round(interval_seconds / 60, 1),
+                "posts_per_day": ppd,
+                "timezone": "UTC",
+            }
 
     def get_content_reuse_insights(self, telegram_chat_id: int) -> dict:
         """Classify media pool into reuse tiers.
 
         Uses existing count_by_posting_status() which buckets items
-        into never_posted / posted_once / posted_multiple.  Adds
-        per-category breakdown of never-posted items.
+        into never_posted / posted_once / posted_multiple.  Includes
+        per-category breakdown of never-posted items so users can
+        identify which categories have the most stagnant content.
         """
         with self.track_execution(
             "get_content_reuse_insights",
@@ -445,8 +472,8 @@ class DashboardService(BaseService):
                 chat_settings_id=chat_settings_id
             )
             total = sum(posting_status.values())
-            category_counts = self.media_repo.count_by_category(
-                chat_settings_id=chat_settings_id
+            never_posted_by_category = self.media_repo.count_dead_content_by_category(
+                min_age_days=0, chat_settings_id=chat_settings_id
             )
 
             self.set_result_summary(run_id, {"total": total, **posting_status})
@@ -458,13 +485,18 @@ class DashboardService(BaseService):
                 "reuse_rate": round(posting_status["posted_multiple"] / total, 2)
                 if total
                 else 0,
-                "categories": category_counts,
+                "never_posted_by_category": never_posted_by_category,
             }
 
     def get_service_health_stats(self, hours: int = 24) -> dict:
         """Aggregate service_runs telemetry for an ops dashboard.
 
         Returns per-service call counts, error rates, and avg duration.
+
+        NOTE: This is intentionally a global (system-level) view.
+        service_runs are not tenant-scoped — they track internal service
+        executions that span tenants. The API endpoint requires valid
+        auth but does not filter by chat_id.
         """
         stats = self.service_run_repo.get_health_stats(hours=hours)
         total_calls = sum(s["call_count"] for s in stats)

--- a/tests/src/repositories/test_service_run_repository.py
+++ b/tests/src/repositories/test_service_run_repository.py
@@ -167,3 +167,43 @@ class TestServiceRunRepository:
         assert mock_run.result_summary == {"processed": 5}
         # commit called twice: once by get_by_id's end_read_transaction, once by the write
         assert mock_db.commit.call_count == 2
+
+
+@pytest.mark.unit
+class TestGetHealthStats:
+    """Tests for get_health_stats aggregation."""
+
+    def test_returns_per_service_aggregation(self, run_repo, mock_db):
+        """Returns per-service call counts, error rates, avg duration."""
+        mock_query = mock_db.query.return_value
+        mock_query.filter.return_value = mock_query
+        mock_query.group_by.return_value = mock_query
+        mock_query.order_by.return_value = mock_query
+
+        row = MagicMock()
+        row.service_name = "PostingService"
+        row.call_count = 100
+        row.success_count = 95
+        row.failure_count = 5
+        row.avg_duration_ms = 150.5
+        mock_query.all.return_value = [row]
+
+        result = run_repo.get_health_stats(hours=24)
+
+        assert len(result) == 1
+        assert result[0]["service_name"] == "PostingService"
+        assert result[0]["call_count"] == 100
+        assert result[0]["error_rate"] == 0.05
+        assert result[0]["avg_duration_ms"] == 150  # round(150.5) = 150 (banker's)
+
+    def test_returns_empty_when_no_runs(self, run_repo, mock_db):
+        """Returns empty list when no runs in window."""
+        mock_query = mock_db.query.return_value
+        mock_query.filter.return_value = mock_query
+        mock_query.group_by.return_value = mock_query
+        mock_query.order_by.return_value = mock_query
+        mock_query.all.return_value = []
+
+        result = run_repo.get_health_stats(hours=24)
+
+        assert result == []

--- a/tests/src/services/test_dashboard_service.py
+++ b/tests/src/services/test_dashboard_service.py
@@ -593,51 +593,81 @@ class TestGetScheduleRecommendations:
 class TestGetSchedulePreview:
     """Tests for get_schedule_preview."""
 
-    def test_returns_slot_times(self):
-        """Preview returns correct number of slots with interval."""
+    def _setup_service(self):
         with patch.object(DashboardService, "__init__", lambda self: None):
             service = DashboardService()
             service.settings_service = MagicMock()
             service.category_mix_repo = MagicMock()
+            service.service_run_repo = MagicMock()
+            service.service_name = "DashboardService"
+            return service
 
-            from decimal import Decimal
+    def test_returns_slot_times(self):
+        """Preview returns correct number of slots with interval."""
+        from decimal import Decimal
 
-            mock_settings = Mock(
-                id="t1",
-                is_paused=False,
-                posts_per_day=3,
-                posting_hours_start=14,
-                posting_hours_end=2,
-                last_post_sent_at=None,
-            )
-            service.settings_service.get_settings.return_value = mock_settings
-            service.category_mix_repo.get_current_mix_as_dict.return_value = {
-                "memes": Decimal("0.50"),
-                "merch": Decimal("0.50"),
-            }
+        service = self._setup_service()
+        mock_settings = Mock(
+            id="t1",
+            is_paused=False,
+            posts_per_day=3,
+            posting_hours_start=14,
+            posting_hours_end=2,
+            last_post_sent_at=None,
+        )
+        service.settings_service.get_settings.return_value = mock_settings
+        service.category_mix_repo.get_current_mix_as_dict.return_value = {
+            "memes": Decimal("0.50"),
+            "merch": Decimal("0.50"),
+        }
 
-            result = service.get_schedule_preview(telegram_chat_id=123, slots=5)
+        result = service.get_schedule_preview(telegram_chat_id=123, slots=5)
 
-            assert result["status"] == "ok"
-            assert len(result["slots"]) == 5
-            assert result["posts_per_day"] == 3
-            assert all(
-                s["predicted_category"] in ("memes", "merch") for s in result["slots"]
-            )
+        assert result["status"] == "ok"
+        assert len(result["slots"]) == 5
+        assert result["posts_per_day"] == 3
+        assert all(
+            s["predicted_category"] in ("memes", "merch") for s in result["slots"]
+        )
 
     def test_returns_paused_when_paused(self):
         """Preview returns paused status when posting is paused."""
-        with patch.object(DashboardService, "__init__", lambda self: None):
-            service = DashboardService()
-            service.settings_service = MagicMock()
+        service = self._setup_service()
+        mock_settings = Mock(is_paused=True)
+        service.settings_service.get_settings.return_value = mock_settings
 
-            mock_settings = Mock(is_paused=True)
-            service.settings_service.get_settings.return_value = mock_settings
+        result = service.get_schedule_preview(telegram_chat_id=123)
 
-            result = service.get_schedule_preview(telegram_chat_id=123)
+        assert result["status"] == "paused"
+        assert result["slots"] == []
 
-            assert result["status"] == "paused"
-            assert result["slots"] == []
+    def test_uses_last_post_sent_at(self):
+        """Slots start from last_post_sent_at + interval when set."""
+        from datetime import datetime, timezone
+        from decimal import Decimal
+
+        service = self._setup_service()
+        last_post = datetime(2026, 4, 15, 15, 0, 0, tzinfo=timezone.utc)
+        mock_settings = Mock(
+            id="t1",
+            is_paused=False,
+            posts_per_day=3,
+            posting_hours_start=14,
+            posting_hours_end=2,
+            last_post_sent_at=last_post,
+        )
+        service.settings_service.get_settings.return_value = mock_settings
+        service.category_mix_repo.get_current_mix_as_dict.return_value = {
+            "memes": Decimal("1.0"),
+        }
+
+        result = service.get_schedule_preview(telegram_chat_id=123, slots=2)
+
+        assert result["status"] == "ok"
+        assert len(result["slots"]) == 2
+        # First slot should be after last_post + interval
+        first_slot = result["slots"][0]["slot_time"]
+        assert first_slot > last_post.isoformat()
 
 
 @pytest.mark.unit
@@ -663,7 +693,10 @@ class TestGetContentReuseInsights:
             "posted_once": 50,
             "posted_multiple": 20,
         }
-        service.media_repo.count_by_category.return_value = {"memes": 60, "merch": 40}
+        service.media_repo.count_dead_content_by_category.return_value = [
+            {"category": "memes", "dead_count": 20},
+            {"category": "merch", "dead_count": 10},
+        ]
 
         result = service.get_content_reuse_insights(telegram_chat_id=123)
 
@@ -672,6 +705,23 @@ class TestGetContentReuseInsights:
         assert result["posted_once"] == 50
         assert result["posted_multiple"] == 20
         assert result["reuse_rate"] == 0.2
+        assert len(result["never_posted_by_category"]) == 2
+
+    def test_handles_empty_pool(self):
+        """Returns zeros when no active media."""
+        service = self._setup_service()
+        service.media_repo.count_by_posting_status.return_value = {
+            "never_posted": 0,
+            "posted_once": 0,
+            "posted_multiple": 0,
+        }
+        service.media_repo.count_dead_content_by_category.return_value = []
+
+        result = service.get_content_reuse_insights(telegram_chat_id=123)
+
+        assert result["total_active"] == 0
+        assert result["reuse_rate"] == 0
+        assert result["never_posted_by_category"] == []
 
 
 @pytest.mark.unit

--- a/tests/src/services/test_dashboard_service.py
+++ b/tests/src/services/test_dashboard_service.py
@@ -587,3 +587,128 @@ class TestGetScheduleRecommendations:
         assert "worst_day" in types
         worst_day_rec = next(r for r in recs if r["type"] == "worst_day")
         assert worst_day_rec["day_name"] == "Sunday"
+
+
+@pytest.mark.unit
+class TestGetSchedulePreview:
+    """Tests for get_schedule_preview."""
+
+    def test_returns_slot_times(self):
+        """Preview returns correct number of slots with interval."""
+        with patch.object(DashboardService, "__init__", lambda self: None):
+            service = DashboardService()
+            service.settings_service = MagicMock()
+            service.category_mix_repo = MagicMock()
+
+            from decimal import Decimal
+
+            mock_settings = Mock(
+                id="t1",
+                is_paused=False,
+                posts_per_day=3,
+                posting_hours_start=14,
+                posting_hours_end=2,
+                last_post_sent_at=None,
+            )
+            service.settings_service.get_settings.return_value = mock_settings
+            service.category_mix_repo.get_current_mix_as_dict.return_value = {
+                "memes": Decimal("0.50"),
+                "merch": Decimal("0.50"),
+            }
+
+            result = service.get_schedule_preview(telegram_chat_id=123, slots=5)
+
+            assert result["status"] == "ok"
+            assert len(result["slots"]) == 5
+            assert result["posts_per_day"] == 3
+            assert all(
+                s["predicted_category"] in ("memes", "merch") for s in result["slots"]
+            )
+
+    def test_returns_paused_when_paused(self):
+        """Preview returns paused status when posting is paused."""
+        with patch.object(DashboardService, "__init__", lambda self: None):
+            service = DashboardService()
+            service.settings_service = MagicMock()
+
+            mock_settings = Mock(is_paused=True)
+            service.settings_service.get_settings.return_value = mock_settings
+
+            result = service.get_schedule_preview(telegram_chat_id=123)
+
+            assert result["status"] == "paused"
+            assert result["slots"] == []
+
+
+@pytest.mark.unit
+class TestGetContentReuseInsights:
+    """Tests for get_content_reuse_insights."""
+
+    def _setup_service(self):
+        with patch.object(DashboardService, "__init__", lambda self: None):
+            service = DashboardService()
+            service.settings_service = MagicMock()
+            service.media_repo = MagicMock()
+            service.service_run_repo = MagicMock()
+            service.service_name = "DashboardService"
+            mock_settings = Mock(id="tenant-uuid-1")
+            service.settings_service.get_settings.return_value = mock_settings
+            return service
+
+    def test_returns_reuse_tiers(self):
+        """Returns posting status breakdown and reuse rate."""
+        service = self._setup_service()
+        service.media_repo.count_by_posting_status.return_value = {
+            "never_posted": 30,
+            "posted_once": 50,
+            "posted_multiple": 20,
+        }
+        service.media_repo.count_by_category.return_value = {"memes": 60, "merch": 40}
+
+        result = service.get_content_reuse_insights(telegram_chat_id=123)
+
+        assert result["total_active"] == 100
+        assert result["never_posted"] == 30
+        assert result["posted_once"] == 50
+        assert result["posted_multiple"] == 20
+        assert result["reuse_rate"] == 0.2
+
+
+@pytest.mark.unit
+class TestGetServiceHealthStats:
+    """Tests for get_service_health_stats."""
+
+    def test_returns_per_service_stats(self):
+        """Returns aggregated service run telemetry."""
+        with patch.object(DashboardService, "__init__", lambda self: None):
+            service = DashboardService()
+            service.service_run_repo = MagicMock()
+            service.service_run_repo.get_health_stats.return_value = [
+                {
+                    "service_name": "PostingService",
+                    "call_count": 100,
+                    "success_count": 95,
+                    "failure_count": 5,
+                    "error_rate": 0.05,
+                    "avg_duration_ms": 150,
+                },
+            ]
+
+            result = service.get_service_health_stats(hours=24)
+
+            assert result["total_calls"] == 100
+            assert result["total_failures"] == 5
+            assert result["overall_error_rate"] == 0.05
+            assert len(result["services"]) == 1
+
+    def test_handles_no_runs(self):
+        """Returns zeros when no service runs in window."""
+        with patch.object(DashboardService, "__init__", lambda self: None):
+            service = DashboardService()
+            service.service_run_repo = MagicMock()
+            service.service_run_repo.get_health_stats.return_value = []
+
+            result = service.get_service_health_stats()
+
+            assert result["total_calls"] == 0
+            assert result["overall_error_rate"] == 0


### PR DESCRIPTION
## Summary

- **Schedule preview** (#178) — `GET /analytics/schedule-preview` shows upcoming N slots with predicted times and categories using the same interval/weighting logic as the scheduler. Informational only, does not pre-select media.
- **Content reuse insights** (#179) — `GET /analytics/content-reuse` classifies media pool into never_posted/posted_once/posted_multiple tiers with overall reuse rate and per-category breakdown.
- **Service health dashboard** (#180) — `GET /analytics/service-health` aggregates `service_runs` table into per-service call counts, error rates, and avg execution duration. New `get_health_stats()` method in ServiceRunRepository.

Closes #178, closes #179, closes #180

## Test plan

- [x] 2 schedule preview tests (slots returned, paused state)
- [x] 1 content reuse test (tier breakdown + reuse rate)
- [x] 2 service health service tests (stats returned, empty runs)
- [x] 2 service run repo tests (aggregation, empty)
- [x] All 1459 unit tests pass
- [x] Lint and format checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)