### PR TITLE
Tighten login page layout and add back navigation

### DIFF
--- a/landing/src/app/login/page.tsx
+++ b/landing/src/app/login/page.tsx
@@ -1,3 +1,5 @@
+import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
 import { TelegramLoginButton } from "@/components/auth/telegram-login-button";
 import { siteConfig } from "@/config/site";
 
@@ -7,16 +9,24 @@ export const metadata = {
 
 export default function LoginPage() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background">
-      <div className="mx-auto w-full max-w-sm space-y-8 px-4">
-        <div className="text-center space-y-2">
+    <div className="flex min-h-svh flex-col items-center justify-center bg-background px-4">
+      <div className="w-full max-w-sm space-y-6">
+        <Link
+          href="/"
+          className="inline-flex items-center gap-1.5 text-sm text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <ArrowLeft className="h-4 w-4" />
+          Back to {siteConfig.name}
+        </Link>
+
+        <div className="space-y-2 text-center">
           <h1 className="text-2xl font-bold tracking-tight">{siteConfig.name}</h1>
           <p className="text-muted-foreground text-sm">
             Sign in with your Telegram account to access the dashboard.
           </p>
         </div>
 
-        <div className="rounded-lg border bg-card p-8 shadow-sm">
+        <div className="rounded-lg border bg-card p-6 shadow-sm">
           <TelegramLoginButton />
         </div>
 


### PR DESCRIPTION
## Summary
- Reduce vertical spacing (`space-y-8` → `space-y-6`) and card padding (`p-8` → `p-6`) to minimize empty whitespace
- Add "Back to Storyline AI" link with arrow icon for navigation back to landing page
- Switch from `min-h-screen` to `min-h-svh` for proper mobile viewport height
- Move horizontal padding to outer container for consistent edge spacing

## Test plan
- [ ] Login page has less empty whitespace — content is tighter
- [ ] "Back to Storyline AI" link navigates to `/`
- [ ] Layout still centers properly on mobile and desktop
- [ ] No visual regression on the Telegram login widget area

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)