### PR TITLE
feat: multi-account data layer (Phase 1a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Multi-account data layer** (#231) — Foundation for multi-account dashboard support. Users can now belong to multiple chat instances via `user_chat_memberships` join table. Memberships are auto-created on group chat interactions. New `DashboardService.get_user_instances()` returns all instances a user belongs to with per-instance stats. Also adds `onboarding_sessions` table for future DM onboarding flow and `display_name` column on `chat_settings`.
 - **Vercel deployment guide** — Documented all required env vars for `landing/` Vercel deployment in `documentation/guides/landing-vercel-deployment.md`.
 
 ### Fixed

--- a/scripts/migrations/023_multi_account_data_layer.sql
+++ b/scripts/migrations/023_multi_account_data_layer.sql
@@ -1,0 +1,79 @@
+-- Migration 023: Multi-account data layer
+--
+-- Phase 1a of multi-account dashboard migration.
+-- Adds:
+--   1. user_chat_memberships table (user ↔ chat_settings join table)
+--   2. onboarding_sessions table (DM onboarding state machine)
+--   3. display_name column on chat_settings
+--   4. Backfill index on user_interactions for future migration script
+--
+-- All changes are additive. No existing data modified.
+
+BEGIN;
+
+-- ============================================================
+-- 1. user_chat_memberships
+-- ============================================================
+
+CREATE TABLE user_chat_memberships (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id),
+    chat_settings_id UUID NOT NULL REFERENCES chat_settings(id),
+    instance_role VARCHAR(20) NOT NULL DEFAULT 'member',
+    joined_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    is_active BOOLEAN NOT NULL DEFAULT TRUE,
+    CONSTRAINT unique_user_chat_membership UNIQUE (user_id, chat_settings_id),
+    CONSTRAINT check_instance_role CHECK (instance_role IN ('owner', 'admin', 'member'))
+);
+
+CREATE INDEX idx_ucm_user_id ON user_chat_memberships(user_id)
+    WHERE is_active = TRUE;
+
+CREATE INDEX idx_ucm_chat_settings_id ON user_chat_memberships(chat_settings_id)
+    WHERE is_active = TRUE;
+
+-- ============================================================
+-- 2. onboarding_sessions
+-- ============================================================
+
+CREATE TABLE onboarding_sessions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id),
+    step VARCHAR(50) NOT NULL DEFAULT 'naming',
+    pending_instance_name VARCHAR(100),
+    pending_chat_settings_id UUID REFERENCES chat_settings(id),
+    expires_at TIMESTAMP NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    CONSTRAINT unique_active_onboarding UNIQUE (user_id),
+    CONSTRAINT check_onboarding_step CHECK (step IN ('naming', 'awaiting_group', 'complete'))
+);
+
+-- ============================================================
+-- 3. display_name on chat_settings
+-- ============================================================
+
+ALTER TABLE chat_settings ADD COLUMN display_name VARCHAR(100);
+
+-- (Section 4 — backfill index — runs after COMMIT below because
+--  CREATE INDEX CONCURRENTLY cannot run inside a transaction block.)
+
+-- ============================================================
+-- Record migration
+-- ============================================================
+
+INSERT INTO schema_version (version, description, applied_at)
+VALUES (23, 'Multi-account data layer: user_chat_memberships, onboarding_sessions, display_name', NOW());
+
+COMMIT;
+
+-- ============================================================
+-- 4. Backfill index on user_interactions (outside transaction —
+--    CREATE INDEX CONCURRENTLY cannot run inside a transaction block)
+-- ============================================================
+
+-- Supports the Phase 1b backfill query:
+--   SELECT DISTINCT user_id, telegram_chat_id FROM user_interactions
+--   WHERE user_id IS NOT NULL AND telegram_chat_id < 0
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_user_interactions_backfill
+    ON user_interactions(user_id, telegram_chat_id)
+    WHERE user_id IS NOT NULL AND telegram_chat_id < 0;

--- a/src/models/__init__.py
+++ b/src/models/__init__.py
@@ -11,6 +11,8 @@ from src.models.category_mix import CategoryPostCaseMix
 from src.models.instagram_account import InstagramAccount
 from src.models.api_token import ApiToken
 from src.models.chat_settings import ChatSettings
