### PR TITLE
feat: get_settings() split + /start refactor (Phase 2a)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Multi-account /start refactor + get_settings() split** (#233) — `get_settings()` now accepts `create_if_missing` parameter to prevent phantom DM `chat_settings` rows. 8 group callback call sites flipped. New `StartCommandRouter` with 5-branch `/start` handler. `ConversationService` wraps DM onboarding state machine. Migration 024 cleans up existing phantom rows.
 - **Multi-account backfill script** (#232) — `scripts/backfill_memberships.py` backfills `user_chat_memberships` from historical `user_interactions`, promotes group admins/owners via Telegram API, and runs a verification gate for Phase 2 deploy readiness. Supports dry run, `--apply`, `--promote`, and `--verify` modes.
 - **Multi-account data layer** (#231) — Foundation for multi-account dashboard support. Users can now belong to multiple chat instances via `user_chat_memberships` join table. Memberships are auto-created on group chat interactions. New `DashboardService.get_user_instances()` returns all instances a user belongs to with per-instance stats. Also adds `onboarding_sessions` table for future DM onboarding flow and `display_name` column on `chat_settings`.
 - **Vercel deployment guide** — Documented all required env vars for `landing/` Vercel deployment in `documentation/guides/landing-vercel-deployment.md`.

--- a/scripts/migrations/024_cleanup_phantom_dm_chat_settings.sql
+++ b/scripts/migrations/024_cleanup_phantom_dm_chat_settings.sql
@@ -1,0 +1,24 @@
+-- Migration 024: Clean up phantom DM chat_settings rows
+--
+-- Deletes chat_settings rows that:
+--   1. Have telegram_chat_id > 0 (DM, not group/supergroup)
+--   2. Have no references from media_items, posting_queue, posting_history,
+--      or user_chat_memberships
+--
+-- These rows were created by the old get_or_create() behavior in
+-- SettingsService.get_settings() when DM users interacted with the bot.
+-- Phase 2a's get_settings() split prevents new phantoms.
+
+BEGIN;
+
+DELETE FROM chat_settings
+WHERE telegram_chat_id > 0
+  AND id NOT IN (SELECT DISTINCT chat_settings_id FROM media_items WHERE chat_settings_id IS NOT NULL)
+  AND id NOT IN (SELECT DISTINCT chat_settings_id FROM posting_queue WHERE chat_settings_id IS NOT NULL)
+  AND id NOT IN (SELECT DISTINCT chat_settings_id FROM posting_history WHERE chat_settings_id IS NOT NULL)
+  AND id NOT IN (SELECT DISTINCT chat_settings_id FROM user_chat_memberships);
+
+INSERT INTO schema_version (version, description, applied_at)
+VALUES (24, 'Clean up phantom DM chat_settings rows', NOW());
+
+COMMIT;

--- a/scripts/migrations/024_cleanup_phantom_dm_chat_settings.sql
+++ b/scripts/migrations/024_cleanup_phantom_dm_chat_settings.sql
@@ -5,6 +5,10 @@
 --   2. Have no references from media_items, posting_queue, posting_history,
 --      or user_chat_memberships
 --
+-- Note: onboarding_sessions.pending_chat_settings_id is also an FK on
+-- chat_settings, but it always references group chats (telegram_chat_id < 0)
+-- so phantoms (telegram_chat_id > 0) are never referenced by it.
+--
 -- These rows were created by the old get_or_create() behavior in
 -- SettingsService.get_settings() when DM users interacted with the bot.
 -- Phase 2a's get_settings() split prevents new phantoms.

--- a/src/repositories/onboarding_repository.py
+++ b/src/repositories/onboarding_repository.py
@@ -41,9 +41,14 @@ class OnboardingRepository(BaseRepository):
     ) -> OnboardingSession:
         """Create a new onboarding session.
 
-        Replaces any existing session for this user (UNIQUE constraint).
+        Replaces any existing session for this user (including expired ones)
+        to avoid hitting the UNIQUE(user_id) constraint.
         """
-        existing = self.get_active_for_user(user_id)
+        existing = (
+            self.db.query(OnboardingSession)
+            .filter(OnboardingSession.user_id == user_id)
+            .first()
+        )
         if existing:
             self.db.delete(existing)
             self.db.commit()

--- a/src/services/core/conversation_service.py
+++ b/src/services/core/conversation_service.py
@@ -1,0 +1,68 @@
+"""Conversation service - DM onboarding state machine."""
+
+from datetime import datetime, timedelta
+from typing import Optional
+
+from src.models.onboarding_session import OnboardingSession
+from src.repositories.onboarding_repository import OnboardingRepository
+from src.services.base_service import BaseService
+from src.utils.logger import logger
+
+ONBOARDING_TTL_HOURS = 24
+
+
+class ConversationService(BaseService):
+    """Wraps onboarding_sessions for the DM instance-creation flow.
+
+    State machine: naming → awaiting_group → complete
+    Sessions expire after 24h.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.onboarding_repo = OnboardingRepository()
+
+    def start_onboarding(self, user_id: str) -> OnboardingSession:
+        """Start a new onboarding session (replaces any existing)."""
+        expires_at = datetime.utcnow() + timedelta(hours=ONBOARDING_TTL_HOURS)
+        session = self.onboarding_repo.create(
+            user_id=user_id,
+            expires_at=expires_at,
+        )
+        logger.info(f"Onboarding started for user {user_id}, session {session.id}")
+        return session
+
+    def get_current_session(self, user_id: str) -> Optional[OnboardingSession]:
+        """Get the active onboarding session for a user, if any."""
+        return self.onboarding_repo.get_active_for_user(user_id)
+
+    def get_session_by_id(self, session_id: str) -> Optional[OnboardingSession]:
+        """Get an onboarding session by ID (for startgroup deep links)."""
+        return self.onboarding_repo.get_by_id(session_id)
+
+    def set_instance_name(
+        self, session_id: str, name: str
+    ) -> Optional[OnboardingSession]:
+        """Record the chosen instance name and advance to awaiting_group."""
+        return self.onboarding_repo.update_step(
+            session_id=session_id,
+            step="awaiting_group",
+            pending_instance_name=name,
+        )
+
+    def link_group(
+        self, session_id: str, chat_settings_id: str
+    ) -> Optional[OnboardingSession]:
+        """Link a group chat to the pending onboarding session."""
+        return self.onboarding_repo.update_step(
+            session_id=session_id,
+            step="complete",
+            pending_chat_settings_id=chat_settings_id,
+        )
+
+    def cleanup_expired(self) -> int:
+        """Delete expired onboarding sessions. Call from scheduler loop."""
+        count = self.onboarding_repo.delete_expired()
+        if count > 0:
+            logger.info(f"Cleaned up {count} expired onboarding session(s)")
+        return count

--- a/src/services/core/settings_service.py
+++ b/src/services/core/settings_service.py
@@ -43,17 +43,25 @@ class SettingsService(BaseService):
         super().__init__()
         self.settings_repo = ChatSettingsRepository()
 
-    def get_settings(self, telegram_chat_id: int) -> ChatSettings:
+    def get_settings(
+        self, telegram_chat_id: int, create_if_missing: bool = True
+    ) -> Optional[ChatSettings]:
         """
-        Get or create settings for a chat.
+        Get settings for a chat.
 
         Args:
             telegram_chat_id: Telegram chat/channel ID
+            create_if_missing: If True (default), create from .env defaults
+                on first access. If False, return None when no record exists.
+                Use False in contexts where creating a phantom row is wrong
+                (e.g. group callbacks that may reference an uninitialized chat).
 
         Returns:
-            ChatSettings record (created from .env if first access)
+            ChatSettings record, or None if create_if_missing=False and not found
         """
-        return self.settings_repo.get_or_create(telegram_chat_id)
+        if create_if_missing:
+            return self.settings_repo.get_or_create(telegram_chat_id)
+        return self.settings_repo.get_by_chat_id(telegram_chat_id)
 
     def get_settings_if_exists(self, telegram_chat_id: int) -> Optional[ChatSettings]:
         """Look up settings for a chat without creating a row.

--- a/src/services/core/start_command_router.py
+++ b/src/services/core/start_command_router.py
@@ -1,0 +1,297 @@
+"""StartCommandRouter — 5-branch /start handler for multi-account DM flow."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+
+from src.config.settings import settings
+from src.services.core.conversation_service import ConversationService
+from src.services.core.dashboard_service import DashboardService
+from src.repositories.membership_repository import MembershipRepository
+from src.services.core.telegram_utils import build_webapp_button
+
+if TYPE_CHECKING:
+    from src.services.core.telegram_service import TelegramService
+
+
+class StartCommandRouter:
+    """Routes /start to the correct handler based on chat type and state.
+
+    Branches:
+    1. Group + startgroup payload → link pending onboarding session
+    2. Group + no payload → existing group setup (unchanged)
+    3. DM + active onboarding session → resume in-progress onboarding
+    4. DM + returning user (1+ memberships) → instance list
+    5. DM + new user (0 memberships) → start onboarding
+    """
+
+    def __init__(self, service: TelegramService):
+        self.service = service
+
+    async def handle_start(self, update, context):
+        """Main /start entry point."""
+        chat_id = update.effective_chat.id
+        user = self.service._get_or_create_user(
+            update.effective_user, telegram_chat_id=chat_id
+        )
+        is_dm = update.effective_chat.type == "private"
+
+        if not is_dm:
+            # Group context
+            payload = context.args[0] if context.args else None
+            if payload and payload.startswith("setup_"):
+                await self._handle_startgroup_link(update, user, payload)
+            else:
+                await self._handle_group_start(update, user, chat_id)
+        else:
+            # DM context
+            with ConversationService() as conv_service:
+                active_session = conv_service.get_current_session(str(user.id))
+
+            if active_session:
+                await self._handle_resume_onboarding(update, user, active_session)
+            else:
+                with MembershipRepository() as membership_repo:
+                    memberships = membership_repo.get_for_user(str(user.id))
+
+                if memberships:
+                    await self._handle_returning_user(update, user)
+                else:
+                    await self._handle_new_user(update, user, context)
+
+        # Log interaction
+        self.service.interaction_service.log_command(
+            user_id=str(user.id),
+            command="/start",
+            telegram_chat_id=chat_id,
+            telegram_message_id=update.message.message_id,
+        )
+
+    # ------------------------------------------------------------------
+    # Branch 1: Group + startgroup payload
+    # ------------------------------------------------------------------
+
+    async def _handle_startgroup_link(self, update, user, payload):
+        """Link this group to a pending onboarding session from DM."""
+        session_id = payload[6:]  # strip "setup_"
+        chat_id = update.effective_chat.id
+
+        with ConversationService() as conv_service:
+            session = conv_service.get_session_by_id(session_id)
+
+        if not session or str(session.user_id) != str(user.id):
+            await update.message.reply_text(
+                "⚠️ Invalid or expired setup link. "
+                "Start a new instance from your DM with the bot."
+            )
+            return
+
+        if session.step != "awaiting_group":
+            await update.message.reply_text(
+                "⚠️ This setup session is not waiting for a group. "
+                "Start a new instance from your DM."
+            )
+            return
+
+        # Create chat_settings for this group and link it
+        from src.services.core.settings_service import SettingsService
+
+        with SettingsService() as settings_service:
+            chat_settings = settings_service.get_settings(chat_id)
+            if session.pending_instance_name:
+                settings_service.update_setting(
+                    chat_id, "display_name", session.pending_instance_name
+                )
+
+        # Create owner membership
+        self.service.membership_repo.create_membership(
+            user_id=str(user.id),
+            chat_settings_id=str(chat_settings.id),
+            instance_role="owner",
+        )
+
+        # Complete the onboarding session
+        with ConversationService() as conv_service:
+            conv_service.link_group(str(session.id), str(chat_settings.id))
+
+        name = session.pending_instance_name or "this group"
+        await update.message.reply_text(
+            f"✅ *{name}* is set up\\!\n\n"
+            f"Use /status to check health, or set up your media source "
+            f"and posting schedule from the dashboard\\.",
+            parse_mode="MarkdownV2",
+        )
+
+        # Notify in DM
+        try:
+            await self.service.bot.send_message(
+                chat_id=update.effective_user.id,
+                text=(
+                    f"✅ Your instance *{name}* is linked to this group!\n\n"
+                    "Use /start here to manage your instances."
+                ),
+                parse_mode="Markdown",
+            )
+        except Exception:
+            pass  # DM may be blocked
+
+    # ------------------------------------------------------------------
+    # Branch 2: Group + no payload (existing behavior)
+    # ------------------------------------------------------------------
+
+    async def _handle_group_start(self, update, user, chat_id):
+        """Standard group /start — show onboarding or dashboard button."""
+        from src.services.core.settings_service import SettingsService
+
+        with SettingsService() as settings_service:
+            chat_settings = settings_service.get_settings(chat_id)
+            onboarding_done = chat_settings.onboarding_completed
+
+        if settings.OAUTH_REDIRECT_BASE_URL:
+            webapp_url = (
+                f"{settings.OAUTH_REDIRECT_BASE_URL}/webapp/onboarding"
+                f"?chat_id={chat_id}"
+            )
+
+            if onboarding_done:
+                button_text = "Open Storyline"
+                message_text = (
+                    "Welcome back to *Storyline AI*!\n\n"
+                    "Tap the button below to view your dashboard "
+                    "and manage your settings."
+                )
+            else:
+                button_text = "Open Setup Wizard"
+                message_text = (
+                    "Welcome to *Storyline AI*!\n\n"
+                    "Let's get you set up. Tap the button below to "
+                    "connect your accounts and configure your posting schedule."
+                )
+
+            button = build_webapp_button(
+                text=button_text,
+                webapp_url=webapp_url,
+                chat_type=update.effective_chat.type,
+                chat_id=chat_id,
+                user_id=update.effective_user.id,
+            )
+
+            keyboard = InlineKeyboardMarkup([[button]])
+            await update.message.reply_text(
+                message_text,
+                parse_mode="Markdown",
+                reply_markup=keyboard,
+            )
+        else:
+            await update.message.reply_text(
+                "👋 *Storyline AI Bot*\n\n"
+                "Commands:\n"
+                "/status - System health & overview\n"
+                "/next - Force send next post\n"
+                "/setup - Quick settings & toggles\n"
+                "/help - Show all commands",
+                parse_mode="Markdown",
+            )
+
+    # ------------------------------------------------------------------
+    # Branch 3: DM + active onboarding → resume
+    # ------------------------------------------------------------------
+
+    async def _handle_resume_onboarding(self, update, user, session):
+        """Resume an in-progress onboarding session."""
+        if session.step == "naming":
+            await update.message.reply_text(
+                "You have an instance setup in progress.\n\n"
+                "What do you want to call this instance?\n"
+                '_(e.g. "TL Enterprises", "Personal Brand")_',
+                parse_mode="Markdown",
+            )
+        elif session.step == "awaiting_group":
+            name = session.pending_instance_name or "your instance"
+            bot_username = (await self.service.bot.get_me()).username
+            startgroup_url = (
+                f"https://t.me/{bot_username}?startgroup=setup_{session.id}"
+            )
+
+            keyboard = InlineKeyboardMarkup(
+                [
+                    [InlineKeyboardButton("Add to Group Chat", url=startgroup_url)],
+                ]
+            )
+            await update.message.reply_text(
+                f"Waiting to link *{name}* to a group chat.\n\n"
+                "Add me to the group, or if I'm already there, "
+                "run `/link` in that group.",
+                parse_mode="Markdown",
+                reply_markup=keyboard,
+            )
+
+    # ------------------------------------------------------------------
+    # Branch 4: DM + returning user → instance list
+    # ------------------------------------------------------------------
+
+    async def _handle_returning_user(self, update, user):
+        """Show the user's instances with stats and management buttons."""
+        with DashboardService() as dash:
+            data = dash.get_user_instances(update.effective_user.id)
+
+        instances = data["instances"]
+        lines = ["Welcome back to *Storyline AI*\\!\n\nYour instances:"]
+
+        keyboard_rows = []
+        for i, inst in enumerate(instances, 1):
+            name = inst["display_name"] or f"Chat {inst['telegram_chat_id']}"
+            media = inst["media_count"]
+            ppd = inst["posts_per_day"]
+            status = "⏸️ paused" if inst["is_paused"] else "✅ active"
+            lines.append(
+                f"{i}\\. *{_escape_md2(name)}* "
+                f"\\({media} media · {ppd}/day · {status}\\)"
+            )
+
+            keyboard_rows.append(
+                [
+                    InlineKeyboardButton(
+                        f"Manage {name}",
+                        callback_data=f"instance_manage:{inst['chat_settings_id']}",
+                    )
+                ]
+            )
+
+        keyboard_rows.append(
+            [InlineKeyboardButton("+ New Instance", callback_data="instance_new")]
+        )
+
+        await update.message.reply_text(
+            "\n".join(lines),
+            parse_mode="MarkdownV2",
+            reply_markup=InlineKeyboardMarkup(keyboard_rows),
+        )
+
+    # ------------------------------------------------------------------
+    # Branch 5: DM + new user → start onboarding
+    # ------------------------------------------------------------------
+
+    async def _handle_new_user(self, update, user, context):
+        """Start the instance creation onboarding flow."""
+        with ConversationService() as conv_service:
+            session = conv_service.start_onboarding(str(user.id))
+
+        # Store session ID in context for conversation routing
+        context.user_data["onboarding_session_id"] = str(session.id)
+
+        await update.message.reply_text(
+            "Welcome to *Storyline AI*\\! Let's set up your first posting instance\\.\n\n"
+            "What do you want to call this instance?\n"
+            '_\\(e\\.g\\. "TL Enterprises", "Personal Brand"\\)_',
+            parse_mode="MarkdownV2",
+        )
+
+
+def _escape_md2(text: str) -> str:
+    """Escape Telegram MarkdownV2 special characters."""
+    import re
+
+    return re.sub(r"([_*\[\]()~`>#+\-=|{}.!\\])", r"\\\1", text)

--- a/src/services/core/start_command_router.py
+++ b/src/services/core/start_command_router.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup
@@ -292,6 +293,5 @@ class StartCommandRouter:
 
 def _escape_md2(text: str) -> str:
     """Escape Telegram MarkdownV2 special characters."""
-    import re
 
     return re.sub(r"([_*\[\]()~`>#+\-=|{}.!\\])", r"\\\1", text)

--- a/src/services/core/telegram_accounts.py
+++ b/src/services/core/telegram_accounts.py
@@ -506,7 +506,11 @@ class TelegramAccountHandlers:
         )
 
         # Rebuild keyboard with account selector
-        chat_settings = self.service.settings_service.get_settings(chat_id)
+        chat_settings = self.service.settings_service.get_settings(
+            chat_id, create_if_missing=False
+        )
+        if not chat_settings:
+            return
         if account_count is None:
             account_count = self.service.ig_account_service.count_active_accounts()
         reply_markup = build_queue_action_keyboard(
@@ -541,7 +545,11 @@ class TelegramAccountHandlers:
         pending_items = self.service.queue_repo.get_pending_with_telegram_message(
             chat_id
         )
-        chat_settings = self.service.settings_service.get_settings(chat_id)
+        chat_settings = self.service.settings_service.get_settings(
+            chat_id, create_if_missing=False
+        )
+        if not chat_settings:
+            return
         if account_count is None:
             account_count = self.service.ig_account_service.count_active_accounts()
         verbose = self.service._is_verbose(chat_id, chat_settings=chat_settings)

--- a/src/services/core/telegram_autopost.py
+++ b/src/services/core/telegram_autopost.py
@@ -200,7 +200,14 @@ class TelegramAutopostHandler:
         Orchestrates: safety check → upload → dry-run check → post → record.
         """
         chat_id = query.message.chat_id
-        chat_settings = self.service.settings_service.get_settings(chat_id)
+        chat_settings = self.service.settings_service.get_settings(
+            chat_id, create_if_missing=False
+        )
+        if not chat_settings:
+            await query.edit_message_caption(
+                caption="⚠️ Chat settings not found.",
+            )
+            return
 
         # Run comprehensive safety check
         safety_result = instagram_service.safety_check_before_post(

--- a/src/services/core/telegram_callbacks_queue.py
+++ b/src/services/core/telegram_callbacks_queue.py
@@ -212,7 +212,11 @@ class TelegramCallbackQueueHandlers:
         )
 
         # Rebuild original keyboard
-        chat_settings = self.service.settings_service.get_settings(chat_id)
+        chat_settings = self.service.settings_service.get_settings(
+            chat_id, create_if_missing=False
+        )
+        if not chat_settings:
+            return
         reply_markup = build_queue_action_keyboard(
             queue_id,
             enable_instagram_api=chat_settings.enable_instagram_api,
@@ -298,7 +302,11 @@ class TelegramCallbackQueueHandlers:
         )
 
         # Get chat settings for enable_instagram_api check (use DB, not env var)
-        chat_settings = self.service.settings_service.get_settings(chat_id)
+        chat_settings = self.service.settings_service.get_settings(
+            chat_id, create_if_missing=False
+        )
+        if not chat_settings:
+            return
 
         # Rebuild original keyboard
         reply_markup = build_queue_action_keyboard(

--- a/src/services/core/telegram_commands.py
+++ b/src/services/core/telegram_commands.py
@@ -27,77 +27,8 @@ class TelegramCommandHandlers:
         self.service = service
 
     async def handle_start(self, update, context):
-        """Handle /start command.
-
-        New users: show onboarding Mini App button.
-        Returning users: show dashboard summary.
-        """
-        chat_id = update.effective_chat.id
-        user = self.service._get_or_create_user(
-            update.effective_user, telegram_chat_id=chat_id
-        )
-
-        # Check onboarding status
-        from src.services.core.settings_service import SettingsService
-
-        with SettingsService() as settings_service:
-            chat_settings = settings_service.get_settings(chat_id)
-            onboarding_done = chat_settings.onboarding_completed
-
-        if settings.OAUTH_REDIRECT_BASE_URL:
-            webapp_url = (
-                f"{settings.OAUTH_REDIRECT_BASE_URL}/webapp/onboarding"
-                f"?chat_id={chat_id}"
-            )
-
-            if onboarding_done:
-                button_text = "Open Storyline"
-                message_text = (
-                    "Welcome back to *Storyline AI*!\n\n"
-                    "Tap the button below to view your dashboard "
-                    "and manage your settings."
-                )
-            else:
-                button_text = "Open Setup Wizard"
-                message_text = (
-                    "Welcome to *Storyline AI*!\n\n"
-                    "Let's get you set up. Tap the button below to "
-                    "connect your accounts and configure your posting schedule."
-                )
-
-            button = build_webapp_button(
-                text=button_text,
-                webapp_url=webapp_url,
-                chat_type=update.effective_chat.type,
-                chat_id=chat_id,
-                user_id=update.effective_user.id,
-            )
-
-            keyboard = InlineKeyboardMarkup([[button]])
-            await update.message.reply_text(
-                message_text,
-                parse_mode="Markdown",
-                reply_markup=keyboard,
-            )
-        else:
-            # Fallback when OAUTH_REDIRECT_BASE_URL not configured
-            await update.message.reply_text(
-                "👋 *Storyline AI Bot*\n\n"
-                "Commands:\n"
-                "/status - System health & overview\n"
-                "/next - Force send next post\n"
-                "/setup - Quick settings & toggles\n"
-                "/help - Show all commands",
-                parse_mode="Markdown",
-            )
-
-        # Log interaction
-        self.service.interaction_service.log_command(
-            user_id=str(user.id),
-            command="/start",
-            telegram_chat_id=chat_id,
-            telegram_message_id=update.message.message_id,
-        )
+        """Handle /start — delegates to StartCommandRouter."""
+        await self.service.start_router.handle_start(update, context)
 
     async def handle_status(self, update, context):
         """Handle /status command.

--- a/src/services/core/telegram_service.py
+++ b/src/services/core/telegram_service.py
@@ -138,12 +138,14 @@ class TelegramService(BaseService):
         from src.services.core.telegram_autopost import TelegramAutopostHandler
         from src.services.core.telegram_settings import TelegramSettingsHandlers
         from src.services.core.telegram_accounts import TelegramAccountHandlers
+        from src.services.core.start_command_router import StartCommandRouter
 
         self.commands = TelegramCommandHandlers(self)
         self.callbacks = TelegramCallbackHandlers(self)
         self.autopost = TelegramAutopostHandler(self)
         self.settings_handler = TelegramSettingsHandlers(self)
         self.accounts = TelegramAccountHandlers(self)
+        self.start_router = StartCommandRouter(self)
 
         # Build callback dispatch table (must be after handlers are initialized)
         self._callback_dispatch = self._build_callback_dispatch_table()
@@ -332,7 +334,62 @@ class TelegramService(BaseService):
             if handled:
                 return
 
+        # Check for DM onboarding conversation
+        if (
+            update.effective_chat.type == "private"
+            and "onboarding_session_id" in context.user_data
+        ):
+            await self._handle_onboarding_message(update, context)
+            return
+
         # Message not part of any conversation - ignore silently
+
+    async def _handle_onboarding_message(self, update, context):
+        """Handle text input during DM onboarding (naming step)."""
+        from src.services.core.conversation_service import ConversationService
+
+        session_id = context.user_data.get("onboarding_session_id")
+        if not session_id:
+            return
+
+        with ConversationService() as conv_service:
+            session = conv_service.get_session_by_id(session_id)
+
+        if not session or session.step == "complete":
+            context.user_data.pop("onboarding_session_id", None)
+            return
+
+        if session.step == "naming":
+            instance_name = update.message.text.strip()[:100]
+            if not instance_name:
+                await update.message.reply_text(
+                    "Please enter a name for your instance."
+                )
+                return
+
+            with ConversationService() as conv_service:
+                conv_service.set_instance_name(str(session.id), instance_name)
+
+            # Show add-to-group step
+            bot_username = (await self.bot.get_me()).username
+            startgroup_url = (
+                f"https://t.me/{bot_username}?startgroup=setup_{session.id}"
+            )
+
+            from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+
+            keyboard = InlineKeyboardMarkup(
+                [
+                    [InlineKeyboardButton("Add to Group Chat", url=startgroup_url)],
+                ]
+            )
+            await update.message.reply_text(
+                f"Great! *{instance_name}* it is.\n\n"
+                "Now add me to the group chat where your team will review posts.\n\n"
+                "Bot already in your group? Run `/link` in that group.",
+                parse_mode="Markdown",
+                reply_markup=keyboard,
+            )
 
     async def _handle_callback(self, update, context):
         """Handle inline button callbacks.

--- a/src/services/core/telegram_service.py
+++ b/src/services/core/telegram_service.py
@@ -390,6 +390,12 @@ class TelegramService(BaseService):
                 parse_mode="Markdown",
                 reply_markup=keyboard,
             )
+        elif session.step == "awaiting_group":
+            await update.message.reply_text(
+                "Still waiting to link your group — add me to the group chat, "
+                "or run `/link` in that group if I'm already there.",
+                parse_mode="Markdown",
+            )
 
     async def _handle_callback(self, update, context):
         """Handle inline button callbacks.

--- a/src/services/core/telegram_settings.py
+++ b/src/services/core/telegram_settings.py
@@ -220,7 +220,11 @@ class TelegramSettingsHandlers:
     async def handle_settings_edit_start(self, setting_name: str, user, query, context):
         """Start editing a numeric setting (posts_per_day or hours)."""
         chat_id = query.message.chat_id
-        chat_settings = self.service.settings_service.get_settings(chat_id)
+        chat_settings = self.service.settings_service.get_settings(
+            chat_id, create_if_missing=False
+        )
+        if not chat_settings:
+            return
 
         if setting_name == "posts_per_day":
             context.user_data["settings_edit_state"] = "awaiting_posts_per_day"
@@ -421,7 +425,9 @@ class TelegramSettingsHandlers:
                 ]
             ]
 
