### PR TITLE
Fix Google Drive token health check false positive

### DIFF
--- a/src/services/core/health_check.py
+++ b/src/services/core/health_check.py
@@ -584,10 +584,12 @@ class HealthCheckService(BaseService):
                 "expires_in_days": None,
             }
 
+        auto_refreshable = token_health.get("auto_refreshable", False)
+
         if not token_health["valid"]:
             return {
                 "healthy": False,
-                "message": "Google Drive token expired",
+                "message": "Google Drive token expired — reconnect required",
                 "expires_in_days": 0,
             }
 
@@ -596,29 +598,38 @@ class HealthCheckService(BaseService):
             round(expires_in_hours / 24, 1) if expires_in_hours is not None else None
         )
 
-        if expires_in_days is not None and expires_in_days <= self.TOKEN_CRITICAL_DAYS:
-            return {
-                "healthy": False,
-                "message": f"Google Drive token expires in {expires_in_days:.0f} day(s)",
-                "expires_in_days": expires_in_days,
-                "needs_refresh": token_health.get("needs_refresh", False),
-            }
+        # Access token expiry warnings don't apply when auto-refresh is available
+        if not auto_refreshable:
+            if (
+                expires_in_days is not None
+                and expires_in_days <= self.TOKEN_CRITICAL_DAYS
+            ):
+                return {
+                    "healthy": False,
+                    "message": f"Google Drive token expires in {expires_in_days:.0f} day(s)",
+                    "expires_in_days": expires_in_days,
+                    "needs_refresh": token_health.get("needs_refresh", False),
+                }
 
-        if expires_in_days is not None and expires_in_days <= self.TOKEN_WARNING_DAYS:
-            return {
-                "healthy": False,
-                "message": f"Google Drive token expires in {expires_in_days:.0f} days",
-                "expires_in_days": expires_in_days,
-                "needs_refresh": token_health.get("needs_refresh", False),
-            }
+            if (
+                expires_in_days is not None
+                and expires_in_days <= self.TOKEN_WARNING_DAYS
+            ):
+                return {
+                    "healthy": False,
+                    "message": f"Google Drive token expires in {expires_in_days:.0f} days",
+                    "expires_in_days": expires_in_days,
+                    "needs_refresh": token_health.get("needs_refresh", False),
+                }
 
         return {
             "healthy": True,
             "message": (
                 "Google Drive token OK"
+                + (" (auto-refresh active)" if auto_refreshable else "")
                 + (
                     f" ({expires_in_days:.0f} days remaining)"
-                    if expires_in_days
+                    if expires_in_days and not auto_refreshable
                     else ""
                 )
             ),
@@ -626,7 +637,7 @@ class HealthCheckService(BaseService):
         }
 
     def format_token_alert(self, token_info: dict, telegram_chat_id: int) -> str | None:
-        """Format a Telegram alert for expiring Google Drive token.
+        """Format a Telegram alert for expiring/expired Google Drive token.
 
         Returns None if no alert needed (healthy token).
         """
@@ -638,7 +649,7 @@ class HealthCheckService(BaseService):
         if expires_in_days is not None and expires_in_days > 0:
             text = f"\u26a0\ufe0f Google Drive token expiring in {expires_in_days:.0f} day(s)."
         else:
-            text = "\u26a0\ufe0f Google Drive token has expired."
+            text = "\u26a0\ufe0f Google Drive token has expired — reconnect required."
 
         reconnect_url = None
         if settings.OAUTH_REDIRECT_BASE_URL:

--- a/src/services/integrations/token_refresh.py
+++ b/src/services/integrations/token_refresh.py
@@ -455,7 +455,9 @@ class TokenRefreshService(BaseService):
         Unlike check_token_health() which queries by instagram_account_id,
         this queries by chat_settings_id for tenant-scoped tokens.
 
-        Returns same dict shape as check_token_health().
+        For services with refresh tokens (e.g., Google Drive), an expired
+        access token is normal — the OAuth library auto-refreshes it. Only
+        report unhealthy when the refresh token is missing or expired.
         """
         db_token = self.token_repo.get_token_for_chat(
             service, "oauth_access", chat_settings_id
@@ -469,9 +471,17 @@ class TokenRefreshService(BaseService):
                 "expires_at": None,
                 "expires_in_hours": None,
                 "needs_refresh": False,
+                "auto_refreshable": False,
+                "refresh_token_exists": False,
                 "last_refreshed": None,
                 "error": f"No {service} token found for this chat",
             }