+from src.models.user_chat_membership import UserChatMembership
+from src.models.onboarding_session import OnboardingSession
 
 __all__ = [
     "User",
@@ -24,4 +26,6 @@ __all__ = [
     "InstagramAccount",
     "ApiToken",
     "ChatSettings",
+    "UserChatMembership",
+    "OnboardingSession",
 ]

--- a/src/models/chat_settings.py
+++ b/src/models/chat_settings.py
@@ -33,6 +33,7 @@ class ChatSettings(Base):
 
     # Chat identification
     telegram_chat_id = Column(BigInteger, nullable=False, unique=True, index=True)
+    display_name = Column(String(100), nullable=True)
 
     # Operational settings
     dry_run_mode = Column(Boolean, default=True)

--- a/src/models/onboarding_session.py
+++ b/src/models/onboarding_session.py
@@ -1,0 +1,55 @@
+"""Onboarding session model - DM-level onboarding state machine."""
+
+from sqlalchemy import (
+    CheckConstraint,
+    Column,
+    String,
+    DateTime,
+    ForeignKey,
+    UniqueConstraint,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+from datetime import datetime
+import uuid
+
+from src.config.database import Base
+
+
+class OnboardingSession(Base):
+    """
+    Tracks DM-level onboarding state for new instance creation.
+
+    Separate from chat_settings.onboarding_step which tracks per-instance
+    setup (Instagram, media, schedule). This table tracks the short-lived
+    DM flow: name the instance, link to a group, done.
+
+    One active session per user (UNIQUE on user_id).
+    Sessions expire after 24h.
+    """
+
+    __tablename__ = "onboarding_sessions"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
+    step = Column(String(50), nullable=False, default="naming")
+    pending_instance_name = Column(String(100))
+    pending_chat_settings_id = Column(
+        UUID(as_uuid=True), ForeignKey("chat_settings.id"), nullable=True
+    )
+    expires_at = Column(DateTime, nullable=False)
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+
+    user = relationship("User")
+    pending_chat_settings = relationship("ChatSettings")
+
+    __table_args__ = (
+        UniqueConstraint("user_id", name="unique_active_onboarding"),
+        CheckConstraint(
+            "step IN ('naming', 'awaiting_group', 'complete')",
+            name="check_onboarding_step",
+        ),
+    )
+
+    def __repr__(self):
+        return f"<OnboardingSession user={self.user_id} step={self.step}>"

--- a/src/models/user_chat_membership.py
+++ b/src/models/user_chat_membership.py
@@ -29,14 +29,11 @@ class UserChatMembership(Base):
     __tablename__ = "user_chat_memberships"
 
     id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
-    user_id = Column(
-        UUID(as_uuid=True), ForeignKey("users.id"), nullable=False, index=True
-    )
+    user_id = Column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
     chat_settings_id = Column(
         UUID(as_uuid=True),
         ForeignKey("chat_settings.id"),
         nullable=False,
-        index=True,
     )
 
     # Distinct from users.role which is a system-level concept

--- a/src/models/user_chat_membership.py
+++ b/src/models/user_chat_membership.py
@@ -1,0 +1,65 @@
+"""User-chat membership model - links users to chat instances."""
+
+from sqlalchemy import (
+    CheckConstraint,
+    Column,
+    String,
+    Boolean,
+    DateTime,
+    ForeignKey,
+    UniqueConstraint,
+)
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import relationship
+from datetime import datetime
+import uuid
+
+from src.config.database import Base
+
+
+class UserChatMembership(Base):
+    """
+    Join table linking users to chat_settings instances.
+
+    Each row represents a user's membership in a specific chat instance.
+    Memberships are auto-created on group chat interactions and can be
+    deactivated when the bot is removed from a group.
+    """
+
+    __tablename__ = "user_chat_memberships"
+
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id = Column(
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=False, index=True
+    )
+    chat_settings_id = Column(
+        UUID(as_uuid=True),
+        ForeignKey("chat_settings.id"),
+        nullable=False,
+        index=True,
+    )
+
+    # Distinct from users.role which is a system-level concept
+    instance_role = Column(String(20), nullable=False, default="member")
+
+    joined_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+    is_active = Column(Boolean, nullable=False, default=True)
+
+    user = relationship("User")
+    chat_settings = relationship("ChatSettings")
+
+    __table_args__ = (
+        UniqueConstraint(
+            "user_id", "chat_settings_id", name="unique_user_chat_membership"
+        ),
+        CheckConstraint(
+            "instance_role IN ('owner', 'admin', 'member')",
+            name="check_instance_role",
+        ),
+    )
+
+    def __repr__(self):
+        return (
+            f"<UserChatMembership user={self.user_id} "
+            f"chat={self.chat_settings_id} role={self.instance_role}>"
+        )

--- a/src/repositories/history_repository.py
+++ b/src/repositories/history_repository.py
@@ -136,16 +136,21 @@ class HistoryRepository(BaseRepository):
         return history
 
     def get_recent_posts(
-        self, hours: int = 24, chat_settings_id: Optional[str] = None
+        self,
+        hours: int = 24,
+        chat_settings_id: Optional[str] = None,
+        limit: Optional[int] = None,
     ) -> List[PostingHistory]:
         """Get posts from the last N hours."""
         since = datetime.now(timezone.utc) - timedelta(hours=hours)
-        result = (
+        query = (
             self._tenant_query(PostingHistory, chat_settings_id)
             .filter(PostingHistory.posted_at >= since)
             .order_by(PostingHistory.posted_at.desc())
-            .all()
         )
+        if limit is not None:
+            query = query.limit(limit)
+        result = query.all()
         self.end_read_transaction()
         return result
 

--- a/src/repositories/membership_repository.py
+++ b/src/repositories/membership_repository.py
@@ -1,0 +1,108 @@
+"""User-chat membership repository - CRUD for instance memberships."""
+
+from typing import Optional
+
+
+from src.repositories.base_repository import BaseRepository
+from src.models.user_chat_membership import UserChatMembership
+
+
+class MembershipRepository(BaseRepository):
+    """Repository for UserChatMembership CRUD operations."""
+
+    def get_for_user(
+        self, user_id: str, active_only: bool = True
+    ) -> list[UserChatMembership]:
+        """Get all memberships for a user, eagerly loading chat_settings."""
+        from sqlalchemy.orm import joinedload
+
+        query = (
+            self.db.query(UserChatMembership)
+            .options(joinedload(UserChatMembership.chat_settings))
+            .filter(UserChatMembership.user_id == user_id)
+        )
+        if active_only:
+            query = query.filter(UserChatMembership.is_active == True)  # noqa: E712
+        result = query.order_by(UserChatMembership.joined_at.asc()).all()
+        self.end_read_transaction()
+        return result
+
+    def get_for_chat(
+        self, chat_settings_id: str, active_only: bool = True
+    ) -> list[UserChatMembership]:
+        """Get all memberships for a chat instance."""
+        query = self.db.query(UserChatMembership).filter(
+            UserChatMembership.chat_settings_id == chat_settings_id
+        )
+        if active_only:
+            query = query.filter(UserChatMembership.is_active == True)  # noqa: E712
+        result = query.order_by(UserChatMembership.joined_at.asc()).all()
+        self.end_read_transaction()
+        return result
+
+    def get_membership(
+        self, user_id: str, chat_settings_id: str
+    ) -> Optional[UserChatMembership]:
+        """Get a specific user-chat membership."""
+        result = (
+            self.db.query(UserChatMembership)
+            .filter(
+                UserChatMembership.user_id == user_id,
+                UserChatMembership.chat_settings_id == chat_settings_id,
+            )
+            .first()
+        )
+        self.end_read_transaction()
+        return result
+
+    def create_membership(
+        self,
+        user_id: str,
+        chat_settings_id: str,
+        instance_role: str = "member",
+    ) -> UserChatMembership:
+        """Create a new membership. No-op if one already exists."""
+        existing = self.get_membership(user_id, chat_settings_id)
+        if existing:
+            if not existing.is_active:
+                existing.is_active = True
+                self.db.commit()
+                self.db.refresh(existing)
+            return existing
+
+        membership = UserChatMembership(
+            user_id=user_id,
+            chat_settings_id=chat_settings_id,
+            instance_role=instance_role,
+        )
+        self.db.add(membership)
+        self.db.commit()
+        self.db.refresh(membership)
+        return membership
+
+    def deactivate_for_chat(self, chat_settings_id: str) -> int:
+        """Deactivate all memberships for a chat (e.g. bot kicked from group).
+
+        Returns number of memberships deactivated.
+        """
+        count = (
+            self.db.query(UserChatMembership)
+            .filter(
+                UserChatMembership.chat_settings_id == chat_settings_id,
+                UserChatMembership.is_active == True,  # noqa: E712
+            )
+            .update({"is_active": False})
+        )
+        self.db.commit()
+        return count
+
+    def deactivate(
+        self, user_id: str, chat_settings_id: str
+    ) -> Optional[UserChatMembership]:
+        """Deactivate a specific membership."""
+        membership = self.get_membership(user_id, chat_settings_id)
+        if membership and membership.is_active:
+            membership.is_active = False
+            self.db.commit()
+            self.db.refresh(membership)
+        return membership

--- a/src/repositories/membership_repository.py
+++ b/src/repositories/membership_repository.py
@@ -61,7 +61,9 @@ class MembershipRepository(BaseRepository):
         chat_settings_id: str,
         instance_role: str = "member",
     ) -> UserChatMembership:
-        """Create a new membership. No-op if one already exists."""
+        """Idempotent upsert. Returns existing membership if active; reactivates if inactive."""
+        from sqlalchemy.exc import IntegrityError
+
         existing = self.get_membership(user_id, chat_settings_id)
         if existing:
             if not existing.is_active:
@@ -76,7 +78,11 @@ class MembershipRepository(BaseRepository):
             instance_role=instance_role,
         )
         self.db.add(membership)
-        self.db.commit()
+        try:
+            self.db.commit()
+        except IntegrityError:
+            self.db.rollback()
+            return self.get_membership(user_id, chat_settings_id)
         self.db.refresh(membership)
         return membership
 

--- a/src/repositories/onboarding_repository.py
+++ b/src/repositories/onboarding_repository.py
@@ -1,0 +1,93 @@
+"""Onboarding session repository - CRUD for DM onboarding state."""
+
+from typing import Optional
+from datetime import datetime
+
+from src.repositories.base_repository import BaseRepository
+from src.models.onboarding_session import OnboardingSession
+
+
+class OnboardingRepository(BaseRepository):
+    """Repository for OnboardingSession CRUD operations."""
+
+    def get_active_for_user(self, user_id: str) -> Optional[OnboardingSession]:
+        """Get the active onboarding session for a user (if any)."""
+        result = (
+            self.db.query(OnboardingSession)
+            .filter(
+                OnboardingSession.user_id == user_id,
+                OnboardingSession.expires_at > datetime.utcnow(),
+                OnboardingSession.step != "complete",
+            )
+            .first()
+        )
+        self.end_read_transaction()
+        return result
+
+    def get_by_id(self, session_id: str) -> Optional[OnboardingSession]:
+        """Get an onboarding session by ID."""
+        result = (
+            self.db.query(OnboardingSession)
+            .filter(OnboardingSession.id == session_id)
+            .first()
+        )
+        self.end_read_transaction()
+        return result
+
+    def create(
+        self,
+        user_id: str,
+        expires_at: datetime,
+    ) -> OnboardingSession:
+        """Create a new onboarding session.
+
+        Replaces any existing session for this user (UNIQUE constraint).
+        """
+        existing = self.get_active_for_user(user_id)
+        if existing:
+            self.db.delete(existing)
+            self.db.commit()
+
+        session = OnboardingSession(
+            user_id=user_id,
+            expires_at=expires_at,
+        )
+        self.db.add(session)
+        self.db.commit()
+        self.db.refresh(session)
+        return session
+
+    def update_step(
+        self,
+        session_id: str,
+        step: str,
+        pending_instance_name: Optional[str] = None,
+        pending_chat_settings_id: Optional[str] = None,
+    ) -> Optional[OnboardingSession]:
+        """Advance the onboarding session to the next step."""
+        session = self.get_by_id(session_id)
+        if not session:
+            return None
+
+        session.step = step
+        if pending_instance_name is not None:
+            session.pending_instance_name = pending_instance_name
+        if pending_chat_settings_id is not None:
+            session.pending_chat_settings_id = pending_chat_settings_id
+        self.db.commit()
+        self.db.refresh(session)
+        return session
+
+    def delete_expired(self) -> int:
+        """Delete all expired onboarding sessions.
+
+        Called by the scheduler loop to clean up stale sessions.
+        Returns number of sessions deleted.
+        """
+        count = (
+            self.db.query(OnboardingSession)
+            .filter(OnboardingSession.expires_at <= datetime.utcnow())
+            .delete()
+        )
+        self.db.commit()
+        return count

--- a/src/services/core/dashboard_service.py
+++ b/src/services/core/dashboard_service.py
@@ -55,7 +55,7 @@ class DashboardService(BaseService):
 
             last_post_at = None
             recent = self.history_repo.get_recent_posts(
-                hours=720, chat_settings_id=cs_id
+                hours=720, chat_settings_id=cs_id, limit=1
             )
             if recent:
                 last_post_at = recent[0].posted_at.isoformat()

--- a/src/services/core/dashboard_service.py
+++ b/src/services/core/dashboard_service.py
@@ -8,6 +8,8 @@ from src.repositories.history_repository import HistoryRepository
 from src.repositories.media_repository import MediaRepository
 from src.repositories.queue_repository import QueueRepository
 from src.repositories.category_mix_repository import CategoryMixRepository
+from src.repositories.membership_repository import MembershipRepository
+from src.repositories.user_repository import UserRepository
 
 
 class DashboardService(BaseService):
@@ -27,10 +29,51 @@ class DashboardService(BaseService):
         self.history_repo = HistoryRepository()
         self.media_repo = MediaRepository()
         self.category_mix_repo = CategoryMixRepository()
+        self.membership_repo = MembershipRepository()
+        self.user_repo = UserRepository()
 
     def _resolve_chat_settings_id(self, telegram_chat_id: int) -> str:
         chat_settings = self.settings_service.get_settings(telegram_chat_id)
         return str(chat_settings.id)
+
+    def get_user_instances(self, telegram_user_id: int) -> dict:
+        """Return all instances a user belongs to, with stats per instance.
+
+        Used by the instance picker (web dashboard and DM Mini App).
+        """
+        user = self.user_repo.get_by_telegram_id(telegram_user_id)
+        if not user:
+            return {"instances": []}
+
+        memberships = self.membership_repo.get_for_user(str(user.id))
+        instances = []
+        for membership in memberships:
+            cs = membership.chat_settings
+            cs_id = str(cs.id)
+
+            media_count = self.media_repo.count_active(chat_settings_id=cs_id)
+
+            last_post_at = None
+            recent = self.history_repo.get_recent_posts(
+                hours=720, chat_settings_id=cs_id
+            )
+            if recent:
+                last_post_at = recent[0].posted_at.isoformat()
+
+            instances.append(
+                {
+                    "chat_settings_id": cs_id,
+                    "telegram_chat_id": cs.telegram_chat_id,
+                    "display_name": cs.display_name,
+                    "media_count": media_count,
+                    "posts_per_day": cs.posts_per_day,
+                    "is_paused": cs.is_paused,
+                    "last_post_at": last_post_at,
+                    "instance_role": membership.instance_role,
+                }
+            )
+
+        return {"instances": instances}
 
     def get_queue_detail(self, telegram_chat_id: int, limit: int = 10) -> dict:
         """Return in-flight queue items with media info and activity summary.

--- a/src/services/core/settings_service.py
+++ b/src/services/core/settings_service.py
@@ -55,6 +55,15 @@ class SettingsService(BaseService):
         """
         return self.settings_repo.get_or_create(telegram_chat_id)
 
+    def get_settings_if_exists(self, telegram_chat_id: int) -> Optional[ChatSettings]:
+        """Look up settings for a chat without creating a row.
+
+        Returns None if no chat_settings record exists for this chat_id.
+        Use this when you need a read-only lookup that must not create
+        phantom rows (e.g. checking group membership eligibility).
+        """
+        return self.settings_repo.get_by_chat_id(telegram_chat_id)
+
     def toggle_setting(
         self, telegram_chat_id: int, setting_name: str, user: Optional[User] = None
     ) -> bool:

--- a/src/services/core/telegram_commands.py
+++ b/src/services/core/telegram_commands.py
@@ -32,8 +32,10 @@ class TelegramCommandHandlers:
         New users: show onboarding Mini App button.
         Returning users: show dashboard summary.
         """
-        user = self.service._get_or_create_user(update.effective_user)
         chat_id = update.effective_chat.id
+        user = self.service._get_or_create_user(
+            update.effective_user, telegram_chat_id=chat_id
+        )
 
         # Check onboarding status
         from src.services.core.settings_service import SettingsService
@@ -103,8 +105,10 @@ class TelegramCommandHandlers:
         All data is scoped to the current chat's tenant (chat_settings_id)
         and all configuration is read from the database, never from env vars.
         """
-        user = self.service._get_or_create_user(update.effective_user)
         chat_id = update.effective_chat.id
+        user = self.service._get_or_create_user(
+            update.effective_user, telegram_chat_id=chat_id
+        )
 
         # Load tenant-scoped settings from DB (single source of truth)
         chat_settings = self.service.settings_service.get_settings(chat_id)
@@ -396,8 +400,10 @@ class TelegramCommandHandlers:
 
     async def handle_cleanup(self, update, context):
         """Handle /cleanup command - delete recent bot messages from chat."""
-        user = self.service._get_or_create_user(update.effective_user)
         chat_id = update.effective_chat.id
+        user = self.service._get_or_create_user(
+            update.effective_user, telegram_chat_id=chat_id
+        )
 
         # Query database for bot messages from last 48 hours
         bot_messages = self.service.interaction_service.get_deletable_bot_messages(
@@ -470,8 +476,10 @@ class TelegramCommandHandlers:
         Shows a summary of pending items and a confirmation button.
         On confirmation, marks each item as posted with history and lock creation.
         """
-        user = self.service._get_or_create_user(update.effective_user)
         chat_id = update.effective_chat.id
+        user = self.service._get_or_create_user(
+            update.effective_user, telegram_chat_id=chat_id
+        )
 
         chat_settings = self.service.settings_service.get_settings(chat_id)
         cs_id = str(chat_settings.id)

--- a/src/services/core/telegram_service.py
+++ b/src/services/core/telegram_service.py
@@ -22,6 +22,7 @@ from src.services.core.interaction_service import InteractionService
 from src.services.core.settings_service import SettingsService
 from src.services.core.instagram_account_service import InstagramAccountService
 from src.services.core.telegram_notification import TelegramNotificationService
+from src.repositories.membership_repository import MembershipRepository
 from src.config.settings import settings
 from src.utils.logger import logger
 from src import __version__
@@ -56,11 +57,13 @@ class TelegramService(BaseService):
         self.interaction_service = InteractionService()
         self.settings_service = SettingsService()
         self.ig_account_service = InstagramAccountService()
+        self.membership_repo = MembershipRepository()
         self.bot = None
         self.application = None
         self.notification_service = TelegramNotificationService(self)
         self._operation_locks: dict[str, asyncio.Lock] = {}
         self._cancel_flags: dict[str, asyncio.Event] = {}
+        self._known_memberships: set[tuple[str, int]] = set()
         self._callback_dispatch: dict = {}
 
     def get_operation_lock(self, queue_id: str) -> asyncio.Lock:
@@ -357,8 +360,12 @@ class TelegramService(BaseService):
 
             logger.info(f"📞 Parsed action='{action}', data='{data}'")
 
-            # Get user info
-            user = self._get_or_create_user(query.from_user)
+            # Get user info (pass chat_id for auto-membership in groups)
+            try:
+                chat_id = int(query.message.chat_id) if query.message else None
+            except (TypeError, ValueError):
+                chat_id = None
+            user = self._get_or_create_user(query.from_user, telegram_chat_id=chat_id)
 
             # Tier 1: Standard dispatch (data, user, query) handlers
             handler = self._callback_dispatch.get(action)
@@ -393,8 +400,12 @@ class TelegramService(BaseService):
             # Clean up open transactions to prevent "idle in transaction"
             self.cleanup_transactions()
 
-    def _get_or_create_user(self, telegram_user):
-        """Get or create user from Telegram data, syncing profile on each interaction."""
+    def _get_or_create_user(self, telegram_user, telegram_chat_id=None):
+        """Get or create user from Telegram data, syncing profile on each interaction.
+
+        If telegram_chat_id is provided and is a group chat (< 0), also ensures
+        a user_chat_membership exists linking this user to that chat's instance.
+        """
         user = self.user_repo.get_by_telegram_id(telegram_user.id)
 
         if not user:
@@ -414,7 +425,35 @@ class TelegramService(BaseService):
                 telegram_last_name=telegram_user.last_name,
             )
 
+        # Auto-create membership for group chat interactions
+        if telegram_chat_id is not None and telegram_chat_id < 0:
+            self._ensure_membership(user, telegram_chat_id)
+
         return user
+
+    def _ensure_membership(self, user, telegram_chat_id):
+        """Ensure a membership exists linking user to a group chat instance.
+
+        Uses a process-local cache to avoid DB queries on repeated
+        interactions from the same user in the same group.
+        """
+        cache_key = (str(user.id), telegram_chat_id)
+        if cache_key in self._known_memberships:
+            return
+
+        try:
+            chat_settings = self.settings_service.settings_repo.get_by_chat_id(
+                telegram_chat_id
+            )
+            if not chat_settings:
+                return
+            self.membership_repo.create_membership(
+                user_id=str(user.id),
+                chat_settings_id=str(chat_settings.id),
+            )
+            self._known_memberships.add(cache_key)
+        except Exception as e:
+            logger.debug(f"Membership auto-create failed: {e}")
 
     def _is_verbose(self, chat_id, chat_settings=None) -> bool:
         """Check if verbose notifications are enabled for a chat.

--- a/src/services/core/telegram_service.py
+++ b/src/services/core/telegram_service.py
@@ -436,13 +436,17 @@ class TelegramService(BaseService):
 
         Uses a process-local cache to avoid DB queries on repeated
         interactions from the same user in the same group.
+
+        NOTE: _known_memberships is never invalidated in this process.
+        Phase 2b's my_chat_member kicked handler must evict entries for
+        the affected chat_id when the bot is removed from a group.
         """
         cache_key = (str(user.id), telegram_chat_id)
         if cache_key in self._known_memberships:
             return
 
         try:
-            chat_settings = self.settings_service.settings_repo.get_by_chat_id(
+            chat_settings = self.settings_service.get_settings_if_exists(
                 telegram_chat_id
             )
             if not chat_settings:
@@ -453,7 +457,7 @@ class TelegramService(BaseService):
             )
             self._known_memberships.add(cache_key)
         except Exception as e:
-            logger.debug(f"Membership auto-create failed: {e}")
+            logger.warning(f"Membership auto-create failed: {e}")
 
     def _is_verbose(self, chat_id, chat_settings=None) -> bool:
         """Check if verbose notifications are enabled for a chat.

--- a/src/services/core/telegram_settings.py
+++ b/src/services/core/telegram_settings.py
@@ -133,8 +133,10 @@ class TelegramSettingsHandlers:
 
     async def handle_settings(self, update, context):
         """Handle /settings command - show settings menu with toggle buttons."""
-        user = self.service._get_or_create_user(update.effective_user)
         chat_id = update.effective_chat.id
+        user = self.service._get_or_create_user(
+            update.effective_user, telegram_chat_id=chat_id
+        )
 
         # Log the actual command used (could be /setup or /settings alias)
         command_text = (


### PR DESCRIPTION
## Summary

- Migration 023: `user_chat_memberships` table, `onboarding_sessions` table, `display_name` on `chat_settings`, backfill index on `user_interactions`
- `UserChatMembership` + `OnboardingSession` models with proper constraints and relationships
- `MembershipRepository` (get_for_user with joinedload, create_membership with idempotent upsert, deactivate_for_chat) + `OnboardingSessionRepository`
- Auto-create membership hook in `TelegramService._get_or_create_user()` for group chat interactions, with process-local cache to avoid hot-path DB overhead
- `DashboardService.get_user_instances(telegram_user_id)` returns all instances with stats for the instance picker

Closes #231

## Test plan

- [x] All 1584 existing tests pass (no regressions)
- [x] Ruff lint + format clean
- [ ] Apply migration 023 on staging/prod
- [ ] Verify `user_chat_memberships` table created with correct constraints
- [ ] Verify membership auto-created on group chat interaction
- [ ] Run Phase 1b backfill script after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)