### PR TITLE
feat: Web Dashboard Phase 3 — Media Management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added — Web Dashboard Phase 3: Media Management
+
+- **Content library browser** (`/dashboard/media`) — paginated grid view of all media items with category filtering, pool health stats (total active, eligible for posting, never posted, reuse rate), and per-category counts.
+- **Media upload** — drag-and-drop or file picker for uploading new media directly through the dashboard, bypassing the Google Drive sync requirement. Validates MIME type, enforces 50 MB limit, and deduplicates by content hash (SHA256).
+- **Content calendar** (`/dashboard/media/calendar`) — visual monthly calendar showing past posts (green), in-queue items (blue), and predicted future slots (gray). Includes posting rate stats and queue summary.
+- **Dead content view** (`/dashboard/media/dead-content`) — surfaces media items 30+ days old that have never been posted, with category-level bar chart breakdown and percentage metrics.
+- **Content reuse view** (`/dashboard/media/reuse`) — donut chart visualization of evergreen (2+ posts) vs one-shot vs never-posted content, with per-category never-posted breakdown table.
+- **New backend endpoints** — `GET /api/onboarding/media-library` (paginated listing with category/posting-status filters and pool health aggregation), `POST /api/onboarding/upload-media` (multipart file upload with hash-based dedup).
+- **Dedicated upload proxy** — separate BFF route (`/api/dashboard/upload`) for multipart form data forwarding, since the generic JSON proxy cannot handle file uploads.
+- **Media tab navigation** — shared layout with tab bar (Library, Calendar, Dead Content, Content Reuse) across all media sub-pages.
+- **Sidebar navigation** — added Media Library and Calendar entries to dashboard sidebar.
+
 ### Added — Web Dashboard Phase 2: Onboarding & Settings
 
 - **Settings page** (`/dashboard/settings`) — tabbed interface (General, Accounts, Integrations) for managing posting schedule, boolean toggles (pause, dry run, Instagram API, verbose notifications, media sync), Instagram account switching/removal, and Google Drive connection.

--- a/landing/src/app/(dashboard)/dashboard/media/calendar/page.tsx
+++ b/landing/src/app/(dashboard)/dashboard/media/calendar/page.tsx
@@ -1,0 +1,83 @@
+import { redirect } from "next/navigation";
+import { getSession } from "@/lib/session";
+import { backendFetchJson } from "@/lib/backend";
+import { ContentCalendar } from "@/components/dashboard/media/content-calendar";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+export default async function CalendarPage() {
+  const session = await getSession();
+  if (!session) redirect("/login");
+  const { chatId, userId } = session;
+
+  const [history, queue, schedule] = await Promise.all([
+    backendFetchJson("history-detail?limit=15", chatId, userId, {
+      revalidate: 60,
+    }),
+    backendFetchJson("queue-detail?limit=10", chatId, userId, {
+      revalidate: 30,
+    }),
+    backendFetchJson("analytics/schedule-preview?slots=15", chatId, userId, {
+      revalidate: 60,
+    }),
+  ]);
+
+  const historyItems = history?.items ?? [];
+  const queueItems = queue?.items ?? [];
+  const scheduleSlots = schedule?.slots ?? [];
+
+  return (
+    <div className="space-y-6">
+      {/* Summary stats */}
+      <div className="grid gap-4 sm:grid-cols-3">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Posts Today
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{queue?.posts_today ?? 0}</div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              In Queue
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">
+              {queue?.total_in_flight ?? 0}
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Posting Rate
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">
+              {schedule?.posts_per_day ?? 0}/day
+            </div>
+            <p className="text-xs text-muted-foreground mt-1">
+              Every {schedule?.interval_minutes ? Math.round(schedule.interval_minutes) : "—"} min
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <ContentCalendar
+        history={historyItems}
+        queue={queueItems}
+        schedule={scheduleSlots}
+      />
+    </div>
+  );
+}

--- a/landing/src/app/(dashboard)/dashboard/media/dead-content/page.tsx
+++ b/landing/src/app/(dashboard)/dashboard/media/dead-content/page.tsx
@@ -1,0 +1,85 @@
+import { redirect } from "next/navigation";
+import { getSession } from "@/lib/session";
+import { backendFetchJson } from "@/lib/backend";
+import { DeadContentChart } from "@/components/dashboard/media/dead-content-chart";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+
+export default async function DeadContentPage() {
+  const session = await getSession();
+  if (!session) redirect("/login");
+  const { chatId, userId } = session;
+
+  const data = await backendFetchJson(
+    "analytics/dead-content?min_age_days=30",
+    chatId,
+    userId,
+    { revalidate: 60 }
+  );
+
+  const totalActive = data?.total_active ?? 0;
+  const totalDead = data?.total_dead ?? 0;
+  const deadPct = Math.round((data?.dead_percentage ?? 0) * 100);
+  const byCategory = data?.by_category ?? [];
+
+  return (
+    <div className="space-y-6">
+      <p className="text-sm text-muted-foreground">
+        Media items that have been in your library for 30+ days and were never posted.
+      </p>
+
+      {/* Summary cards */}
+      <div className="grid gap-4 sm:grid-cols-3">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Dead Content
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{totalDead}</div>
+            <Progress value={deadPct} className="mt-2 h-1.5" />
+            <p className="text-xs text-muted-foreground mt-1">
+              {deadPct}% of library
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Total Active
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{totalActive}</div>
+            <p className="text-xs text-muted-foreground mt-1">
+              {totalActive - totalDead} have been posted
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Categories Affected
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{byCategory.length}</div>
+            <p className="text-xs text-muted-foreground mt-1">
+              with dead content
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <DeadContentChart data={byCategory} />
+    </div>
+  );
+}

--- a/landing/src/app/(dashboard)/dashboard/media/layout.tsx
+++ b/landing/src/app/(dashboard)/dashboard/media/layout.tsx
@@ -1,0 +1,20 @@
+import { MediaTabs } from "@/components/dashboard/media/media-tabs";
+
+export default function MediaLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">Media Management</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Browse, upload, and manage your content library.
+        </p>
+      </div>
+      <MediaTabs />
+      {children}
+    </div>
+  );
+}

--- a/landing/src/app/(dashboard)/dashboard/media/page.tsx
+++ b/landing/src/app/(dashboard)/dashboard/media/page.tsx
@@ -1,0 +1,46 @@
+import { redirect } from "next/navigation";
+import { getSession } from "@/lib/session";
+import { backendFetchJson } from "@/lib/backend";
+import { PoolHealth } from "@/components/dashboard/media/pool-health";
+import { MediaGrid } from "@/components/dashboard/media/media-grid";
+import { MediaUploadWrapper } from "@/components/dashboard/media/media-upload-wrapper";
+
+export default async function MediaLibraryPage() {
+  const session = await getSession();
+  if (!session) redirect("/login");
+  const { chatId, userId } = session;
+
+  const library = await backendFetchJson(
+    "media-library?page=1&page_size=20",
+    chatId,
+    userId,
+    { revalidate: 30 }
+  );
+
+  const poolHealth = library?.pool_health ?? {
+    total_active: 0,
+    never_posted: 0,
+    posted_once: 0,
+    posted_multiple: 0,
+    eligible_for_posting: 0,
+    by_category: [],
+  };
+
+  return (
+    <div className="space-y-6">
+      <PoolHealth health={poolHealth} />
+
+      <div className="grid gap-6 lg:grid-cols-[1fr_300px]">
+        <MediaGrid initialData={library ?? {
+          items: [],
+          total: 0,
+          page: 1,
+          page_size: 20,
+          categories: [],
+          pool_health: poolHealth,
+        }} />
+        <MediaUploadWrapper categories={library?.categories ?? []} />
+      </div>
+    </div>
+  );
+}