+
+        refresh_token = self.token_repo.get_token_for_chat(
+            service, "oauth_refresh", chat_settings_id
+        )
+        refresh_token_exists = refresh_token is not None
+        auto_refreshable = refresh_token_exists and not refresh_token.is_expired
 
         expires_in_hours = db_token.hours_until_expiry()
         needs_refresh = (
@@ -479,15 +489,25 @@ class TokenRefreshService(BaseService):
             and expires_in_hours <= self.REFRESH_BUFFER_HOURS
         )
 
+        access_expired = db_token.is_expired
+        valid = not access_expired or auto_refreshable
+        error = (
+            "Token expired and no valid refresh token"
+            if access_expired and not auto_refreshable
+            else None
+        )
+
         return {
-            "valid": not db_token.is_expired,
+            "valid": valid,
             "exists": True,
             "source": "database",
             "expires_at": db_token.expires_at,
             "expires_in_hours": expires_in_hours,
             "needs_refresh": needs_refresh,
+            "auto_refreshable": auto_refreshable,
+            "refresh_token_exists": refresh_token_exists,
             "last_refreshed": db_token.last_refreshed_at,
-            "error": "Token expired" if db_token.is_expired else None,
+            "error": error,
         }
 
     def get_tokens_needing_refresh(self) -> list:

--- a/tests/src/services/test_health_check.py
+++ b/tests/src/services/test_health_check.py
@@ -599,6 +599,7 @@ class TestHealthCheckService:
             "exists": True,
             "expires_in_hours": 30 * 24,  # 30 days
             "needs_refresh": False,
+            "auto_refreshable": False,
             "error": None,
         }
 
@@ -607,14 +608,32 @@ class TestHealthCheckService:
         assert result["healthy"] is True
         assert result["expires_in_days"] == 30.0
 
-    def test_gdrive_token_warning(self, token_service):
-        """Returns unhealthy when token expires within warning threshold."""
+    def test_gdrive_token_healthy_auto_refreshable(self, token_service):
+        """Access token expired but refresh token exists — healthy."""
+        chat = self._gdrive_chat()
+        token_service._token_service.check_token_health_for_chat.return_value = {
+            "valid": True,
+            "exists": True,
+            "expires_in_hours": 0,
+            "needs_refresh": True,
+            "auto_refreshable": True,
+            "error": None,
+        }
+
+        result = token_service.check_gdrive_token_for_chat(-123, chat_settings=chat)
+
+        assert result["healthy"] is True
+        assert "auto-refresh" in result["message"]
+
+    def test_gdrive_token_warning_no_refresh(self, token_service):
+        """Returns unhealthy when token expires soon and no refresh token."""
         chat = self._gdrive_chat()
         token_service._token_service.check_token_health_for_chat.return_value = {
             "valid": True,
             "exists": True,
             "expires_in_hours": 3 * 24,  # 3 days
             "needs_refresh": True,
+            "auto_refreshable": False,
             "error": None,
         }
 
@@ -624,15 +643,32 @@ class TestHealthCheckService:
         assert result["expires_in_days"] == 3.0
         assert "3 days" in result["message"]
 
-    def test_gdrive_token_expired(self, token_service):
-        """Returns unhealthy when token is already expired."""
+    def test_gdrive_token_warning_with_refresh(self, token_service):
+        """Access token expiring soon but refresh token exists — healthy."""
+        chat = self._gdrive_chat()
+        token_service._token_service.check_token_health_for_chat.return_value = {
+            "valid": True,
+            "exists": True,
+            "expires_in_hours": 3 * 24,
+            "needs_refresh": True,
+            "auto_refreshable": True,
+            "error": None,
+        }
+
+        result = token_service.check_gdrive_token_for_chat(-123, chat_settings=chat)
+
+        assert result["healthy"] is True
+
+    def test_gdrive_token_expired_no_refresh(self, token_service):
+        """Expired access token with no refresh token — unhealthy."""
         chat = self._gdrive_chat()
         token_service._token_service.check_token_health_for_chat.return_value = {
             "valid": False,
             "exists": True,
             "expires_in_hours": 0,
             "needs_refresh": False,
-            "error": "Token expired",
+            "auto_refreshable": False,
+            "error": "Token expired and no valid refresh token",
         }
 
         result = token_service.check_gdrive_token_for_chat(-123, chat_settings=chat)
@@ -648,6 +684,7 @@ class TestHealthCheckService:
             "exists": False,
             "expires_in_hours": None,
             "needs_refresh": False,
+            "auto_refreshable": False,
             "error": "No google_drive token found for this chat",
         }
 
@@ -699,7 +736,7 @@ class TestHealthCheckService:
 
         assert result is not None
         assert "expired" in result
-        assert "paused" in result
+        assert "reconnect required" in result
 
     def test_format_token_alert_healthy(self, token_service):
         """Format alert returns None for healthy token."""

