### PR TITLE
Fix schedule step completion state for new users

### DIFF
--- a/landing/src/components/dashboard/setup-wizard.tsx
+++ b/landing/src/components/dashboard/setup-wizard.tsx
@@ -71,12 +71,20 @@ export function SetupWizard({ initialState }: SetupWizardProps) {
   const [postsPerDay, setPostsPerDay] = useState<number>(state.posts_per_day);
   const [hoursStart, setHoursStart] = useState(String(state.posting_hours_start));
   const [hoursEnd, setHoursEnd] = useState(String(state.posting_hours_end));
+  const [scheduleSaved, setScheduleSaved] = useState(
+    initialState.schedule_configured === true && initialState.onboarding_completed
+  );
 
   async function refreshState() {
     setError(null);
     try {
       const data = await postApi("init");
-      if (data?.setup_state) setState(data.setup_state);
+      if (data?.setup_state) {
+        setState(data.setup_state);
+        if (data.setup_state.schedule_configured && data.setup_state.onboarding_completed) {
+          setScheduleSaved(true);
+        }
+      }
       return data?.setup_state as SetupState | undefined;
     } catch (e) {
       setError(e instanceof Error ? e.message : "Operation failed");
@@ -150,6 +158,7 @@ export function SetupWizard({ initialState }: SetupWizardProps) {
         posting_hours_end: Number(hoursEnd),
         schedule_configured: true,
       }));
+      setScheduleSaved(true);
       setStep(5);
     } catch (e) {
       setError(e instanceof Error ? e.message : "Operation failed");
@@ -177,7 +186,7 @@ export function SetupWizard({ initialState }: SetupWizardProps) {
       case 1: return state.gdrive_connected;
       case 2: return state.media_folder_configured;
       case 3: return state.media_indexed;
-      case 4: return true;
+      case 4: return scheduleSaved;
       case 5: return true;
       default: return false;
     }
@@ -189,7 +198,7 @@ export function SetupWizard({ initialState }: SetupWizardProps) {
       case 1: return state.gdrive_connected;
       case 2: return state.media_folder_configured;
       case 3: return state.media_indexed;
-      case 4: return state.schedule_configured === true;
+      case 4: return scheduleSaved;
       case 5: return state.onboarding_completed;
       default: return false;
     }


### PR DESCRIPTION
## Summary
- Add local `scheduleSaved` state that's only `true` when the user explicitly saves their schedule or has previously completed onboarding
- `canAdvance()` for step 4 now requires save (was unconditionally `true`)
- `isStepComplete(4)` uses `scheduleSaved` instead of trusting `schedule_configured` from API (which is `true` for new users with defaults)
- Sync `scheduleSaved` in `refreshState()` to prevent drift

## Test plan
- [ ] New user: schedule step should NOT show green checkmark before saving
- [ ] New user: "Next" button on schedule step should be disabled until save
- [ ] After saving schedule: step shows complete and Next is enabled
- [ ] Returning onboarded user: schedule step shows as complete on load
- [ ] Returning mid-setup user (saved schedule but didn't complete): step shows incomplete (must re-confirm)

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)