### PR TITLE
fix: Telegram login fallback for missing env var + Vercel deployment docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Vercel deployment guide** — Documented all required env vars for `landing/` Vercel deployment in `documentation/guides/landing-vercel-deployment.md`.
+
+### Fixed
+
+- **Telegram login widget missing env var fallback** — `/login` now shows a helpful error message when `NEXT_PUBLIC_TELEGRAM_BOT_NAME` is not configured, instead of an infinite loading spinner.
+
 ### Fixed — Design Issues (#214–#219)
 
 - **Mobile dashboard navigation** (#214) — Added hamburger menu (Sheet drawer) to dashboard header so sidebar nav is accessible on mobile viewports.

--- a/documentation/guides/landing-vercel-deployment.md
+++ b/documentation/guides/landing-vercel-deployment.md
@@ -1,0 +1,35 @@
+# Landing Site — Vercel Deployment
+
+The Next.js landing/dashboard app lives in `landing/` and deploys to Vercel.
+
+## Required Environment Variables
+
+Set these in **Vercel → Project Settings → Environment Variables**:
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `DATABASE_URL` | Server | Neon PostgreSQL connection string (same DB as Python backend) |
+| `TELEGRAM_BOT_TOKEN` | Server | Telegram bot token — used for auth verification and waitlist notifications |
+| `ADMIN_TELEGRAM_CHAT_ID` | Server | Chat ID to receive waitlist signup notifications |
+| `JWT_SECRET` | Server | Random 32+ character string for signing session tokens |
+| `BACKEND_URL` | Server | FastAPI backend URL (e.g. `https://storyline-api.up.railway.app`) |
+| `NEXT_PUBLIC_SITE_URL` | Client | Public site URL (e.g. `https://storyline.ai`) |
+| `NEXT_PUBLIC_TELEGRAM_BOT_NAME` | Client | Bot username without `@` (e.g. `storyline_ai_bot`) — required for the Telegram Login Widget on `/login` |
+
+### Client vs Server Variables
+
+- **`NEXT_PUBLIC_*`** variables are inlined at build time and visible in the browser bundle. They must be set before the build runs.
+- **Server** variables are only available in API routes, middleware, and server components. They can be changed without rebuilding.
+
+### Common Issues
+
+- **Login page shows "Telegram login is not configured"**: `NEXT_PUBLIC_TELEGRAM_BOT_NAME` is missing. Add it in Vercel env vars and redeploy (client vars require a rebuild).
+- **Login widget loads but auth fails**: `TELEGRAM_BOT_TOKEN` is missing or doesn't match the bot named in `NEXT_PUBLIC_TELEGRAM_BOT_NAME`.
+- **Dashboard API calls fail**: `BACKEND_URL` is missing or the Railway backend is down.
+
+## Vercel Project Settings
+
+- **Root Directory**: `landing`
+- **Framework Preset**: Next.js
+- **Build Command**: `next build` (default)
+- **Node.js Version**: 20.x

--- a/landing/src/components/auth/telegram-login-button.tsx
+++ b/landing/src/components/auth/telegram-login-button.tsx
@@ -18,6 +18,7 @@ export function TelegramLoginButton() {
   const containerRef = useRef<HTMLDivElement>(null);
   const router = useRouter();
   const [loaded, setLoaded] = useState(false);
+  const botName = process.env.NEXT_PUBLIC_TELEGRAM_BOT_NAME;
 
   const handleAuth = useCallback(
     async (user: TelegramUser) => {
@@ -37,7 +38,6 @@ export function TelegramLoginButton() {
   );
 
   useEffect(() => {
-    const botName = process.env.NEXT_PUBLIC_TELEGRAM_BOT_NAME;
     if (!botName || !containerRef.current) return;
 
     setLoaded(false);
@@ -61,7 +61,19 @@ export function TelegramLoginButton() {
       delete (window as unknown as Record<string, unknown>).__telegram_login_callback;
       container.innerHTML = "";
     };
-  }, [handleAuth]);
+  }, [botName, handleAuth]);
+
+  if (!botName) {
+    return (
+      <div className="min-h-[56px] flex items-center justify-center">
+        <p className="text-sm text-muted-foreground">
+          Telegram login is not configured. Set{" "}
+          <code className="rounded bg-muted px-1 py-0.5 text-xs">NEXT_PUBLIC_TELEGRAM_BOT_NAME</code>{" "}
+          to enable sign-in.
+        </p>
+      </div>
+    );
+  }
 
   return (
     <div className="relative min-h-[56px] flex items-center justify-center">


### PR DESCRIPTION
## Summary
- **Telegram widget fallback**: When `NEXT_PUBLIC_TELEGRAM_BOT_NAME` is not set, `/login` now shows "Telegram login is not configured" with the env var name, instead of spinning forever on "Loading Telegram login..."
- **Vercel deployment docs**: Added `documentation/guides/landing-vercel-deployment.md` listing all 7 required env vars (client vs server), common issues, and Vercel project settings

## Test plan
- [ ] Deploy to Vercel without `NEXT_PUBLIC_TELEGRAM_BOT_NAME` set — login page shows config error message
- [ ] Deploy with env var set — login page shows spinner then Telegram button as before
- [ ] Verify deployment guide is accurate against Vercel project settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)