-            chat_settings = self.service.settings_service.get_settings(chat_id)
+            chat_settings = self.service.settings_service.get_settings(
+                chat_id, create_if_missing=False
+            )
             chat_settings_id = str(chat_settings.id) if chat_settings else None
             pending_count = self.service.queue_repo.count_pending(
                 chat_settings_id=chat_settings_id
@@ -457,7 +463,9 @@ class TelegramSettingsHandlers:
         if action == "clear_queue":
             await query.answer("Clearing queue...")
 
-            chat_settings = self.service.settings_service.get_settings(chat_id)
+            chat_settings = self.service.settings_service.get_settings(
+                chat_id, create_if_missing=False
+            )
             chat_settings_id = str(chat_settings.id) if chat_settings else None
             cleared = self.service.queue_repo.delete_all_pending(
                 chat_settings_id=chat_settings_id

--- a/tests/src/services/conftest.py
+++ b/tests/src/services/conftest.py
@@ -4,6 +4,7 @@ import pytest
 from contextlib import contextmanager
 from unittest.mock import patch
 
+from src.services.core.start_command_router import StartCommandRouter  # noqa: F401
 from src.services.core.telegram_service import TelegramService
 
 
@@ -59,6 +60,9 @@ def mock_telegram_service():
         patch(
             "src.services.core.telegram_service.InstagramAccountService"
         ) as mock_ig_account_service_class,
+        patch(
+            "src.services.core.telegram_service.MembershipRepository"
+        ) as mock_membership_repo_class,
     ):
         mock_settings.TELEGRAM_BOT_TOKEN = "123456:ABC-DEF1234ghIkl"
         mock_settings.TELEGRAM_CHANNEL_ID = -1001234567890
@@ -78,5 +82,7 @@ def mock_telegram_service():
         service.settings_service = mock_settings_service_class.return_value
         service.ig_account_service = mock_ig_account_service_class.return_value
         service.ig_account_service.count_active_accounts.return_value = 1
+        service.membership_repo = mock_membership_repo_class.return_value
+        service.start_router = StartCommandRouter(service)
 
         yield service

--- a/tests/src/services/test_telegram_commands.py
+++ b/tests/src/services/test_telegram_commands.py
@@ -1426,6 +1426,152 @@ class TestStartCommand:
         call_kwargs = service.interaction_service.log_command.call_args[1]
         assert call_kwargs["command"] == "/start"
 
+    async def test_start_dm_returning_user_shows_instance_list(
+        self, mock_command_handlers
+    ):
+        """DM user with memberships sees instance list (branch 4)."""
+        handlers = mock_command_handlers
+        service = handlers.service
+
+        mock_user = Mock()
+        mock_user.id = uuid4()
+        service.user_repo.get_by_telegram_id.return_value = mock_user
+
+        mock_update = AsyncMock()
+        mock_update.effective_user.id = 12345
+        mock_update.effective_user.first_name = "Test"
+        mock_update.effective_user.username = "testuser"
+        mock_update.effective_chat.id = 12345
+        mock_update.effective_chat.type = "private"
+        mock_update.message.message_id = 1
+        mock_context = Mock()
+        mock_context.args = []
+
+        with (
+            patch(
+                "src.services.core.start_command_router.ConversationService"
+            ) as MockConv,
+            patch(
+                "src.services.core.start_command_router.MembershipRepository"
+            ) as MockMembership,
+            patch(
+                "src.services.core.start_command_router.DashboardService"
+            ) as MockDash,
+        ):
+            mock_conv = MockConv.return_value
+            mock_conv.__enter__ = Mock(return_value=mock_conv)
+            mock_conv.__exit__ = Mock(return_value=False)
+            mock_conv.get_current_session.return_value = None
+
+            mock_mem = MockMembership.return_value
+            mock_mem.__enter__ = Mock(return_value=mock_mem)
+            mock_mem.__exit__ = Mock(return_value=False)
+            mock_mem.get_for_user.return_value = [Mock()]  # has memberships
+
+            mock_dash = MockDash.return_value
+            mock_dash.__enter__ = Mock(return_value=mock_dash)
+            mock_dash.__exit__ = Mock(return_value=False)
+            mock_dash.get_user_instances.return_value = {
+                "instances": [
+                    {
+                        "chat_settings_id": "abc",
+                        "telegram_chat_id": -100123,
+                        "display_name": "TL Enterprises",
+                        "media_count": 100,
+                        "posts_per_day": 5,
+                        "is_paused": False,
+                        "last_post_at": None,
+                        "instance_role": "owner",
+                    }
+                ]
+            }
+
+            await handlers.handle_start(mock_update, mock_context)
+
+        call_args = str(mock_update.message.reply_text.call_args)
+        assert "TL Enterprises" in call_args
+        assert "Welcome back" in call_args
+
+    async def test_start_dm_new_user_starts_onboarding(self, mock_command_handlers):
+        """DM user with no memberships starts onboarding (branch 5)."""
+        handlers = mock_command_handlers
+        service = handlers.service
+
+        mock_user = Mock()
+        mock_user.id = uuid4()
+        service.user_repo.get_by_telegram_id.return_value = mock_user
+
+        mock_update = AsyncMock()
+        mock_update.effective_user.id = 12345
+        mock_update.effective_user.first_name = "Test"
+        mock_update.effective_user.username = "testuser"
+        mock_update.effective_chat.id = 12345
+        mock_update.effective_chat.type = "private"
+        mock_update.message.message_id = 1
+        mock_context = Mock()
+        mock_context.args = []
+        mock_context.user_data = {}
+
+        with (
+            patch(
+                "src.services.core.start_command_router.ConversationService"
+            ) as MockConv,
+            patch(
+                "src.services.core.start_command_router.MembershipRepository"
+            ) as MockMembership,
+        ):
+            mock_conv = MockConv.return_value
+            mock_conv.__enter__ = Mock(return_value=mock_conv)
+            mock_conv.__exit__ = Mock(return_value=False)
+            mock_conv.get_current_session.return_value = None
+            mock_session = Mock()
+            mock_session.id = uuid4()
+            mock_conv.start_onboarding.return_value = mock_session
+
+            mock_mem = MockMembership.return_value
+            mock_mem.__enter__ = Mock(return_value=mock_mem)
+            mock_mem.__exit__ = Mock(return_value=False)
+            mock_mem.get_for_user.return_value = []  # no memberships
+
+            await handlers.handle_start(mock_update, mock_context)
+
+        call_args = str(mock_update.message.reply_text.call_args)
+        assert "first posting instance" in call_args
+        assert "onboarding_session_id" in mock_context.user_data
+
+    async def test_start_dm_resume_onboarding(self, mock_command_handlers):
+        """DM user with active onboarding session resumes (branch 3)."""
+        handlers = mock_command_handlers
+        service = handlers.service
+
+        mock_user = Mock()
+        mock_user.id = uuid4()
+        service.user_repo.get_by_telegram_id.return_value = mock_user
+
+        mock_update = AsyncMock()
+        mock_update.effective_user.id = 12345
+        mock_update.effective_user.first_name = "Test"
+        mock_update.effective_user.username = "testuser"
+        mock_update.effective_chat.id = 12345
+        mock_update.effective_chat.type = "private"
+        mock_update.message.message_id = 1
+        mock_context = Mock()
+        mock_context.args = []
+
+        with patch(
+            "src.services.core.start_command_router.ConversationService"
+        ) as MockConv:
+            mock_conv = MockConv.return_value
+            mock_conv.__enter__ = Mock(return_value=mock_conv)
+            mock_conv.__exit__ = Mock(return_value=False)
+            mock_session = Mock(step="naming")
+            mock_conv.get_current_session.return_value = mock_session
+
+            await handlers.handle_start(mock_update, mock_context)
+
+        call_args = str(mock_update.message.reply_text.call_args)
+        assert "instance setup in progress" in call_args
+
 
 @pytest.mark.unit
 @pytest.mark.asyncio

--- a/tests/src/services/test_telegram_commands.py
+++ b/tests/src/services/test_telegram_commands.py
@@ -1270,7 +1270,7 @@ class TestStartCommand:
     """Tests for the /start command with onboarding Mini App support."""
 
     async def test_start_new_user_shows_webapp_button(self, mock_command_handlers):
-        """New user (onboarding not completed) sees the setup wizard button."""
+        """New user (onboarding not completed) sees the setup wizard button in group."""
         handlers = mock_command_handlers
         service = handlers.service
 
@@ -1284,7 +1284,10 @@ class TestStartCommand:
         mock_update.effective_user.first_name = "Test"
         mock_update.effective_user.username = "testuser"
         mock_update.effective_chat.id = -100123
+        mock_update.effective_chat.type = "group"
         mock_update.message.message_id = 1
+        mock_context = Mock()
+        mock_context.args = []
 
         with patch(
             "src.services.core.settings_service.SettingsService"
@@ -1296,11 +1299,11 @@ class TestStartCommand:
             mock_settings_instance.get_settings.return_value = mock_chat_settings
 
             with patch(
-                "src.services.core.telegram_commands.settings"
+                "src.services.core.start_command_router.settings"  # app settings
             ) as mock_app_settings:
                 mock_app_settings.OAUTH_REDIRECT_BASE_URL = "https://example.com"
 
-                await handlers.handle_start(mock_update, Mock())
+                await handlers.handle_start(mock_update, mock_context)
 
         call_args = mock_update.message.reply_text.call_args
         assert "Setup Wizard" in str(call_args)
@@ -1308,7 +1311,7 @@ class TestStartCommand:
     async def test_start_returning_user_shows_webapp_button(
         self, mock_command_handlers
     ):
-        """Returning user (onboarding completed) sees 'Open Storyline' Mini App button."""
+        """Returning user (onboarding completed) sees 'Open Storyline' button in group."""
         handlers = mock_command_handlers
         service = handlers.service
 
@@ -1321,7 +1324,10 @@ class TestStartCommand:
         mock_update.effective_user.first_name = "Test"
         mock_update.effective_user.username = "testuser"
         mock_update.effective_chat.id = -100123
+        mock_update.effective_chat.type = "group"
         mock_update.message.message_id = 1
+        mock_context = Mock()
+        mock_context.args = []
 
         with patch(
             "src.services.core.settings_service.SettingsService"
@@ -1333,18 +1339,18 @@ class TestStartCommand:
             mock_settings_instance.get_settings.return_value = mock_chat_settings
 
             with patch(
-                "src.services.core.telegram_commands.settings"
+                "src.services.core.start_command_router.settings"  # app settings
             ) as mock_app_settings:
                 mock_app_settings.OAUTH_REDIRECT_BASE_URL = "https://example.com"
 
-                await handlers.handle_start(mock_update, Mock())
+                await handlers.handle_start(mock_update, mock_context)
 
         call_args = mock_update.message.reply_text.call_args
         assert "Open Storyline" in str(call_args)
         assert "Welcome back" in str(call_args)
 
     async def test_start_no_oauth_url_shows_text_fallback(self, mock_command_handlers):
-        """When OAUTH_REDIRECT_BASE_URL is not set, show text command list."""
+        """When OAUTH_REDIRECT_BASE_URL is not set, show text command list in group."""
         handlers = mock_command_handlers
         service = handlers.service
 
@@ -1357,7 +1363,10 @@ class TestStartCommand:
         mock_update.effective_user.first_name = "Test"
         mock_update.effective_user.username = "testuser"
         mock_update.effective_chat.id = -100123
+        mock_update.effective_chat.type = "group"
         mock_update.message.message_id = 1
+        mock_context = Mock()
+        mock_context.args = []
 
         with patch(
             "src.services.core.settings_service.SettingsService"
@@ -1369,11 +1378,11 @@ class TestStartCommand:
             mock_settings_instance.get_settings.return_value = mock_chat_settings
 
             with patch(
-                "src.services.core.telegram_commands.settings"
+                "src.services.core.start_command_router.settings"  # app settings
             ) as mock_app_settings:
                 mock_app_settings.OAUTH_REDIRECT_BASE_URL = None
 
-                await handlers.handle_start(mock_update, Mock())
+                await handlers.handle_start(mock_update, mock_context)
 
         call_text = mock_update.message.reply_text.call_args[0][0]
         assert "/status" in call_text
@@ -1393,7 +1402,10 @@ class TestStartCommand:
         mock_update.effective_user.first_name = "Test"
         mock_update.effective_user.username = "testuser"
         mock_update.effective_chat.id = -100123
+        mock_update.effective_chat.type = "group"
         mock_update.message.message_id = 1
+        mock_context = Mock()
+        mock_context.args = []
 
         with patch(
             "src.services.core.settings_service.SettingsService"
@@ -1404,7 +1416,11 @@ class TestStartCommand:
             mock_chat_settings = Mock(onboarding_completed=True)
             mock_settings_instance.get_settings.return_value = mock_chat_settings
 
-            await handlers.handle_start(mock_update, Mock())
+            with patch(
+                "src.services.core.start_command_router.settings"  # app settings
+            ) as mock_app_settings:
+                mock_app_settings.OAUTH_REDIRECT_BASE_URL = "https://example.com"
+                await handlers.handle_start(mock_update, mock_context)
 
         service.interaction_service.log_command.assert_called_once()
         call_kwargs = service.interaction_service.log_command.call_args[1]


### PR DESCRIPTION
## Summary

- `get_settings()` now accepts `create_if_missing` parameter (default True). 8 group callback call sites flipped to False to prevent phantom DM `chat_settings` rows.
- New `StartCommandRouter` with 5-branch `/start` handler: group setup, startgroup deep link, DM onboarding, returning user instance list, resume in-progress onboarding.
- `ConversationService` wraps `onboarding_sessions` table for the DM naming -> awaiting_group -> complete state machine. Wired into `_handle_conversation_message()` for text input routing.
- Migration 024 cleans up existing phantom DM `chat_settings` rows where telegram_chat_id > 0 and no data references.

Closes #233

## Call site audit

8 callback handlers flipped to `create_if_missing=False`:
- telegram_accounts.py (2): account switch, batch caption update
- telegram_settings.py (3): settings edit start, schedule action, schedule confirm
- telegram_callbacks_queue.py (2): back button, cancel reject
- telegram_autopost.py (1): auto-post handler

## Test plan

- [x] All 1584 existing tests pass (no regressions)
- [x] Ruff lint + format clean
- [ ] Verify /start in group shows setup wizard (branch 2 - unchanged)
- [ ] Verify /start in DM with instances shows instance list (branch 4)
- [ ] Verify /start in DM with no instances starts onboarding (branch 5)
- [ ] Apply migration 024 on staging
- [ ] Verify no new phantom rows created after DM interactions