--- a/tests/src/services/test_token_refresh.py
+++ b/tests/src/services/test_token_refresh.py
@@ -246,6 +246,85 @@ class TestTokenRefreshService:
         assert result["exists"] is False
         assert "No token found" in result["error"]
 
+    # ==================== check_token_health_for_chat Tests ====================
+
+    def test_check_token_health_for_chat_access_expired_refresh_valid(
+        self, token_service, mock_db_token
+    ):
+        """Access token expired + valid refresh token = healthy (auto-refreshable)."""
+        mock_db_token.is_expired = True
+        mock_db_token.expires_at = datetime.utcnow() - timedelta(hours=1)
+
+        refresh_token = Mock()
+        refresh_token.expires_at = None  # Refresh tokens don't expire
+        refresh_token.is_expired = False
+
+        token_service.token_repo.get_token_for_chat.side_effect = (
+            lambda svc, token_type, cid: (
+                mock_db_token if token_type == "oauth_access" else refresh_token
+            )
+        )
+
+        result = token_service.check_token_health_for_chat("google_drive", "chat-1")
+
+        assert result["valid"] is True
+        assert result["auto_refreshable"] is True
+        assert result["refresh_token_exists"] is True
+        assert result["error"] is None
+
+    def test_check_token_health_for_chat_access_expired_no_refresh(
+        self, token_service, mock_db_token
+    ):
+        """Access token expired + no refresh token = unhealthy."""
+        mock_db_token.is_expired = True
+        mock_db_token.expires_at = datetime.utcnow() - timedelta(hours=1)
+
+        token_service.token_repo.get_token_for_chat.side_effect = (
+            lambda svc, token_type, cid: (
+                mock_db_token if token_type == "oauth_access" else None
+            )
+        )
+
+        result = token_service.check_token_health_for_chat("google_drive", "chat-1")
+
+        assert result["valid"] is False
+        assert result["auto_refreshable"] is False
+        assert result["refresh_token_exists"] is False
+        assert "no valid refresh token" in result["error"]
+
+    def test_check_token_health_for_chat_both_expired(
+        self, token_service, mock_db_token
+    ):
+        """Both access and refresh tokens expired = unhealthy."""
+        mock_db_token.is_expired = True
+        mock_db_token.expires_at = datetime.utcnow() - timedelta(hours=1)
+
+        refresh_token = Mock()
+        refresh_token.expires_at = datetime.utcnow() - timedelta(days=1)
+        refresh_token.is_expired = True
+
+        token_service.token_repo.get_token_for_chat.side_effect = (
+            lambda svc, token_type, cid: (
+                mock_db_token if token_type == "oauth_access" else refresh_token
+            )
+        )
+
+        result = token_service.check_token_health_for_chat("google_drive", "chat-1")
+
+        assert result["valid"] is False
+        assert result["auto_refreshable"] is False
+        assert result["refresh_token_exists"] is True
+
+    def test_check_token_health_for_chat_no_tokens(self, token_service):
+        """No tokens at all = unhealthy."""
+        token_service.token_repo.get_token_for_chat.return_value = None
+
+        result = token_service.check_token_health_for_chat("google_drive", "chat-1")
+
+        assert result["valid"] is False
+        assert result["exists"] is False
+        assert result["auto_refreshable"] is False
+
     # ==================== refresh_instagram_token Tests ====================
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- `check_token_health_for_chat()` now queries for the `oauth_refresh` token alongside the `oauth_access` token. If a valid refresh token exists, the access token expiry is normal (Google auto-refreshes it) — reports `valid=True, auto_refreshable=True`
- `check_gdrive_token_for_chat()` skips critical/warning expiry alerts when `auto_refreshable` is True
- `format_token_alert()` only sends scary "expired/paused" messages when reconnection is actually required (no refresh token, or refresh token also expired)
- Returns two new fields: `auto_refreshable` and `refresh_token_exists` for downstream consumers

**Root cause**: Google OAuth access tokens expire every ~1 hour (normal). The posting flow in `get_user_credentials()` constructs a `Credentials` object with both access + refresh tokens, and Google's library auto-refreshes transparently. The health check was alarming on the access token expiry without checking whether a refresh token existed.

## Test plan
- [x] All 70 existing tests pass (0 failures)
- [x] New test: access token expired + valid refresh token = healthy (auto-refreshable)
- [x] New test: access token expired + no refresh token = unhealthy
- [x] New test: both tokens expired = unhealthy
- [x] New test: no tokens at all = unhealthy
- [x] Updated test: warning threshold skipped when auto-refreshable
- [x] Updated test: expired alert says "reconnect required" not "paused"

🤖 Generated with [Claude Code](https://claude.com/claude-code)