### PR TITLE
Add sign-in link to landing page header

### DIFF
--- a/landing/src/components/layout/header.tsx
+++ b/landing/src/components/layout/header.tsx
@@ -8,12 +8,20 @@ export function Header() {
         <Link href="/" className="text-lg font-semibold tracking-tight">
           {siteConfig.name}
         </Link>
-        <a
-          href="#waitlist"
-          className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
-        >
-          Join Waitlist
-        </a>
+        <div className="flex items-center gap-4">
+          <Link
+            href="/login"
+            className="text-sm text-muted-foreground transition-colors hover:text-foreground"
+          >
+            Sign in
+          </Link>
+          <a
+            href="#waitlist"
+            className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
+          >
+            Join Waitlist
+          </a>
+        </div>
       </div>
     </header>
   )


### PR DESCRIPTION
## Summary
- Adds a subtle "Sign in" text link in the header next to the "Join Waitlist" button
- Links to `/login` where the Telegram login widget lives

## Test plan
- [ ] Verify "Sign in" link appears in header on landing page
- [ ] Verify link navigates to `/login` page
- [ ] Verify Telegram widget loads (NEXT_PUBLIC_TELEGRAM_BOT_NAME env var has been set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)