--- a/landing/src/app/(dashboard)/dashboard/media/reuse/page.tsx
+++ b/landing/src/app/(dashboard)/dashboard/media/reuse/page.tsx
@@ -1,0 +1,152 @@
+import { redirect } from "next/navigation";
+import { getSession } from "@/lib/session";
+import { backendFetchJson } from "@/lib/backend";
+import { ReuseChart } from "@/components/dashboard/media/reuse-chart";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+export default async function ContentReusePage() {
+  const session = await getSession();
+  if (!session) redirect("/login");
+  const { chatId, userId } = session;
+
+  const data = await backendFetchJson(
+    "analytics/content-reuse",
+    chatId,
+    userId,
+    { revalidate: 60 }
+  );
+
+  const totalActive = data?.total_active ?? 0;
+  const reuseRate = Math.round((data?.reuse_rate ?? 0) * 100);
+  const neverPosted = data?.never_posted ?? 0;
+  const postedOnce = data?.posted_once ?? 0;
+  const postedMultiple = data?.posted_multiple ?? 0;
+  const neverPostedByCategory = data?.never_posted_by_category ?? [];
+
+  return (
+    <div className="space-y-6">
+      <p className="text-sm text-muted-foreground">
+        How effectively your content library is being reused across posts.
+      </p>
+
+      {/* Summary cards */}
+      <div className="grid gap-4 sm:grid-cols-4">
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Reuse Rate
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold">{reuseRate}%</div>
+            <p className="text-xs text-muted-foreground mt-1">
+              of content posted 2+ times
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Never Posted
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold text-red-500">{neverPosted}</div>
+            <p className="text-xs text-muted-foreground mt-1">
+              {totalActive > 0
+                ? `${Math.round((neverPosted / totalActive) * 100)}% of library`
+                : "—"}
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              One-Shot
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold text-yellow-500">
+              {postedOnce}
+            </div>
+            <p className="text-xs text-muted-foreground mt-1">
+              posted exactly once
+            </p>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">
+              Evergreen
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="text-2xl font-bold text-green-500">
+              {postedMultiple}
+            </div>
+            <p className="text-xs text-muted-foreground mt-1">
+              reused 2+ times
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <ReuseChart
+          data={
+            data ?? {
+              total_active: 0,
+              never_posted: 0,
+              posted_once: 0,
+              posted_multiple: 0,
+              reuse_rate: 0,
+              never_posted_by_category: [],
+            }
+          }
+        />
+
+        {/* Never-posted by category table */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">
+              Never-Posted by Category
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {neverPostedByCategory.length === 0 ? (
+              <p className="text-sm text-muted-foreground py-4 text-center">
+                All content has been posted at least once.
+              </p>
+            ) : (
+              <div className="space-y-3">
+                {neverPostedByCategory.map(
+                  (cat: { category: string; dead_count: number }) => (
+                    <div
+                      key={cat.category}
+                      className="flex items-center justify-between"
+                    >
+                      <span className="text-sm font-medium">
+                        {cat.category}
+                      </span>
+                      <span className="text-sm text-muted-foreground">
+                        {cat.dead_count} items
+                      </span>
+                    </div>
+                  )
+                )}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/landing/src/app/api/dashboard/[...path]/route.ts
+++ b/landing/src/app/api/dashboard/[...path]/route.ts
@@ -18,6 +18,7 @@ const ALLOWED_PATHS = [
   "analytics",
   "accounts",
   "history-detail",
+  "media-library",
   "media-stats",
   "queue-detail",
   "queue-preview",

--- a/landing/src/app/api/dashboard/upload/route.ts
+++ b/landing/src/app/api/dashboard/upload/route.ts
@@ -21,6 +21,16 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Invalid session" }, { status: 401 });
   }
 
+  // Reject oversized uploads before buffering
+  const MAX_UPLOAD_BYTES = 50 * 1024 * 1024; // 50 MB
+  const contentLength = parseInt(request.headers.get("content-length") || "0", 10);
+  if (contentLength > MAX_UPLOAD_BYTES) {
+    return NextResponse.json(
+      { error: "File exceeds 50 MB limit" },
+      { status: 413 }
+    );
+  }
+
   const urlToken = generateUrlToken(session.chatId, session.userId);
   const url = new URL("/api/onboarding/upload-media", BACKEND_URL);
   url.searchParams.set("init_data", urlToken);
@@ -29,6 +39,14 @@ export async function POST(request: NextRequest) {
   // Forward the raw multipart body to FastAPI
   const contentType = request.headers.get("content-type") || "";
   const body = await request.arrayBuffer();
+
+  // Double-check actual size after buffering
+  if (body.byteLength > MAX_UPLOAD_BYTES) {
+    return NextResponse.json(
+      { error: "File exceeds 50 MB limit" },
+      { status: 413 }
+    );
+  }
 
   try {
     const backendResponse = await fetch(url.toString(), {

--- a/landing/src/app/api/dashboard/upload/route.ts
+++ b/landing/src/app/api/dashboard/upload/route.ts
@@ -1,0 +1,57 @@
+/**
+ * Dedicated upload proxy — forwards multipart file uploads to FastAPI.
+ *
+ * Separated from the generic BFF proxy because file uploads require
+ * streaming the raw body (not JSON re-encoding).
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { verifySessionToken, SESSION_COOKIE } from "@/lib/auth";
+import { generateUrlToken } from "@/lib/auth";
+import { BACKEND_URL } from "@/lib/backend";
+
+export async function POST(request: NextRequest) {
+  const token = request.cookies.get(SESSION_COOKIE)?.value;
+  if (!token) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const session = await verifySessionToken(token);
+  if (!session) {
+    return NextResponse.json({ error: "Invalid session" }, { status: 401 });
+  }
+
+  const urlToken = generateUrlToken(session.chatId, session.userId);
+  const url = new URL("/api/onboarding/upload-media", BACKEND_URL);
+  url.searchParams.set("init_data", urlToken);
+  url.searchParams.set("chat_id", String(session.chatId));
+
+  // Forward the raw multipart body to FastAPI
+  const contentType = request.headers.get("content-type") || "";
+  const body = await request.arrayBuffer();
+
+  try {
+    const backendResponse = await fetch(url.toString(), {
+      method: "POST",
+      headers: { "Content-Type": contentType },
+      body: body,
+    });
+
+    if (backendResponse.status >= 500) {
+      console.error("Upload backend 5xx:", backendResponse.status);
+      return NextResponse.json(
+        { error: "Backend unavailable" },
+        { status: 502 }
+      );
+    }
+
+    const data = await backendResponse.json();
+    return NextResponse.json(data, { status: backendResponse.status });
+  } catch (error) {
+    console.error("Upload proxy error:", error);
+    return NextResponse.json(
+      { error: "Backend unavailable" },
+      { status: 502 }
+    );
+  }
+}

--- a/landing/src/components/dashboard/media/content-calendar.tsx
+++ b/landing/src/components/dashboard/media/content-calendar.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import { useMemo } from "react";
+import { Badge } from "@/components/ui/badge";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+interface HistoryItem {
+  posted_at: string;
+  media_name: string;
+  category: string;
+  status: string;
+}
+
+interface ScheduleSlot {
+  slot_time: string;
+  predicted_category: string | null;
+}
+
+interface QueueItem {
+  scheduled_for: string;
+  media_name: string;
+  category: string;
+  status: string;
+}
+
+interface CalendarDay {
+  date: string;
+  dayOfMonth: number;
+  isToday: boolean;
+  isCurrentMonth: boolean;
+  posts: { label: string; category: string; type: "past" | "queued" | "predicted" }[];
+}
+
+function buildCalendarDays(
+  history: HistoryItem[],
+  queue: QueueItem[],
+  schedule: ScheduleSlot[]
+): CalendarDay[] {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = now.getMonth();
+
+  // Start from beginning of the month, pad to Monday
+  const firstOfMonth = new Date(year, month, 1);
+  const startDay = firstOfMonth.getDay();
+  const start = new Date(firstOfMonth);
+  start.setDate(start.getDate() - ((startDay + 6) % 7)); // Monday start
+
+  // End at end of month, pad to Sunday
+  const lastOfMonth = new Date(year, month + 1, 0);
+  const endDay = lastOfMonth.getDay();
+  const end = new Date(lastOfMonth);
+  end.setDate(end.getDate() + (7 - endDay) % 7);
+
+  // Index events by date string
+  const postsByDate = new Map<string, CalendarDay["posts"]>();
+
+  for (const item of history) {
+    const date = item.posted_at.split("T")[0];
+    if (!postsByDate.has(date)) postsByDate.set(date, []);
+    postsByDate.get(date)!.push({
+      label: item.media_name,
+      category: item.category,
+      type: "past",
+    });
+  }
+
+  for (const item of queue) {
+    const date = item.scheduled_for.split("T")[0];
+    if (!postsByDate.has(date)) postsByDate.set(date, []);
+    postsByDate.get(date)!.push({
+      label: item.media_name,
+      category: item.category,
+      type: "queued",
+    });
+  }
+
+  for (const slot of schedule) {
+    const date = slot.slot_time.split("T")[0];
+    if (!postsByDate.has(date)) postsByDate.set(date, []);
+    postsByDate.get(date)!.push({
+      label: slot.predicted_category || "any",
+      category: slot.predicted_category || "any",
+      type: "predicted",
+    });
+  }
+
+  const today = now.toISOString().split("T")[0];
+  const days: CalendarDay[] = [];
+  const current = new Date(start);
+
+  while (current <= end) {
+    const dateStr = current.toISOString().split("T")[0];
+    days.push({
+      date: dateStr,
+      dayOfMonth: current.getDate(),
+      isToday: dateStr === today,
+      isCurrentMonth: current.getMonth() === month,
+      posts: postsByDate.get(dateStr) || [],
+    });
+    current.setDate(current.getDate() + 1);
+  }
+
+  return days;
+}
+
+const typeColors = {
+  past: "bg-green-500/20 text-green-700 dark:text-green-400",
+  queued: "bg-blue-500/20 text-blue-700 dark:text-blue-400",
+  predicted: "bg-muted text-muted-foreground",
+};
+
+export function ContentCalendar({
+  history,
+  queue,
+  schedule,
+}: {
+  history: HistoryItem[];
+  queue: QueueItem[];
+  schedule: ScheduleSlot[];
+}) {
+  const days = useMemo(
+    () => buildCalendarDays(history, queue, schedule),
+    [history, queue, schedule]
+  );
+
+  const weekDays = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+  const monthName = new Date().toLocaleDateString("en-US", {
+    month: "long",
+    year: "numeric",
+  });
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base">{monthName}</CardTitle>
+        <div className="flex gap-4 text-xs text-muted-foreground">
+          <span className="flex items-center gap-1">
+            <span className="h-2 w-2 rounded-full bg-green-500" /> Posted
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="h-2 w-2 rounded-full bg-blue-500" /> In Queue
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="h-2 w-2 rounded-full bg-muted-foreground" /> Predicted
+          </span>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {/* Header */}
+        <div className="grid grid-cols-7 gap-px mb-1">
+          {weekDays.map((d) => (
+            <div
+              key={d}
+              className="text-center text-xs font-medium text-muted-foreground py-1"
+            >
+              {d}
+            </div>
+          ))}
+        </div>
+
+        {/* Days grid */}
+        <div className="grid grid-cols-7 gap-px">
+          {days.map((day) => (
+            <div
+              key={day.date}
+              className={cn(
+                "min-h-[80px] border rounded-sm p-1",
+                !day.isCurrentMonth && "opacity-30",
+                day.isToday && "border-primary"
+              )}
+            >
+              <span
+                className={cn(
+                  "text-xs font-medium",
+                  day.isToday && "text-primary"
+                )}
+              >
+                {day.dayOfMonth}
+              </span>
+              <div className="mt-0.5 space-y-0.5">
+                {day.posts.slice(0, 3).map((post, i) => (
+                  <div
+                    key={i}
+                    className={cn(
+                      "truncate rounded px-1 py-0.5 text-[10px]",
+                      typeColors[post.type]
+                    )}
+                    title={post.label}
+                  >
+                    {post.label}
+                  </div>
+                ))}
+                {day.posts.length > 3 && (
+                  <div className="text-[10px] text-muted-foreground px-1">
+                    +{day.posts.length - 3} more
+                  </div>
+                )}
+              </div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/landing/src/components/dashboard/media/dead-content-chart.tsx
+++ b/landing/src/components/dashboard/media/dead-content-chart.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import {
+  ResponsiveContainer,
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  Tooltip,
+  CartesianGrid,
+} from "recharts";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+interface CategoryDead {
+  category: string;
+  dead_count: number;
+  total_count?: number;
+}
+
+export function DeadContentChart({ data }: { data: CategoryDead[] }) {
+  if (data.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Dead Content by Category</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground py-8 text-center">
+            No dead content found.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Dead Content by Category</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ResponsiveContainer width="100%" height={300}>
+          <BarChart data={data} layout="vertical">
+            <CartesianGrid strokeDasharray="3 3" className="opacity-30" />
+            <XAxis type="number" tick={{ fontSize: 12 }} allowDecimals={false} />
+            <YAxis
+              type="category"
+              dataKey="category"
+              tick={{ fontSize: 12 }}
+              width={100}
+            />
+            <Tooltip />
+            <Bar
+              dataKey="dead_count"
+              fill="hsl(0, 84%, 60%)"
+              name="Never Posted"
+              radius={[0, 4, 4, 0]}
+            />
+          </BarChart>
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/landing/src/components/dashboard/media/media-grid.tsx
+++ b/landing/src/components/dashboard/media/media-grid.tsx
@@ -1,0 +1,199 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { getApi } from "@/lib/dashboard-api";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+interface MediaItem {
+  id: string;
+  file_name: string;
+  category: string;
+  mime_type: string;
+  file_size: number;
+  times_posted: number;
+  last_posted_at: string | null;
+  source_type: string;
+  created_at: string;
+}
+
+interface MediaLibraryResponse {
+  items: MediaItem[];
+  total: number;
+  page: number;
+  page_size: number;
+  categories: string[];
+  pool_health: {
+    total_active: number;
+    never_posted: number;
+    posted_once: number;
+    posted_multiple: number;
+    eligible_for_posting: number;
+    by_category: { name: string; count: number }[];
+  };
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function postingBadge(times: number) {
+  if (times === 0)
+    return <Badge variant="outline" className="text-xs">Never posted</Badge>;
+  if (times === 1)
+    return <Badge variant="secondary" className="text-xs">Posted once</Badge>;
+  return (
+    <Badge className="text-xs bg-green-600 hover:bg-green-700">
+      {times}x posted
+    </Badge>
+  );
+}
+
+export function MediaGrid({
+  initialData,
+}: {
+  initialData: MediaLibraryResponse;
+}) {
+  const [data, setData] = useState(initialData);
+  const [poolHealth, setPoolHealth] = useState(initialData.pool_health);
+  const [page, setPage] = useState(initialData.page);
+  const [category, setCategory] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const fetchPage = useCallback(
+    async (p: number, cat: string | null) => {
+      setLoading(true);
+      try {
+        const params = new URLSearchParams({ page: String(p), page_size: "20" });
+        if (cat) params.set("category", cat);
+        const result = await getApi(`media-library?${params}`);
+        // Pool health is only returned on page 1
+        if (result.pool_health) setPoolHealth(result.pool_health);
+        setData(result);
+        setPage(p);
+      } finally {
+        setLoading(false);
+      }
+    },
+    []
+  );
+
+  const handleCategoryFilter = (cat: string | null) => {
+    setCategory(cat);
+    fetchPage(1, cat);
+  };
+
+  const totalPages = Math.ceil(data.total / data.page_size);
+
+  return (
+    <div className="space-y-4">
+      {/* Category filter */}
+      <div className="flex flex-wrap gap-2">
+        <Button
+          variant={category === null ? "default" : "outline"}
+          size="sm"
+          onClick={() => handleCategoryFilter(null)}
+        >
+          All ({poolHealth.total_active})
+        </Button>
+        {poolHealth.by_category.map((cat) => (
+          <Button
+            key={cat.name}
+            variant={category === cat.name ? "default" : "outline"}
+            size="sm"
+            onClick={() => handleCategoryFilter(cat.name)}
+          >
+            {cat.name} ({cat.count})
+          </Button>
+        ))}
+      </div>
+
+      {/* Items grid */}
+      <div
+        className={cn(
+          "grid gap-3 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4",
+          loading && "opacity-50 pointer-events-none"
+        )}
+      >
+        {data.items.length === 0 ? (
+          <p className="col-span-full text-center text-sm text-muted-foreground py-12">
+            No media items found.
+          </p>
+        ) : (
+          data.items.map((item) => (
+            <Card key={item.id} className="overflow-hidden">
+              <div className="bg-muted h-32 flex items-center justify-center text-muted-foreground">
+                <span className="text-xs uppercase tracking-wider">
+                  {item.mime_type?.split("/")[1] || "file"}
+                </span>
+              </div>
+              <CardContent className="p-3 space-y-2">
+                <p
+                  className="text-sm font-medium truncate"
+                  title={item.file_name}
+                >
+                  {item.file_name}
+                </p>
+                <div className="flex items-center justify-between">
+                  <Badge variant="outline" className="text-xs">
+                    {item.category}
+                  </Badge>
+                  {postingBadge(item.times_posted)}
+                </div>
+                <div className="flex items-center justify-between text-xs text-muted-foreground">
+                  <span>{formatBytes(item.file_size)}</span>
+                  <span>{formatDate(item.created_at)}</span>
+                </div>
+              </CardContent>
+            </Card>
+          ))
+        )}
+      </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between pt-2">
+          <p className="text-sm text-muted-foreground">
+            Showing {(page - 1) * data.page_size + 1}-
+            {Math.min(page * data.page_size, data.total)} of {data.total}
+          </p>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={page <= 1}
+              onClick={() => fetchPage(page - 1, category)}
+            >
+              Previous
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={page >= totalPages}
+              onClick={() => fetchPage(page + 1, category)}
+            >
+              Next
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/landing/src/components/dashboard/media/media-tabs.tsx
+++ b/landing/src/components/dashboard/media/media-tabs.tsx
@@ -1,0 +1,40 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { cn } from "@/lib/utils";
+
+const tabs = [
+  { href: "/dashboard/media", label: "Library" },
+  { href: "/dashboard/media/calendar", label: "Calendar" },
+  { href: "/dashboard/media/dead-content", label: "Dead Content" },
+  { href: "/dashboard/media/reuse", label: "Content Reuse" },
+];
+
+export function MediaTabs() {
+  const pathname = usePathname();
+
+  return (
+    <div className="border-b">
+      <nav className="-mb-px flex gap-4" aria-label="Media tabs">
+        {tabs.map((tab) => {
+          const active = pathname === tab.href;
+          return (
+            <Link
+              key={tab.href}
+              href={tab.href}
+              className={cn(
+                "border-b-2 px-1 py-2 text-sm font-medium transition-colors",
+                active
+                  ? "border-primary text-primary"
+                  : "border-transparent text-muted-foreground hover:border-muted-foreground/30 hover:text-foreground"
+              )}
+            >
+              {tab.label}
+            </Link>
+          );
+        })}
+      </nav>
+    </div>
+  );
+}

--- a/landing/src/components/dashboard/media/media-upload-wrapper.tsx
+++ b/landing/src/components/dashboard/media/media-upload-wrapper.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { MediaUpload } from "./media-upload";
+
+export function MediaUploadWrapper({ categories }: { categories: string[] }) {
+  const router = useRouter();
+
+  return (
+    <MediaUpload
+      categories={categories}
+      onUploadComplete={() => router.refresh()}
+    />
+  );
+}

--- a/landing/src/components/dashboard/media/media-upload.tsx
+++ b/landing/src/components/dashboard/media/media-upload.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+
+const ACCEPTED_TYPES = [
+  "image/jpeg",
+  "image/png",
+  "image/gif",
+  "video/mp4",
+  "video/quicktime",
+];
+const MAX_SIZE = 50 * 1024 * 1024;
+
+interface UploadResult {
+  id: string;
+  file_name: string;
+  category: string;
+}
+
+export function MediaUpload({
+  categories,
+  onUploadComplete,
+}: {
+  categories: string[];
+  onUploadComplete: () => void;
+}) {
+  const [dragging, setDragging] = useState(false);
+  const [uploading, setUploading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+  const [selectedCategory, setSelectedCategory] = useState<string>("");
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const uploadFile = useCallback(
+    async (file: File) => {
+      setError(null);
+      setSuccess(null);
+
+      if (!ACCEPTED_TYPES.includes(file.type)) {
+        setError(`Unsupported file type: ${file.type}`);
+        return;
+      }
+      if (file.size > MAX_SIZE) {
+        setError("File exceeds 50 MB limit");
+        return;
+      }
+
+      setUploading(true);
+      try {
+        const formData = new FormData();
+        formData.append("file", file);
+        if (selectedCategory) {
+          formData.append("category", selectedCategory);
+        }
+
+        const res = await fetch("/api/dashboard/upload", {
+          method: "POST",
+          body: formData,
+        });
+
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({ error: "Upload failed" }));
+          throw new Error(err.detail || err.error || `Upload failed (${res.status})`);
+        }
+
+        const result: UploadResult = await res.json();
+        setSuccess(`Uploaded: ${result.file_name} (${result.category})`);
+        onUploadComplete();
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Upload failed");
+      } finally {
+        setUploading(false);
+      }
+    },
+    [selectedCategory, onUploadComplete]
+  );
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      setDragging(false);
+      const file = e.dataTransfer.files[0];
+      if (file) uploadFile(file);
+    },
+    [uploadFile]
+  );
+
+  const handleFileSelect = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (file) uploadFile(file);
+      e.target.value = "";
+    },
+    [uploadFile]
+  );
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-base">Upload Media</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {/* Category selector */}
+        <div className="flex items-center gap-2">
+          <label className="text-sm text-muted-foreground">Category:</label>
+          <select
+            value={selectedCategory}
+            onChange={(e) => setSelectedCategory(e.target.value)}
+            className="rounded-md border bg-background px-2 py-1 text-sm"
+          >
+            <option value="">Uncategorized</option>
+            {categories.map((cat) => (
+              <option key={cat} value={cat}>
+                {cat}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Drop zone */}
+        <div
+          onDragOver={(e) => {
+            e.preventDefault();
+            setDragging(true);
+          }}
+          onDragLeave={() => setDragging(false)}
+          onDrop={handleDrop}
+          onClick={() => fileInputRef.current?.click()}
+          className={cn(
+            "flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed p-8 text-center transition-colors",
+            dragging
+              ? "border-primary bg-primary/5"
+              : "border-muted-foreground/25 hover:border-muted-foreground/50",
+            uploading && "pointer-events-none opacity-50"
+          )}
+        >
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept={ACCEPTED_TYPES.join(",")}
+            onChange={handleFileSelect}
+            className="hidden"
+          />
+          {uploading ? (
+            <p className="text-sm text-muted-foreground">Uploading...</p>
+          ) : (
+            <>
+              <p className="text-sm font-medium">
+                Drop a file here or click to browse
+              </p>
+              <p className="text-xs text-muted-foreground mt-1">
+                JPG, PNG, GIF, MP4 — max 50 MB
+              </p>
+            </>
+          )}
+        </div>
+
+        {error && (
+          <p className="text-sm text-red-500">{error}</p>
+        )}
+        {success && (
+          <p className="text-sm text-green-600">{success}</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/landing/src/components/dashboard/media/pool-health.tsx
+++ b/landing/src/components/dashboard/media/pool-health.tsx
@@ -1,0 +1,83 @@
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { Progress } from "@/components/ui/progress";
+
+interface PoolHealth {
+  total_active: number;
+  never_posted: number;
+  posted_once: number;
+  posted_multiple: number;
+  eligible_for_posting: number;
+  by_category: { name: string; count: number }[];
+}
+
+export function PoolHealth({ health }: { health: PoolHealth }) {
+  const total = health.total_active || 1;
+  const reuseRate = Math.round((health.posted_multiple / total) * 100);
+  const eligiblePct = Math.round((health.eligible_for_posting / total) * 100);
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium text-muted-foreground">
+            Total Active
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold">{health.total_active}</div>
+          <p className="text-xs text-muted-foreground mt-1">
+            {health.by_category.length} categories
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium text-muted-foreground">
+            Eligible for Posting
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold">{health.eligible_for_posting}</div>
+          <Progress value={eligiblePct} className="mt-2 h-1.5" />
+          <p className="text-xs text-muted-foreground mt-1">
+            {eligiblePct}% of library
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium text-muted-foreground">
+            Never Posted
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold">{health.never_posted}</div>
+          <p className="text-xs text-muted-foreground mt-1">
+            {Math.round((health.never_posted / total) * 100)}% untouched
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="pb-2">
+          <CardTitle className="text-sm font-medium text-muted-foreground">
+            Reuse Rate
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold">{reuseRate}%</div>
+          <p className="text-xs text-muted-foreground mt-1">
+            {health.posted_multiple} posted 2+ times
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/landing/src/components/dashboard/media/reuse-chart.tsx
+++ b/landing/src/components/dashboard/media/reuse-chart.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+import type { PieLabelRenderProps } from "recharts";
+import {
+  ResponsiveContainer,
+  PieChart,
+  Pie,
+  Cell,
+  Tooltip,
+  Legend,
+} from "recharts";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+
+interface ReuseData {
+  total_active: number;
+  never_posted: number;
+  posted_once: number;
+  posted_multiple: number;
+  reuse_rate: number;
+  never_posted_by_category: { category: string; dead_count: number }[];
+}
+
+const COLORS = [
+  "hsl(0, 84%, 60%)",    // never posted — red
+  "hsl(48, 96%, 53%)",   // posted once — yellow
+  "hsl(142, 76%, 36%)",  // posted multiple — green
+];
+
+export function ReuseChart({ data }: { data: ReuseData }) {
+  const pieData = [
+    { name: "Never Posted", value: data.never_posted },
+    { name: "Posted Once", value: data.posted_once },
+    { name: "Reused (2+)", value: data.posted_multiple },
+  ].filter((d) => d.value > 0);
+
+  if (pieData.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Content Reuse Breakdown</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground py-8 text-center">
+            No content data available.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Content Reuse Breakdown</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ResponsiveContainer width="100%" height={300}>
+          <PieChart>
+            <Pie
+              data={pieData}
+              cx="50%"
+              cy="50%"
+              innerRadius={60}
+              outerRadius={100}
+              paddingAngle={2}
+              dataKey="value"
+              label={(props: PieLabelRenderProps) =>
+                `${props.name ?? ""} ${(((props.percent as number | undefined) ?? 0) * 100).toFixed(0)}%`
+              }
+              labelLine={false}
+            >
+              {pieData.map((_, i) => (
+                <Cell key={i} fill={COLORS[i % COLORS.length]} />
+              ))}
+            </Pie>
+            <Tooltip />
+            <Legend />
+          </PieChart>
+        </ResponsiveContainer>
+      </CardContent>
+    </Card>
+  );
+}

--- a/landing/src/components/dashboard/sidebar.tsx
+++ b/landing/src/components/dashboard/sidebar.tsx
@@ -2,15 +2,23 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { BarChart3, LayoutDashboard, Rocket, Settings } from "lucide-react";
+import {
+  BarChart3,
+  CalendarDays,
+  ImageIcon,
+  LayoutDashboard,
+  Rocket,
+  Settings,
+} from "lucide-react";
 import { cn } from "@/lib/utils";
 import { siteConfig } from "@/config/site";
 
 const navItems = [
   { href: "/dashboard", label: "Overview", icon: LayoutDashboard },
+  { href: "/dashboard/media", label: "Media Library", icon: ImageIcon },
+  { href: "/dashboard/media/calendar", label: "Calendar", icon: CalendarDays },
   { href: "/dashboard/settings", label: "Settings", icon: Settings },
   { href: "/dashboard/setup", label: "Setup Wizard", icon: Rocket },
-  // TODO: /dashboard/analytics — detailed analytics page is Phase 3
   { href: "/dashboard/analytics", label: "Analytics", icon: BarChart3 },
 ];
 
@@ -29,7 +37,7 @@ export function Sidebar() {
           const active =
             item.href === "/dashboard"
               ? pathname === "/dashboard"
-              : pathname.startsWith(item.href);
+              : pathname === item.href || pathname.startsWith(item.href + "/");
 
           return (
             <Link

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,7 @@ google-auth-oauthlib>=1.1.0
 # API Server (Phase 04 OAuth)
 fastapi>=0.109.0
 uvicorn>=0.27.0
+python-multipart>=0.0.6
 
 # Security (Phase 2)
 cryptography>=41.0.0

--- a/src/api/routes/onboarding/dashboard.py
+++ b/src/api/routes/onboarding/dashboard.py
@@ -1,7 +1,12 @@
 """Dashboard detail endpoints for onboarding Mini App."""
 
-from fastapi import APIRouter, Query
+import hashlib
+import mimetypes
+from pathlib import Path
 
+from fastapi import APIRouter, File, Form, HTTPException, Query, UploadFile
+
+from src.repositories.media_repository import MediaRepository
 from src.services.core.dashboard_service import DashboardService
 from src.services.core.health_check import HealthCheckService
 from src.services.core.instagram_account_service import InstagramAccountService
@@ -229,3 +234,128 @@ async def onboarding_system_status(
 
     with HealthCheckService() as health_service:
         return health_service.check_all()
+
+
+@router.get("/media-library")
+async def onboarding_media_library(
+    init_data: str,
+    chat_id: int,
+    page: int = Query(default=1, ge=1),
+    page_size: int = Query(default=20, ge=1, le=100),
+    category: str | None = Query(default=None),
+    posting_status: str | None = Query(default=None),
+):
+    """Return paginated media library with pool health stats."""
+    _validate_request(init_data, chat_id)
+
+    with DashboardService() as service:
+        return service.get_media_library(
+            chat_id,
+            page=page,
+            page_size=page_size,
+            category=category,
+            posting_status=posting_status,
+        )
+
+
+UPLOAD_DIR = "/tmp/media/uploads"
+ALLOWED_MIME_TYPES = {
+    "image/jpeg",
+    "image/png",
+    "image/gif",
+    "video/mp4",
+    "video/quicktime",
+}
+MAX_UPLOAD_SIZE = 50 * 1024 * 1024  # 50 MB
+
+
+@router.post("/upload-media")
+async def onboarding_upload_media(
+    init_data: str = Query(...),
+    chat_id: int = Query(...),
+    file: UploadFile = File(...),
+    category: str | None = Form(default=None),
+):
+    """Upload a media file and create a media_item record.
+
+    Files are stored locally and indexed for posting.
+    """
+
+    _validate_request(init_data, chat_id)
+
+    # Validate MIME type
+    mime_type = (
+        file.content_type
+        or mimetypes.guess_type(file.filename or "")[0]
+        or "application/octet-stream"
+    )
+    if mime_type not in ALLOWED_MIME_TYPES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported file type: {mime_type}. Allowed: {', '.join(sorted(ALLOWED_MIME_TYPES))}",
+        )
+
+    # Read file content
+    content = await file.read()
+    if len(content) > MAX_UPLOAD_SIZE:
+        raise HTTPException(status_code=400, detail="File exceeds 50 MB limit")
+    if len(content) == 0:
+        raise HTTPException(status_code=400, detail="Empty file")
+
+    file_hash = hashlib.sha256(content).hexdigest()
+
+    # Resolve tenant
+    with SettingsService() as settings_service:
+        chat_settings = settings_service.get_settings(chat_id)
+        chat_settings_id = str(chat_settings.id)
+
+    # Check for duplicate content
+    with MediaRepository() as media_repo:
+        existing = media_repo.get_active_by_hash(
+            file_hash, chat_settings_id=chat_settings_id
+        )
+        if existing:
+            raise HTTPException(
+                status_code=409,
+                detail=f"Duplicate content — matches existing file: {existing.file_name}",
+            )
+
+    # Save to disk
+    folder = category or "uncategorized"
+    save_dir = Path(UPLOAD_DIR) / chat_settings_id / folder
+    save_dir.mkdir(parents=True, exist_ok=True)
+    save_path = save_dir / (file.filename or "upload")
+
+    # Handle filename collisions
+    if save_path.exists():
+        stem = save_path.stem
+        suffix = save_path.suffix
+        counter = 1
+        while save_path.exists():
+            save_path = save_dir / f"{stem}_{counter}{suffix}"
+            counter += 1
+
+    save_path.write_bytes(content)
+
+    # Create media_item record
+    with MediaRepository() as media_repo:
+        media_item = media_repo.create(
+            file_path=str(save_path),
+            file_name=file.filename or "upload",
+            file_hash=file_hash,
+            file_size_bytes=len(content),
+            mime_type=mime_type,
+            category=category,
+            source_type="upload",
+            source_identifier=str(save_path),
+            chat_settings_id=chat_settings_id,
+        )
+
+    return {
+        "id": str(media_item.id),
+        "file_name": media_item.file_name,
+        "category": media_item.category or "uncategorized",
+        "file_size": media_item.file_size,
+        "mime_type": media_item.mime_type,
+        "created_at": media_item.created_at.isoformat(),
+    }

--- a/src/api/routes/onboarding/dashboard.py
+++ b/src/api/routes/onboarding/dashboard.py
@@ -4,7 +4,7 @@ import hashlib
 import mimetypes
 from pathlib import Path
 
-from fastapi import APIRouter, File, Form, HTTPException, Query, UploadFile
+from fastapi import APIRouter, File, Form, HTTPException, Query, Request, UploadFile
 
 from src.repositories.media_repository import MediaRepository
 from src.services.core.dashboard_service import DashboardService
@@ -258,6 +258,9 @@ async def onboarding_media_library(
         )
 
 
+# Ephemeral local storage — files survive service restarts but not OS reboots.
+# Media records in DB will have stale source_identifier paths after reboot.
+# Planned migration: Cloudinary persistent storage (cloud_url columns exist on model).
 UPLOAD_DIR = "/tmp/media/uploads"
 ALLOWED_MIME_TYPES = {
     "image/jpeg",
@@ -268,9 +271,29 @@ ALLOWED_MIME_TYPES = {
 }
 MAX_UPLOAD_SIZE = 50 * 1024 * 1024  # 50 MB
 
+# Magic bytes for content-type verification (first N bytes → expected MIME)
+_MAGIC_SIGNATURES = {
+    b"\xff\xd8\xff": "image/jpeg",
+    b"\x89PNG\r\n\x1a\n": "image/png",
+    b"GIF87a": "image/gif",
+    b"GIF89a": "image/gif",
+}
+
+
+def _detect_mime_from_magic(content: bytes) -> str | None:
+    """Detect MIME type from file magic bytes. Returns None if unrecognized."""
+    for signature, mime in _MAGIC_SIGNATURES.items():
+        if content[: len(signature)] == signature:
+            return mime
+    # MP4/QuickTime: check for ftyp box (byte 4-7)
+    if len(content) >= 8 and content[4:8] == b"ftyp":
+        return "video/mp4"
+    return None
+
 
 @router.post("/upload-media")
 async def onboarding_upload_media(
+    request: Request,
     init_data: str = Query(...),
     chat_id: int = Query(...),
     file: UploadFile = File(...),
@@ -280,34 +303,70 @@ async def onboarding_upload_media(
 
     Files are stored locally and indexed for posting.
     """
-
     _validate_request(init_data, chat_id)
 
-    # Validate MIME type
-    mime_type = (
-        file.content_type
-        or mimetypes.guess_type(file.filename or "")[0]
-        or "application/octet-stream"
-    )
-    if mime_type not in ALLOWED_MIME_TYPES:
-        raise HTTPException(
-            status_code=400,
-            detail=f"Unsupported file type: {mime_type}. Allowed: {', '.join(sorted(ALLOWED_MIME_TYPES))}",
-        )
+    # Fast-fail on Content-Length before buffering the file
+    content_length = int(request.headers.get("content-length", 0))
+    if content_length > MAX_UPLOAD_SIZE:
+        raise HTTPException(status_code=413, detail="File exceeds 50 MB limit")
 
     # Read file content
     content = await file.read()
     if len(content) > MAX_UPLOAD_SIZE:
-        raise HTTPException(status_code=400, detail="File exceeds 50 MB limit")
+        raise HTTPException(status_code=413, detail="File exceeds 50 MB limit")
     if len(content) == 0:
         raise HTTPException(status_code=400, detail="Empty file")
 
+    # Validate MIME type from header/extension, then verify with magic bytes
+    claimed_mime = (
+        file.content_type
+        or mimetypes.guess_type(file.filename or "")[0]
+        or "application/octet-stream"
+    )
+    if claimed_mime not in ALLOWED_MIME_TYPES:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unsupported file type: {claimed_mime}. "
+            f"Allowed: {', '.join(sorted(ALLOWED_MIME_TYPES))}",
+        )
+
+    actual_mime = _detect_mime_from_magic(content)
+    if actual_mime is not None and actual_mime != claimed_mime:
+        raise HTTPException(
+            status_code=400,
+            detail=f"File content ({actual_mime}) does not match declared type ({claimed_mime})",
+        )
+
     file_hash = hashlib.sha256(content).hexdigest()
+
+    # Sanitize filename — strip path components to prevent directory traversal
+    safe_name = Path(file.filename or "upload").name
+    if not safe_name or safe_name.startswith("."):
+        safe_name = "upload"
 
     # Resolve tenant
     with SettingsService() as settings_service:
         chat_settings = settings_service.get_settings(chat_id)
         chat_settings_id = str(chat_settings.id)
+
+    # Validate category against known categories from DB
+    valid_category = None
+    if category:
+        with MediaRepository() as media_repo:
+            known_categories = media_repo.get_categories(
+                chat_settings_id=chat_settings_id
+            )
+        if category in known_categories:
+            valid_category = category
+        else:
+            # Sanitize: strip path separators as defense-in-depth
+            sanitized = Path(category).name
+            if sanitized and not sanitized.startswith(".") and "/" not in category:
+                valid_category = sanitized
+            else:
+                raise HTTPException(
+                    status_code=400, detail=f"Invalid category: {category}"
+                )
 
     # Check for duplicate content
     with MediaRepository() as media_repo:
@@ -321,10 +380,15 @@ async def onboarding_upload_media(
             )
 
     # Save to disk
-    folder = category or "uncategorized"
+    folder = valid_category or "uncategorized"
     save_dir = Path(UPLOAD_DIR) / chat_settings_id / folder
     save_dir.mkdir(parents=True, exist_ok=True)
-    save_path = save_dir / (file.filename or "upload")
+    save_path = save_dir / safe_name
+
+    # Belt-and-suspenders: verify resolved path is within UPLOAD_DIR
+    resolved = save_path.resolve()
+    if not str(resolved).startswith(str(Path(UPLOAD_DIR).resolve())):
+        raise HTTPException(status_code=400, detail="Invalid file path")
 
     # Handle filename collisions
     if save_path.exists():
@@ -341,11 +405,11 @@ async def onboarding_upload_media(
     with MediaRepository() as media_repo:
         media_item = media_repo.create(
             file_path=str(save_path),
-            file_name=file.filename or "upload",
+            file_name=safe_name,
             file_hash=file_hash,
             file_size_bytes=len(content),
-            mime_type=mime_type,
-            category=category,
+            mime_type=claimed_mime,
+            category=valid_category,
             source_type="upload",
             source_identifier=str(save_path),
             chat_settings_id=chat_settings_id,

--- a/src/repositories/media_repository.py
+++ b/src/repositories/media_repository.py
@@ -247,6 +247,54 @@ class MediaRepository(BaseRepository):
         self.end_read_transaction()
         return result
 
+    def get_paginated(
+        self,
+        page: int = 1,
+        page_size: int = 20,
+        category: Optional[str] = None,
+        posting_status: Optional[str] = None,
+        is_active: bool = True,
+        chat_settings_id: Optional[str] = None,
+    ) -> tuple[List[MediaItem], int]:
+        """Get paginated media items with filters.
+
+        Args:
+            page: 1-indexed page number
+            page_size: Items per page
+            category: Filter by category name
+            posting_status: Filter by posting tier: "never_posted", "posted_once", "posted_multiple"
+            is_active: Filter by active status (default True)
+            chat_settings_id: Tenant filter
+
+        Returns:
+            Tuple of (items list, total count matching filters)
+        """
+        query = self._tenant_query(MediaItem, chat_settings_id).filter(
+            MediaItem.is_active == is_active
+        )
+
+        if category is not None:
+            query = query.filter(MediaItem.category == category)
+
+        if posting_status == "never_posted":
+            query = query.filter(MediaItem.times_posted == 0)
+        elif posting_status == "posted_once":
+            query = query.filter(MediaItem.times_posted == 1)
+        elif posting_status == "posted_multiple":
+            query = query.filter(MediaItem.times_posted > 1)
+
+        total = query.with_entities(func.count(MediaItem.id)).scalar() or 0
+
+        items = (
+            query.order_by(MediaItem.created_at.desc())
+            .offset((page - 1) * page_size)
+            .limit(page_size)
+            .all()
+        )
+
+        self.end_read_transaction()
+        return items, total
+
     def get_categories(self, chat_settings_id: Optional[str] = None) -> List[str]:
         """Get all unique categories."""
         result = (

--- a/src/services/core/dashboard_service.py
+++ b/src/services/core/dashboard_service.py
@@ -107,6 +107,99 @@ class DashboardService(BaseService):
 
         return {"items": items}
 
+    def get_media_library(
+        self,
+        telegram_chat_id: int,
+        page: int = 1,
+        page_size: int = 20,
+        category: Optional[str] = None,
+        posting_status: Optional[str] = None,
+    ) -> dict:
+        """Return paginated media items with pool health stats.
+
+        Combines item listing with aggregate stats for the media library view.
+        """
+        with self.track_execution(
+            "get_media_library",
+            input_params={
+                "telegram_chat_id": telegram_chat_id,
+                "page": page,
+                "category": category,
+            },
+        ) as run_id:
+            chat_settings_id = self._resolve_chat_settings_id(telegram_chat_id)
+
+            items, total = self.media_repo.get_paginated(
+                page=page,
+                page_size=page_size,
+                category=category,
+                posting_status=posting_status,
+                chat_settings_id=chat_settings_id,
+            )
+
+            serialized = []
+            for item in items:
+                serialized.append(
+                    {
+                        "id": str(item.id),
+                        "file_name": item.file_name,
+                        "category": item.category or "uncategorized",
+                        "mime_type": item.mime_type,
+                        "file_size": item.file_size,
+                        "times_posted": item.times_posted,
+                        "last_posted_at": (
+                            item.last_posted_at.isoformat()
+                            if item.last_posted_at
+                            else None
+                        ),
+                        "source_type": item.source_type,
+                        "created_at": item.created_at.isoformat(),
+                    }
+                )
+
+            # Only compute expensive pool health stats on page 1
+            pool_health = None
+            categories: list[str] = []
+            if page == 1:
+                posting_status_counts = self.media_repo.count_by_posting_status(
+                    chat_settings_id=chat_settings_id
+                )
+                category_counts = self.media_repo.count_by_category(
+                    chat_settings_id=chat_settings_id
+                )
+                eligible_count = self.media_repo.count_eligible(
+                    chat_settings_id=chat_settings_id
+                )
+                categories = sorted(category_counts.keys())
+                pool_health = {
+                    "total_active": sum(posting_status_counts.values()),
+                    "never_posted": posting_status_counts.get("never_posted", 0),
+                    "posted_once": posting_status_counts.get("posted_once", 0),
+                    "posted_multiple": posting_status_counts.get("posted_multiple", 0),
+                    "eligible_for_posting": eligible_count,
+                    "by_category": [
+                        {"name": name, "count": count}
+                        for name, count in sorted(
+                            category_counts.items(),
+                            key=lambda x: x[1],
+                            reverse=True,
+                        )
+                    ],
+                }
+
+            self.set_result_summary(
+                run_id, {"total": total, "page": page, "returned": len(serialized)}
+            )
+
+            return {
+                "items": serialized,
+                "total": total,
+                "page": page,
+                "page_size": page_size,
+                "categories": categories,
+                "pool_health": pool_health,
+            }
+
     def get_media_stats(self, telegram_chat_id: int) -> dict:
         """Return media library breakdown by category."""
         chat_settings_id = self._resolve_chat_settings_id(telegram_chat_id)

--- a/src/services/media_sources/factory.py
+++ b/src/services/media_sources/factory.py
@@ -111,12 +111,17 @@ class MediaSourceFactory:
         """Get the appropriate provider for an existing media item.
         Falls back to 'local' if source_type is not set.
 
+        For 'upload' source type, creates a local provider since uploaded
+        files are stored on the local filesystem.
+
         Args:
             media_item: MediaItem with source_type and source_identifier.
             telegram_chat_id: Telegram chat ID for per-tenant OAuth lookup
                 (required for Google Drive sources using user OAuth).
         """
         source_type = media_item.source_type or "local"
+        if source_type == "upload":
+            source_type = "local"
         return cls.create(source_type, telegram_chat_id=telegram_chat_id)
 
     @classmethod


### PR DESCRIPTION
## Summary

- **Content library browser** (`/dashboard/media`) — paginated grid of all media items with category filtering, pool health stats (total active, eligible, never posted, reuse rate), drag-and-drop upload
- **Content calendar** (`/dashboard/media/calendar`) — monthly calendar showing past posts, in-queue items, and predicted future slots with posting rate stats
- **Dead content view** (`/dashboard/media/dead-content`) — surfaces never-posted items (30+ days old) with category-level bar chart breakdown
- **Content reuse view** (`/dashboard/media/reuse`) — donut chart of evergreen vs one-shot vs never-posted content with per-category breakdown
- **New backend endpoints**: `GET /media-library` (paginated listing with pool health), `POST /upload-media` (multipart file upload with SHA256 dedup)
- **Upload architecture**: BFF → FastAPI → local storage with `source_type="upload"` provider mapping. Cloudinary columns exist for future migration.

### Architecture Decisions

- Pool health stats only computed on page 1 to avoid 3 unnecessary DB queries on pagination
- Dedicated upload proxy route (not the generic JSON BFF proxy) for multipart form data
- `source_type="upload"` mapped to local provider in factory for posting system compatibility

## Test plan

- [ ] Verify `/dashboard/media` loads with media items grid and pool health cards
- [ ] Test category filter buttons update the grid
- [ ] Test pagination (next/previous) works without re-fetching pool health
- [ ] Test drag-and-drop upload with valid image (JPG/PNG)
- [ ] Test upload rejects unsupported file types and duplicates (409)
- [ ] Verify `/dashboard/media/calendar` shows monthly view with post history
- [ ] Verify `/dashboard/media/dead-content` shows stats from analytics endpoint
- [ ] Verify `/dashboard/media/reuse` shows donut chart and category table
- [ ] Verify sidebar shows Media Library and Calendar entries with correct active states
- [ ] Run `pytest` — 1578 tests pass
- [ ] Run `npx tsc --noEmit` — no new TS errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)