### PR TITLE
fix: resolve 6 design issues from visual crawl (#214–#219)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed — Design Issues (#214–#219)
+
+- **Mobile dashboard navigation** (#214) — Added hamburger menu (Sheet drawer) to dashboard header so sidebar nav is accessible on mobile viewports.
+- **Setup guide mobile overflow** (#215) — Fixed horizontal scroll on `/setup/*` pages at 375px by constraining the tab nav scroll container.
+- **Setup wizard false-complete** (#216) — "Set Schedule" step no longer shows a green checkmark for new users; was triggered by default `posting_hours_end: 22` always passing `> 0`. Now tracks explicit `schedule_configured` flag.
+- **Telegram login loading state** (#217) — Added spinner and placeholder text to Telegram widget container on `/login` (was a blank white box while script loaded).
+- **Styled category select** (#218) — Replaced native `<select>` with shadcn `Select` component in media upload for visual consistency.
+- **Theme token colors** (#219) — Added `--warning` and `--success` CSS custom properties (light + dark). Replaced hardcoded `text-red-500`/`text-yellow-500`/`text-green-500` and HSL chart fills with design tokens across content reuse page, reuse chart, dead-content chart, and media upload.
+
 ### Changed — Dependency Updates
 
 - **Python**: pydantic 2.12.5→2.13.0, python-telegram-bot 22.6→22.7, click 8.3.1→8.3.2, rich 14.3.2→15.0.0, fastapi ≥0.109→≥0.135, uvicorn ≥0.27→≥0.44, pytest 9.0.2→9.0.3, pytest-cov 7.0.0→7.1.0

--- a/landing/src/app/(dashboard)/dashboard/media/reuse/page.tsx
+++ b/landing/src/app/(dashboard)/dashboard/media/reuse/page.tsx
@@ -57,7 +57,7 @@ export default async function ContentReusePage() {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-red-500">{neverPosted}</div>
+            <div className="text-2xl font-bold text-destructive">{neverPosted}</div>
             <p className="text-xs text-muted-foreground mt-1">
               {totalActive > 0
                 ? `${Math.round((neverPosted / totalActive) * 100)}% of library`
@@ -73,7 +73,7 @@ export default async function ContentReusePage() {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-yellow-500">
+            <div className="text-2xl font-bold text-warning">
               {postedOnce}
             </div>
             <p className="text-xs text-muted-foreground mt-1">
@@ -89,7 +89,7 @@ export default async function ContentReusePage() {
             </CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="text-2xl font-bold text-green-500">
+            <div className="text-2xl font-bold text-success">
               {postedMultiple}
             </div>
             <p className="text-xs text-muted-foreground mt-1">

--- a/landing/src/app/(marketing)/setup/layout.tsx
+++ b/landing/src/app/(marketing)/setup/layout.tsx
@@ -18,9 +18,9 @@ export default function SetupLayout({
         Back to home
       </Link>
 
-      {/* Mobile nav */}
-      <div className="mt-6 overflow-x-auto md:hidden">
-        <SetupNav className="flex-row gap-1" />
+      {/* Mobile nav — scrollable horizontal tabs */}
+      <div className="mt-6 -mx-4 px-4 overflow-x-auto md:hidden">
+        <SetupNav className="flex-row gap-1 w-max" />
       </div>
 
       <div className="mt-8 flex gap-12">

--- a/landing/src/app/globals.css
+++ b/landing/src/app/globals.css
@@ -18,6 +18,8 @@
   --color-input: var(--input);
   --color-border: var(--border);
   --color-destructive: var(--destructive);
+  --color-warning: var(--warning);
+  --color-success: var(--success);
   --color-accent-foreground: var(--accent-foreground);
   --color-accent: var(--accent);
   --color-muted-foreground: var(--muted-foreground);
@@ -64,6 +66,8 @@
   --chart-3: oklch(0.398 0.07 227.392);
   --chart-4: oklch(0.828 0.189 84.429);
   --chart-5: oklch(0.769 0.188 70.08);
+  --warning: oklch(0.75 0.15 75);
+  --success: oklch(0.65 0.15 145);
 }
 
 .dark {
@@ -90,6 +94,8 @@
   --chart-3: oklch(0.769 0.188 70.08);
   --chart-4: oklch(0.627 0.265 303.9);
   --chart-5: oklch(0.645 0.246 16.439);
+  --warning: oklch(0.8 0.12 75);
+  --success: oklch(0.7 0.12 145);
 }
 
 @layer base {

--- a/landing/src/components/auth/telegram-login-button.tsx
+++ b/landing/src/components/auth/telegram-login-button.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect, useRef, useCallback } from "react";
+import { useEffect, useRef, useCallback, useState } from "react";
 import { useRouter } from "next/navigation";
+import { Loader2 } from "lucide-react";
 
 interface TelegramUser {
   id: number;
@@ -16,6 +17,7 @@ interface TelegramUser {
 export function TelegramLoginButton() {
   const containerRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
+  const [loaded, setLoaded] = useState(false);
 
   const handleAuth = useCallback(
     async (user: TelegramUser) => {
@@ -38,6 +40,7 @@ export function TelegramLoginButton() {
     const botName = process.env.NEXT_PUBLIC_TELEGRAM_BOT_NAME;
     if (!botName || !containerRef.current) return;
 
+    setLoaded(false);
     // Expose callback globally for the Telegram widget
     (window as unknown as Record<string, unknown>).__telegram_login_callback = handleAuth;
 
@@ -49,6 +52,7 @@ export function TelegramLoginButton() {
     script.setAttribute("data-radius", "8");
     script.setAttribute("data-onauth", "__telegram_login_callback(user)");
     script.setAttribute("data-request-access", "write");
+    script.onload = () => setLoaded(true);
 
     const container = containerRef.current;
     container.appendChild(script);
@@ -59,5 +63,15 @@ export function TelegramLoginButton() {
     };
   }, [handleAuth]);
 
-  return <div ref={containerRef} className="flex justify-center" />;
+  return (
+    <div className="relative min-h-[56px] flex items-center justify-center">
+      {!loaded && (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Loading Telegram login...
+        </div>
+      )}
+      <div ref={containerRef} className={loaded ? "flex justify-center" : "absolute inset-0 flex justify-center"} />
+    </div>
+  );
 }

--- a/landing/src/components/dashboard/header.tsx
+++ b/landing/src/components/dashboard/header.tsx
@@ -1,7 +1,11 @@
 "use client";
 
 import { useRouter } from "next/navigation";
+import { Menu } from "lucide-react";
 import type { SessionPayload } from "@/lib/auth";
+import { Button } from "@/components/ui/button";
+import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
+import { Sidebar } from "@/components/dashboard/sidebar";
 
 export function DashboardHeader({ user }: { user: SessionPayload }) {
   const router = useRouter();
@@ -13,7 +17,20 @@ export function DashboardHeader({ user }: { user: SessionPayload }) {
 
   return (
     <header className="flex h-14 items-center justify-between border-b bg-card px-6">
-      <h2 className="text-sm font-medium text-muted-foreground">Dashboard</h2>
+      <div className="flex items-center gap-3">
+        <Sheet>
+          <SheetTrigger asChild>
+            <Button variant="ghost" size="icon" className="md:hidden">
+              <Menu className="h-5 w-5" />
+              <span className="sr-only">Open navigation</span>
+            </Button>
+          </SheetTrigger>
+          <SheetContent side="left" className="w-56 p-0">
+            <Sidebar mobile />
+          </SheetContent>
+        </Sheet>
+        <h2 className="text-sm font-medium text-muted-foreground">Dashboard</h2>
+      </div>
       <div className="flex items-center gap-4">
         <span className="text-sm text-muted-foreground">
           {user.firstName}

--- a/landing/src/components/dashboard/media/dead-content-chart.tsx
+++ b/landing/src/components/dashboard/media/dead-content-chart.tsx
@@ -57,7 +57,7 @@ export function DeadContentChart({ data }: { data: CategoryDead[] }) {
             <Tooltip />
             <Bar
               dataKey="dead_count"
-              fill="hsl(0, 84%, 60%)"
+              fill="var(--destructive)"
               name="Never Posted"
               radius={[0, 4, 4, 0]}
             />

--- a/landing/src/components/dashboard/media/media-upload.tsx
+++ b/landing/src/components/dashboard/media/media-upload.tsx
@@ -8,6 +8,13 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { cn } from "@/lib/utils";
 
 const ACCEPTED_TYPES = [
@@ -111,18 +118,19 @@ export function MediaUpload({
         {/* Category selector */}
         <div className="flex items-center gap-2">
           <label className="text-sm text-muted-foreground">Category:</label>
-          <select
-            value={selectedCategory}
-            onChange={(e) => setSelectedCategory(e.target.value)}
-            className="rounded-md border bg-background px-2 py-1 text-sm"
-          >
-            <option value="">Uncategorized</option>
-            {categories.map((cat) => (
-              <option key={cat} value={cat}>
-                {cat}
-              </option>
-            ))}
-          </select>
+          <Select value={selectedCategory} onValueChange={setSelectedCategory}>
+            <SelectTrigger className="w-40">
+              <SelectValue placeholder="Uncategorized" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="">Uncategorized</SelectItem>
+              {categories.map((cat) => (
+                <SelectItem key={cat} value={cat}>
+                  {cat}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
 
         {/* Drop zone */}
@@ -164,10 +172,10 @@ export function MediaUpload({
         </div>
 
         {error && (
-          <p className="text-sm text-red-500">{error}</p>
+          <p className="text-sm text-destructive">{error}</p>
         )}
         {success && (
-          <p className="text-sm text-green-600">{success}</p>
+          <p className="text-sm text-success">{success}</p>
         )}
       </CardContent>
     </Card>

--- a/landing/src/components/dashboard/media/media-upload.tsx
+++ b/landing/src/components/dashboard/media/media-upload.tsx
@@ -17,6 +17,8 @@ import {
 } from "@/components/ui/select";
 import { cn } from "@/lib/utils";
 
+const UNCATEGORIZED = "__uncategorized__";
+
 const ACCEPTED_TYPES = [
   "image/jpeg",
   "image/png",
@@ -43,7 +45,7 @@ export function MediaUpload({
   const [uploading, setUploading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
-  const [selectedCategory, setSelectedCategory] = useState<string>("");
+  const [selectedCategory, setSelectedCategory] = useState<string>(UNCATEGORIZED);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const uploadFile = useCallback(
@@ -64,7 +66,7 @@ export function MediaUpload({
       try {
         const formData = new FormData();
         formData.append("file", file);
-        if (selectedCategory) {
+        if (selectedCategory && selectedCategory !== UNCATEGORIZED) {
           formData.append("category", selectedCategory);
         }
 
@@ -123,7 +125,7 @@ export function MediaUpload({
               <SelectValue placeholder="Uncategorized" />
             </SelectTrigger>
             <SelectContent>
-              <SelectItem value="">Uncategorized</SelectItem>
+              <SelectItem value={UNCATEGORIZED}>Uncategorized</SelectItem>
               {categories.map((cat) => (
                 <SelectItem key={cat} value={cat}>
                   {cat}

--- a/landing/src/components/dashboard/media/reuse-chart.tsx
+++ b/landing/src/components/dashboard/media/reuse-chart.tsx
@@ -26,9 +26,9 @@ interface ReuseData {
 }
 
 const COLORS = [
-  "hsl(0, 84%, 60%)",    // never posted — red
-  "hsl(48, 96%, 53%)",   // posted once — yellow
-  "hsl(142, 76%, 36%)",  // posted multiple — green
+  "var(--destructive)",  // never posted — red
+  "var(--warning)",      // posted once — yellow
+  "var(--success)",      // posted multiple — green
 ];
 
 export function ReuseChart({ data }: { data: ReuseData }) {

--- a/landing/src/components/dashboard/setup-wizard.tsx
+++ b/landing/src/components/dashboard/setup-wizard.tsx
@@ -36,6 +36,7 @@ interface SetupState {
   posts_per_day: number;
   posting_hours_start: number;
   posting_hours_end: number;
+  schedule_configured?: boolean;
   onboarding_completed: boolean;
 }
 
@@ -142,7 +143,13 @@ export function SetupWizard({ initialState }: SetupWizardProps) {
         posting_hours_start: Number(hoursStart),
         posting_hours_end: Number(hoursEnd),
       });
-      await refreshState();
+      setState((prev) => ({
+        ...prev,
+        posts_per_day: postsPerDay,
+        posting_hours_start: Number(hoursStart),
+        posting_hours_end: Number(hoursEnd),
+        schedule_configured: true,
+      }));
       setStep(5);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Operation failed");
@@ -182,7 +189,7 @@ export function SetupWizard({ initialState }: SetupWizardProps) {
       case 1: return state.gdrive_connected;
       case 2: return state.media_folder_configured;
       case 3: return state.media_indexed;
-      case 4: return state.posting_hours_end > 0;
+      case 4: return state.schedule_configured === true;
       case 5: return state.onboarding_completed;
       default: return false;
     }
@@ -238,7 +245,6 @@ export function SetupWizard({ initialState }: SetupWizardProps) {
 
           {step === 0 && (
             <OAuthStep
-              provider="instagram"
               label="Instagram"
               connected={state.instagram_connected}
               username={state.instagram_username}
@@ -250,7 +256,6 @@ export function SetupWizard({ initialState }: SetupWizardProps) {
 
           {step === 1 && (
             <OAuthStep
-              provider="google-drive"
               label="Google Drive"
               connected={state.gdrive_connected}
               username={state.gdrive_email}

--- a/landing/src/components/dashboard/sidebar.tsx
+++ b/landing/src/components/dashboard/sidebar.tsx
@@ -22,11 +22,11 @@ const navItems = [
   { href: "/dashboard/analytics", label: "Analytics", icon: BarChart3 },
 ];
 
-export function Sidebar() {
+export function Sidebar({ mobile }: { mobile?: boolean }) {
   const pathname = usePathname();
 
   return (
-    <aside className="hidden w-56 shrink-0 border-r bg-card md:block">
+    <aside className={mobile ? "w-56 bg-card" : "hidden w-56 shrink-0 border-r bg-card md:block"}>
       <div className="flex h-14 items-center border-b px-4">
         <Link href="/dashboard" className="text-lg font-semibold tracking-tight">
           {siteConfig.name}

--- a/landing/src/components/ui/sheet.tsx
+++ b/landing/src/components/ui/sheet.tsx
@@ -1,0 +1,143 @@
+"use client"
+
+import * as React from "react"
+import { XIcon } from "lucide-react"
+import { Dialog as SheetPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Sheet({ ...props }: React.ComponentProps<typeof SheetPrimitive.Root>) {
+  return <SheetPrimitive.Root data-slot="sheet" {...props} />
+}
+
+function SheetTrigger({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Trigger>) {
+  return <SheetPrimitive.Trigger data-slot="sheet-trigger" {...props} />
+}
+
+function SheetClose({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Close>) {
+  return <SheetPrimitive.Close data-slot="sheet-close" {...props} />
+}
+
+function SheetPortal({
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Portal>) {
+  return <SheetPrimitive.Portal data-slot="sheet-portal" {...props} />
+}
+
+function SheetOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Overlay>) {
+  return (
+    <SheetPrimitive.Overlay
+      data-slot="sheet-overlay"
+      className={cn(
+        "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function SheetContent({
+  className,
+  children,
+  side = "right",
+  showCloseButton = true,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Content> & {
+  side?: "top" | "right" | "bottom" | "left"
+  showCloseButton?: boolean
+}) {
+  return (
+    <SheetPortal>
+      <SheetOverlay />
+      <SheetPrimitive.Content
+        data-slot="sheet-content"
+        className={cn(
+          "fixed z-50 flex flex-col gap-4 bg-background shadow-lg transition ease-in-out data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:animate-in data-[state=open]:duration-500",
+          side === "right" &&
+            "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+          side === "left" &&
+            "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+          side === "top" &&
+            "inset-x-0 top-0 h-auto border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
+          side === "bottom" &&
+            "inset-x-0 bottom-0 h-auto border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <SheetPrimitive.Close className="absolute top-4 right-4 rounded-xs opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none data-[state=open]:bg-secondary">
+            <XIcon className="size-4" />
+            <span className="sr-only">Close</span>
+          </SheetPrimitive.Close>
+        )}
+      </SheetPrimitive.Content>
+    </SheetPortal>
+  )
+}
+
+function SheetHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-header"
+      className={cn("flex flex-col gap-1.5 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="sheet-footer"
+      className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Title>) {
+  return (
+    <SheetPrimitive.Title
+      data-slot="sheet-title"
+      className={cn("font-semibold text-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+function SheetDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof SheetPrimitive.Description>) {
+  return (
+    <SheetPrimitive.Description
+      data-slot="sheet-description"
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Sheet,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+}


### PR DESCRIPTION
## Summary
Fixes 6 design issues identified by Virgil's visual crawl of the storyline-ai landing/dashboard:

**HIGH:**
- **#214** — Added mobile hamburger nav (Sheet drawer) to dashboard header so sidebar nav is accessible on mobile
- **#215** — Fixed horizontal overflow on `/setup/*` mobile nav by constraining scroll container with `-mx-4 px-4` edge-to-edge pattern and `w-max`

**MEDIUM:**
- **#216** — Fixed "Set Schedule" step falsely showing complete for new users (default `posting_hours_end: 22` always passed `> 0` check). Now tracks explicit `schedule_configured` flag
- **#217** — Added loading spinner + placeholder text to Telegram login widget container (was blank white box)
- **#218** — Replaced native `<select>` with shadcn `Select` component in media upload category picker

**LOW:**
- **#219** — Added `--warning` and `--success` CSS custom properties to design tokens. Replaced hardcoded `text-red-500`/`text-yellow-500`/`text-green-500` and HSL chart colors with theme tokens across reuse page, reuse chart, dead-content chart, and media upload

**Bonus fixes from /simplify:**
- Fixed double-setState in `handleSaveSchedule` (refreshState was setting state internally, then caller set it again)
- Fixed Telegram widget loading state not resetting on effect re-fire
- Removed dead default parameter on Sidebar component
- Fixed pre-existing TypeScript error (unused `provider` prop on OAuthStep)

Closes #214, #215, #216, #217, #218, #219

## Files changed (11)
- `globals.css` — new `--warning`/`--success` tokens (light + dark)
- `header.tsx` — Sheet-based mobile nav drawer
- `sidebar.tsx` — `mobile` prop to strip `hidden md:block`
- `sheet.tsx` — new shadcn Sheet component (installed via CLI)
- `setup/layout.tsx` — mobile nav scroll containment
- `setup-wizard.tsx` — `schedule_configured` flag, removed unused prop
- `telegram-login-button.tsx` — loading state with spinner
- `media-upload.tsx` — shadcn Select, theme token colors
- `reuse/page.tsx` — theme token colors on stat cards
- `reuse-chart.tsx` — CSS var chart colors
- `dead-content-chart.tsx` — CSS var chart color

## Test plan
- [ ] View dashboard at 375px — hamburger menu opens Sheet with full nav
- [ ] View `/setup/google-drive` at 375px — tabs scroll horizontally, no page overflow
- [ ] Load `/dashboard/setup` as new user — step 5 should NOT show green checkmark
- [ ] Save schedule in wizard — step 5 shows green, advances to Complete
- [ ] View `/login` — spinner shows while Telegram widget loads
- [ ] Upload media — category picker renders as styled Select, not native dropdown
- [ ] View `/dashboard/media/reuse` — stat card colors match theme (destructive/warning/success)
- [ ] Toggle dark mode — all new colors adapt correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)