### PR TITLE
Fix CI: dead content report tests + ruff format

### DIFF
--- a/src/api/routes/onboarding/dashboard.py
+++ b/src/api/routes/onboarding/dashboard.py
@@ -152,6 +152,8 @@ async def onboarding_service_health(
 
     with DashboardService() as service:
         return service.get_service_health_stats(hours=hours)
+
+
 @router.get("/analytics/category-drift")
 async def onboarding_category_drift(
     init_data: str,
@@ -176,6 +178,8 @@ async def onboarding_dead_content(
 
     with DashboardService() as service:
         return service.get_dead_content_report(chat_id, min_age_days=min_age_days)
+
+
 @router.get("/analytics/approval-latency")
 async def onboarding_approval_latency(
     init_data: str,

--- a/src/services/core/dashboard_service.py
+++ b/src/services/core/dashboard_service.py
@@ -617,6 +617,7 @@ class DashboardService(BaseService):
             else 0,
             "hours": hours,
         }
+
     def get_approval_latency(self, telegram_chat_id: int, days: int = 30) -> dict:
         """Return approval latency statistics — time from queue to decision.
 

--- a/tests/src/services/test_dashboard_service.py
+++ b/tests/src/services/test_dashboard_service.py
@@ -593,14 +593,6 @@ class TestGetScheduleRecommendations:
 class TestGetSchedulePreview:
     """Tests for get_schedule_preview."""
 
-
-class TestGetCategoryMixDrift:
-    """Tests for get_category_mix_drift."""
-
-
-class TestGetApprovalLatency:
-    """Tests for get_approval_latency."""
-
     def _setup_service(self):
         with patch.object(DashboardService, "__init__", lambda self: None):
             service = DashboardService()
@@ -673,22 +665,18 @@ class TestGetApprovalLatency:
 
         assert result["status"] == "ok"
         assert len(result["slots"]) == 2
-        # First slot should be after last_post + interval
         first_slot = result["slots"][0]["slot_time"]
         assert first_slot > last_post.isoformat()
 
 
 @pytest.mark.unit
-class TestGetContentReuseInsights:
-    """Tests for get_content_reuse_insights."""
+class TestGetCategoryMixDrift:
+    """Tests for get_category_mix_drift."""
 
     def _setup_service(self):
         with patch.object(DashboardService, "__init__", lambda self: None):
             service = DashboardService()
             service.settings_service = MagicMock()
-            service.media_repo = MagicMock()
-            service.service_run_repo = MagicMock()
-            service.service_name = "DashboardService"
             service.history_repo = MagicMock()
             service.category_mix_repo = MagicMock()
             service.service_run_repo = MagicMock()
@@ -696,28 +684,6 @@ class TestGetContentReuseInsights:
             mock_settings = Mock(id="tenant-uuid-1")
             service.settings_service.get_settings.return_value = mock_settings
             return service
-
-    def test_returns_reuse_tiers(self):
-        """Returns posting status breakdown and reuse rate."""
-        service = self._setup_service()
-        service.media_repo.count_by_posting_status.return_value = {
-            "never_posted": 30,
-            "posted_once": 50,
-            "posted_multiple": 20,
-        }
-        service.media_repo.count_dead_content_by_category.return_value = [
-            {"category": "memes", "dead_count": 20},
-            {"category": "merch", "dead_count": 10},
-        ]
-
-        result = service.get_content_reuse_insights(telegram_chat_id=123)
-
-        assert result["total_active"] == 100
-        assert result["never_posted"] == 30
-        assert result["posted_once"] == 50
-        assert result["posted_multiple"] == 20
-        assert result["reuse_rate"] == 0.2
-        assert len(result["never_posted_by_category"]) == 2
 
     def test_detects_drift(self):
         """Flags categories with significant drift as warning/critical."""
@@ -778,6 +744,117 @@ class TestGetContentReuseInsights:
 
 
 @pytest.mark.unit
+class TestGetApprovalLatency:
+    """Tests for get_approval_latency."""
+
+    def _setup_service(self):
+        with patch.object(DashboardService, "__init__", lambda self: None):
+            service = DashboardService()
+            service.settings_service = MagicMock()
+            service.history_repo = MagicMock()
+            service.service_run_repo = MagicMock()
+            service.service_name = "DashboardService"
+            mock_settings = Mock(id="tenant-uuid-1")
+            service.settings_service.get_settings.return_value = mock_settings
+            return service
+
+    def test_returns_latency_stats(self):
+        """get_approval_latency returns overall + breakdowns from repo."""
+        service = self._setup_service()
+        service.history_repo.get_approval_latency.return_value = {
+            "overall": {
+                "count": 50,
+                "avg_minutes": 5.0,
+                "min_minutes": 1.0,
+                "max_minutes": 30.0,
+            },
+            "by_hour": [{"hour": 14, "count": 20, "avg_minutes": 4.0}],
+            "by_category": [{"category": "memes", "count": 30, "avg_minutes": 3.0}],
+        }
+
+        result = service.get_approval_latency(telegram_chat_id=123, days=30)
+
+        assert result["overall"]["count"] == 50
+        assert result["overall"]["avg_minutes"] == 5.0
+        assert result["days"] == 30
+        assert len(result["by_hour"]) == 1
+        assert len(result["by_category"]) == 1
+
+    def test_empty_latency(self):
+        """Returns zero stats when no posting history."""
+        service = self._setup_service()
+        service.history_repo.get_approval_latency.return_value = {
+            "overall": {
+                "count": 0,
+                "avg_minutes": 0,
+                "min_minutes": 0,
+                "max_minutes": 0,
+            },
+            "by_hour": [],
+            "by_category": [],
+        }
+
+        result = service.get_approval_latency(telegram_chat_id=123)
+
+        assert result["overall"]["count"] == 0
+        assert result["days"] == 30
+
+
+@pytest.mark.unit
+class TestGetContentReuseInsights:
+    """Tests for get_content_reuse_insights."""
+
+    def _setup_service(self):
+        with patch.object(DashboardService, "__init__", lambda self: None):
+            service = DashboardService()
+            service.settings_service = MagicMock()
+            service.media_repo = MagicMock()
+            service.service_run_repo = MagicMock()
+            service.service_name = "DashboardService"
+            mock_settings = Mock(id="tenant-uuid-1")
+            service.settings_service.get_settings.return_value = mock_settings
+            return service
+
+    def test_returns_reuse_tiers(self):
+        """Returns posting status breakdown and reuse rate."""
+        service = self._setup_service()
+        service.media_repo.count_by_posting_status.return_value = {
+            "never_posted": 30,
+            "posted_once": 50,
+            "posted_multiple": 20,
+        }
+        service.media_repo.count_dead_content_by_category.return_value = [
+            {"category": "memes", "dead_count": 20},
+            {"category": "merch", "dead_count": 10},
+        ]
+
+        result = service.get_content_reuse_insights(telegram_chat_id=123)
+
+        assert result["total_active"] == 100
+        assert result["never_posted"] == 30
+        assert result["posted_once"] == 50
+        assert result["posted_multiple"] == 20
+        assert result["reuse_rate"] == 0.2
+        assert len(result["never_posted_by_category"]) == 2
+
+    def test_handles_empty_pool(self):
+        """Returns zeros when no active media."""
+        service = self._setup_service()
+        service.media_repo.count_by_posting_status.return_value = {
+            "never_posted": 0,
+            "posted_once": 0,
+            "posted_multiple": 0,
+        }
+        service.media_repo.count_dead_content_by_category.return_value = []
+
+        result = service.get_content_reuse_insights(telegram_chat_id=123)
+
+        assert result["total_active"] == 0
+        assert result["reuse_rate"] == 0
+        assert result["never_posted_by_category"] == []
+
+
+@pytest.mark.unit
 class TestGetDeadContentReport:
     """Tests for get_dead_content_report."""
 
@@ -786,8 +863,6 @@ class TestGetDeadContentReport:
             service = DashboardService()
             service.settings_service = MagicMock()
             service.media_repo = MagicMock()
-            service.history_repo = MagicMock()
-            service.category_mix_repo = MagicMock()
             service.service_run_repo = MagicMock()
             service.service_name = "DashboardService"
             mock_settings = Mock(id="tenant-uuid-1")
@@ -830,7 +905,6 @@ class TestGetTeamPerformance:
         with patch.object(DashboardService, "__init__", lambda self: None):
             service = DashboardService()
             service.settings_service = MagicMock()
-            service.media_repo = MagicMock()
             service.history_repo = MagicMock()
             service.service_run_repo = MagicMock()
             service.service_name = "DashboardService"
@@ -838,37 +912,38 @@ class TestGetTeamPerformance:
             service.settings_service.get_settings.return_value = mock_settings
             return service
 
-    def test_returns_dead_content_breakdown(self):
-        """Returns total dead, percentage, and per-category data."""
+    def test_returns_user_stats(self):
+        """get_team_performance returns per-user data from repo."""
         service = self._setup_service()
-        service.media_repo.count_active.return_value = 100
-        service.media_repo.count_dead_content_by_category.return_value = [
-            {"category": "memes", "dead_count": 15},
-            {"category": "merch", "dead_count": 5},
+        service.history_repo.get_user_approval_stats.return_value = [
+            {
+                "user_id": "u1",
+                "username": "alice",
+                "posted": 40,
+                "skipped": 5,
+                "rejected": 5,
+                "total": 50,
+                "approval_rate": 0.8,
+                "avg_latency_minutes": 3.0,
+            },
         ]
 
-        result = service.get_dead_content_report(telegram_chat_id=123)
+        result = service.get_team_performance(telegram_chat_id=123, days=30)
 
-        assert result["total_active"] == 100
-        assert result["total_dead"] == 20
-        assert result["dead_percentage"] == 0.20
-        assert len(result["by_category"]) == 2
+        assert len(result["users"]) == 1
+        assert result["users"][0]["username"] == "alice"
+        assert result["users"][0]["approval_rate"] == 0.8
+        assert result["days"] == 30
 
-    def test_handles_empty_pool(self):
-        """Returns zeros when no active media."""
+    def test_empty_users(self):
+        """Returns empty user list when no data."""
         service = self._setup_service()
-        service.media_repo.count_by_posting_status.return_value = {
-            "never_posted": 0,
-            "posted_once": 0,
-            "posted_multiple": 0,
-        }
-        service.media_repo.count_dead_content_by_category.return_value = []
+        service.history_repo.get_user_approval_stats.return_value = []
 
-        result = service.get_content_reuse_insights(telegram_chat_id=123)
+        result = service.get_team_performance(telegram_chat_id=123)
 
-        assert result["total_active"] == 0
-        assert result["reuse_rate"] == 0
-        assert result["never_posted_by_category"] == []
+        assert result["users"] == []
+        assert result["days"] == 30
 
 
 @pytest.mark.unit
@@ -909,43 +984,3 @@ class TestGetServiceHealthStats:
 
             assert result["total_calls"] == 0
             assert result["overall_error_rate"] == 0
-        service.media_repo.count_active.return_value = 0
-        service.media_repo.count_dead_content_by_category.return_value = []
-
-        result = service.get_dead_content_report(telegram_chat_id=123)
-
-        assert result["total_dead"] == 0
-        assert result["dead_percentage"] == 0
-
-    def test_returns_user_stats(self):
-        """get_team_performance returns per-user data from repo."""
-        service = self._setup_service()
-        service.history_repo.get_user_approval_stats.return_value = [
-            {
-                "user_id": "u1",
-                "username": "alice",
-                "posted": 40,
-                "skipped": 5,
-                "rejected": 5,
-                "total": 50,
-                "approval_rate": 0.8,
-                "avg_latency_minutes": 3.0,
-            },
-        ]
-
-        result = service.get_team_performance(telegram_chat_id=123, days=30)
-
-        assert len(result["users"]) == 1
-        assert result["users"][0]["username"] == "alice"
-        assert result["users"][0]["approval_rate"] == 0.8
-        assert result["days"] == 30
-
-    def test_empty_users(self):
-        """Returns empty user list when no data."""
-        service = self._setup_service()
-        service.history_repo.get_user_approval_stats.return_value = []
-
-        result = service.get_team_performance(telegram_chat_id=123)
-
-        assert result["users"] == []
-        assert result["days"] == 30

--- a/tests/src/services/test_dashboard_service.py
+++ b/tests/src/services/test_dashboard_service.py
@@ -592,8 +592,12 @@ class TestGetScheduleRecommendations:
 @pytest.mark.unit
 class TestGetSchedulePreview:
     """Tests for get_schedule_preview."""
+
+
 class TestGetCategoryMixDrift:
     """Tests for get_category_mix_drift."""
+
+
 class TestGetApprovalLatency:
     """Tests for get_approval_latency."""
 
@@ -714,6 +718,7 @@ class TestGetContentReuseInsights:
         assert result["posted_multiple"] == 20
         assert result["reuse_rate"] == 0.2
         assert len(result["never_posted_by_category"]) == 2
+
     def test_detects_drift(self):
         """Flags categories with significant drift as warning/critical."""
         from decimal import Decimal
@@ -775,46 +780,46 @@ class TestGetContentReuseInsights:
 @pytest.mark.unit
 class TestGetDeadContentReport:
     """Tests for get_dead_content_report."""
-    def test_returns_latency_stats(self):
-        """get_approval_latency returns overall + breakdowns from repo."""
+
+    def _setup_service(self):
+        with patch.object(DashboardService, "__init__", lambda self: None):
+            service = DashboardService()
+            service.settings_service = MagicMock()
+            service.media_repo = MagicMock()
+            service.history_repo = MagicMock()
+            service.category_mix_repo = MagicMock()
+            service.service_run_repo = MagicMock()
+            service.service_name = "DashboardService"
+            mock_settings = Mock(id="tenant-uuid-1")
+            service.settings_service.get_settings.return_value = mock_settings
+            return service
+
+    def test_returns_dead_content(self):
+        """get_dead_content_report returns per-category dead content stats."""
         service = self._setup_service()
-        service.history_repo.get_approval_latency.return_value = {
-            "overall": {
-                "count": 50,
-                "avg_minutes": 5.0,
-                "min_minutes": 1.0,
-                "max_minutes": 30.0,
-            },
-            "by_hour": [{"hour": 14, "count": 20, "avg_minutes": 4.0}],
-            "by_category": [{"category": "memes", "count": 30, "avg_minutes": 3.0}],
-        }
+        service.media_repo.count_active.return_value = 100
+        service.media_repo.count_dead_content_by_category.return_value = [
+            {"category": "memes", "dead_count": 10},
+            {"category": "merch", "dead_count": 5},
+        ]
 
-        result = service.get_approval_latency(telegram_chat_id=123, days=30)
+        result = service.get_dead_content_report(telegram_chat_id=123)
 
-        assert result["overall"]["count"] == 50
-        assert result["overall"]["avg_minutes"] == 5.0
-        assert result["days"] == 30
-        assert len(result["by_hour"]) == 1
-        assert len(result["by_category"]) == 1
+        assert result["total_active"] == 100
+        assert result["total_dead"] == 15
+        assert result["dead_percentage"] == 0.15
+        assert len(result["by_category"]) == 2
 
-    def test_empty_latency(self):
-        """Returns zero stats when no posting history."""
+    def test_empty_dead_content(self):
+        """Returns zero stats when no dead content."""
         service = self._setup_service()
-        service.history_repo.get_approval_latency.return_value = {
-            "overall": {
-                "count": 0,
-                "avg_minutes": 0,
-                "min_minutes": 0,
-                "max_minutes": 0,
-            },
-            "by_hour": [],
-            "by_category": [],
-        }
+        service.media_repo.count_active.return_value = 50
+        service.media_repo.count_dead_content_by_category.return_value = []
 
-        result = service.get_approval_latency(telegram_chat_id=123)
+        result = service.get_dead_content_report(telegram_chat_id=123)
 
-        assert result["overall"]["count"] == 0
-        assert result["days"] == 30
+        assert result["total_dead"] == 0
+        assert result["dead_percentage"] == 0
 
 
 @pytest.mark.unit
@@ -911,6 +916,7 @@ class TestGetServiceHealthStats:
 
         assert result["total_dead"] == 0
         assert result["dead_percentage"] == 0
+
     def test_returns_user_stats(self):
         """get_team_performance returns per-user data from repo."""
         service = self._setup_service()


### PR DESCRIPTION
## Summary
- Fix misplaced approval latency tests in TestGetDeadContentReport (caused by merge conflict resolution)
- Replace with proper dead content tests matching actual method signature
- Fix ruff format issue in dashboard.py

## Test plan
- [x] TestGetDeadContentReport passes locally (2 tests)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)