### PR TITLE
Fix setup page horizontal overflow at 375px mobile

### DIFF
--- a/landing/src/components/setup/copy-button.tsx
+++ b/landing/src/components/setup/copy-button.tsx
@@ -21,11 +21,11 @@ export function CopyButton({ value, className }: CopyButtonProps) {
   return (
     <span
       className={cn(
-        "inline-flex items-center gap-2 rounded-md bg-muted px-3 py-1.5 font-mono text-sm",
+        "inline-flex max-w-full items-center gap-2 rounded-md bg-muted px-3 py-1.5 font-mono text-sm",
         className
       )}
     >
-      <span className="truncate">{value}</span>
+      <span className="min-w-0 truncate">{value}</span>
       <button
         onClick={handleCopy}
         className="shrink-0 text-muted-foreground transition-colors hover:text-foreground"

--- a/landing/src/components/setup/step-card.tsx
+++ b/landing/src/components/setup/step-card.tsx
@@ -14,12 +14,12 @@ export function StepCard({
   className,
 }: StepCardProps) {
   return (
-    <div className={cn("relative pl-12", className)}>
+    <div className={cn("relative pl-10 sm:pl-12", className)}>
       <div className="absolute left-0 top-0.5 flex h-8 w-8 items-center justify-center rounded-full bg-primary text-sm font-bold text-primary-foreground">
         {number}
       </div>
       <h3 className="text-lg font-semibold">{title}</h3>
-      <div className="mt-2 space-y-2 text-muted-foreground">{children}</div>
+      <div className="mt-2 min-w-0 space-y-2 text-muted-foreground">{children}</div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- **CopyButton**: Add `max-w-full` and `min-w-0` so long URLs (like the OAuth redirect URI) truncate properly inside flex containers instead of overflowing the viewport
- **StepCard**: Reduce left padding on mobile (`pl-10 sm:pl-12`) and add `min-w-0` on content container to prevent child content from blowing out card width

Fixes are in shared components so all setup pages benefit, not just `/setup/google-drive`.

## Test plan
- [ ] Open `/setup/google-drive` at 375px viewport width — no horizontal scrollbar
- [ ] Verify the long redirect URI in Step 4 truncates with ellipsis
- [ ] Check other setup pages (`/setup/instagram`, `/setup/meta-developer`) still look correct
- [ ] Verify copy button still works after truncation fix

Closes #215

🤖 Generated with [Claude Code](https://claude.com/claude-code)