### PR TITLE
fix: replace deprecated datetime.utcnow() with timezone-aware alternatives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Replace deprecated `datetime.utcnow()` calls** (#249) — Replaced 30+ `datetime.utcnow()` calls across `src/services/` with timezone-aware `datetime.now(timezone.utc)`, eliminating Python 3.12 deprecation warnings. Inverted `.replace(tzinfo=None)` patterns to ensure consistent aware-to-aware datetime comparisons.
+
 ### Added
 
 - **AI caption generation** (#182) — New `CaptionService` generates Instagram Story captions using Claude API at queue time. Controlled by per-instance `enable_ai_captions` toggle. Generated captions are stored separately from manual captions on `media_items.generated_caption`, shown with a robot indicator in Telegram review, and include a "Regenerate Caption" button. Skips generation when a manual caption exists or ANTHROPIC_API_KEY is not configured. Non-blocking — API failures never prevent posting. Migration 026 adds the new columns.

--- a/src/services/base_service.py
+++ b/src/services/base_service.py
@@ -1,7 +1,7 @@
 """Base service class with automatic execution tracking and error handling."""
 
 from abc import ABC
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional, Dict, Any
 from uuid import UUID
 import traceback
@@ -131,7 +131,7 @@ class BaseService(ABC):
             context_metadata=metadata,
         )
 
-        started_at = datetime.utcnow()
+        started_at = datetime.now(timezone.utc)
 
         try:
             logger.info(
@@ -141,7 +141,7 @@ class BaseService(ABC):
             yield run_id  # Allow service to access run_id if needed
 
             # Success
-            completed_at = datetime.utcnow()
+            completed_at = datetime.now(timezone.utc)
             duration_ms = int((completed_at - started_at).total_seconds() * 1000)
 
             self.service_run_repo.complete_run(
@@ -154,7 +154,7 @@ class BaseService(ABC):
 
         except Exception as e:
             # Failure
-            completed_at = datetime.utcnow()
+            completed_at = datetime.now(timezone.utc)
             duration_ms = int((completed_at - started_at).total_seconds() * 1000)
 
             error_type = type(e).__name__

--- a/src/services/core/conversation_service.py
+++ b/src/services/core/conversation_service.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Optional
 
 from src.models.onboarding_session import OnboardingSession
@@ -29,7 +29,7 @@ class ConversationService(BaseService):
 
     def start_onboarding(self, user_id: str) -> OnboardingSession:
         """Start a new onboarding session (replaces any existing)."""
-        expires_at = datetime.utcnow() + timedelta(hours=ONBOARDING_TTL_HOURS)
+        expires_at = datetime.now(timezone.utc) + timedelta(hours=ONBOARDING_TTL_HOURS)
         session = self.onboarding_repo.create(
             user_id=user_id,
             expires_at=expires_at,
@@ -120,7 +120,7 @@ class ConversationService(BaseService):
             )
 
             try:
-                now = datetime.utcnow()
+                now = datetime.now(timezone.utc)
                 with InteractionRepository() as interaction_repo:
                     for session in expired:
                         duration_minutes = int(

--- a/src/services/core/dashboard_service.py
+++ b/src/services/core/dashboard_service.py
@@ -619,7 +619,7 @@ class DashboardService(BaseService):
         slot falls outside the window, it advances to the next open.
         """
         import random
-        from datetime import datetime, timedelta
+        from datetime import datetime, timedelta, timezone
 
         with self.track_execution(
             "get_schedule_preview",
@@ -639,10 +639,10 @@ class DashboardService(BaseService):
             )
             interval_seconds = (window_hours * 3600) / ppd if ppd else 3600
 
-            now = datetime.utcnow()
+            now = datetime.now(timezone.utc)
             last = chat_settings.last_post_sent_at
-            if last and last.tzinfo:
-                last = last.replace(tzinfo=None)
+            if last and last.tzinfo is None:
+                last = last.replace(tzinfo=timezone.utc)
             next_time = last + timedelta(seconds=interval_seconds) if last else now
 
             configured = self.category_mix_repo.get_current_mix_as_dict(

--- a/src/services/core/health_check.py
+++ b/src/services/core/health_check.py
@@ -1,6 +1,6 @@
 """Health check service - system health monitoring."""
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from src.services.base_service import BaseService
 from src.repositories.queue_repository import QueueRepository
@@ -94,7 +94,7 @@ class HealthCheckService(BaseService):
         return {
             "status": overall_status,
             "checks": checks,
-            "timestamp": datetime.utcnow().isoformat(),
+            "timestamp": datetime.now(timezone.utc).isoformat(),
         }
 
     def _check_database(self) -> dict:
@@ -209,7 +209,7 @@ class HealthCheckService(BaseService):
 
             # Alert if oldest item is very old
             if oldest_pending:
-                age = datetime.utcnow() - oldest_pending.created_at
+                age = datetime.now(timezone.utc) - oldest_pending.created_at
                 if age > timedelta(hours=self.MAX_PENDING_AGE_HOURS):
                     return {
                         "healthy": False,
@@ -327,7 +327,7 @@ class HealthCheckService(BaseService):
                 stale_threshold = timedelta(
                     seconds=settings.MEDIA_SYNC_INTERVAL_SECONDS * 3
                 )
-                if datetime.utcnow() - completed > stale_threshold:
+                if datetime.now(timezone.utc) - completed > stale_threshold:
                     return {
                         "healthy": False,
                         "message": (
@@ -661,7 +661,7 @@ class HealthCheckService(BaseService):
 
         if expires_in_days is not None and expires_in_days > 0:
             expiry_date = (
-                datetime.utcnow() + timedelta(days=expires_in_days)
+                datetime.now(timezone.utc) + timedelta(days=expires_in_days)
             ).strftime("%b %d")
             text += f"\n\nIf ignored, media sync will stop on {expiry_date}."
         else:

--- a/src/services/core/oauth_service.py
+++ b/src/services/core/oauth_service.py
@@ -2,7 +2,7 @@
 
 import json
 import secrets
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 from urllib.parse import urlencode
 
@@ -184,7 +184,7 @@ class OAuthService(BaseService):
             # Step 4: Create or update account
             ig_account_id = account_info["id"]
             ig_username = account_info["username"]
-            expires_at = datetime.utcnow() + timedelta(seconds=expires_in)
+            expires_at = datetime.now(timezone.utc) + timedelta(seconds=expires_in)
 
             existing = self.account_service.get_account_by_instagram_id(ig_account_id)
 

--- a/src/services/core/scheduler.py
+++ b/src/services/core/scheduler.py
@@ -1,6 +1,6 @@
 """Scheduler service - JIT posting schedule with per-slot media selection."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional, List, Union
 import random
 
@@ -53,7 +53,7 @@ class SchedulerService(BaseService):
             None — slot is due, no category preference
             False — slot is not due
         """
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
 
         if not self._in_posting_window(now, chat_settings):
             return False
@@ -63,10 +63,9 @@ class SchedulerService(BaseService):
 
         last_sent = chat_settings.last_post_sent_at
         if last_sent:
-            # ORM now declares timezone=True; strip tzinfo for naive UTC comparison
-            last_sent = (
-                last_sent.replace(tzinfo=None) if last_sent.tzinfo else last_sent
-            )
+            # DB may return naive UTC; normalize to aware
+            if last_sent.tzinfo is None:
+                last_sent = last_sent.replace(tzinfo=timezone.utc)
         if last_sent and (now - last_sent).total_seconds() < interval_seconds:
             return False  # Too soon
 
@@ -265,7 +264,7 @@ class SchedulerService(BaseService):
             # Create in-flight queue item
             queue_item = self.queue_repo.create(
                 media_item_id=str(media_item.id),
-                scheduled_for=datetime.utcnow(),
+                scheduled_for=datetime.now(timezone.utc),
                 chat_settings_id=str(chat_settings.id),
             )
 
@@ -276,7 +275,7 @@ class SchedulerService(BaseService):
 
             if success:
                 self.settings_service.update_last_post_sent_at(
-                    chat_settings.telegram_chat_id, datetime.utcnow()
+                    chat_settings.telegram_chat_id, datetime.now(timezone.utc)
                 )
 
             result = {
@@ -349,7 +348,7 @@ class SchedulerService(BaseService):
         """
         from src.repositories.history_repository import HistoryCreateParams
 
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         media_id = str(media_item.id)
         cs_id = str(chat_settings.id)
 

--- a/src/services/core/setup_state_service.py
+++ b/src/services/core/setup_state_service.py
@@ -1,6 +1,6 @@
 """Setup state service - unified setup status for Telegram and API."""
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from src.services.base_service import BaseService
 from src.services.core.instagram_account_service import InstagramAccountService
@@ -182,7 +182,7 @@ class SetupStateService(BaseService):
             if recent_posts:
                 last_post_at = recent_posts[0].posted_at.isoformat()
                 # Consider posting active if last post was within 48 hours
-                age = datetime.utcnow() - recent_posts[0].posted_at
+                age = datetime.now(timezone.utc) - recent_posts[0].posted_at
                 posting_active = age < timedelta(hours=48)
         except Exception:
             logger.debug("Failed to fetch queue/history for setup state")
@@ -254,7 +254,7 @@ def is_token_stale(token) -> bool:
     Shared utility used by SetupStateService and available for import
     elsewhere to avoid duplicating the staleness heuristic.
     """
-    if token.expires_at and token.expires_at < datetime.utcnow() - timedelta(
+    if token.expires_at and token.expires_at < datetime.now(timezone.utc) - timedelta(
         days=TOKEN_STALE_DAYS
     ):
         return True

--- a/src/services/core/telegram_autopost.py
+++ b/src/services/core/telegram_autopost.py
@@ -23,7 +23,7 @@ from src.services.core.telegram_utils import (
 )
 from src.utils.logger import logger
 from src.utils.resilience import telegram_edit_with_retry
-from datetime import datetime
+from datetime import datetime, timezone
 
 if TYPE_CHECKING:
     from src.services.core.telegram_service import TelegramService
@@ -322,7 +322,7 @@ class TelegramAutopostHandler:
             media_id=str(ctx.media_item.id),
             cloud_url=ctx.cloud_url,
             cloud_public_id=ctx.cloud_public_id,
-            cloud_uploaded_at=datetime.utcnow(),
+            cloud_uploaded_at=datetime.now(timezone.utc),
         )
 
         return True
@@ -447,14 +447,15 @@ class TelegramAutopostHandler:
 
     def _record_successful_post(self, ctx: AutopostContext, story_id: str) -> None:
         """Record a successful Instagram post in all relevant tables."""
+        now = datetime.now(timezone.utc)
         self.service.history_repo.create(
             HistoryCreateParams(
                 media_item_id=str(ctx.queue_item.media_item_id),
                 queue_item_id=ctx.queue_id,
                 queue_created_at=ctx.queue_item.created_at,
-                queue_deleted_at=datetime.utcnow(),
+                queue_deleted_at=now,
                 scheduled_for=ctx.queue_item.scheduled_for,
-                posted_at=datetime.utcnow(),
+                posted_at=now,
                 status="posted",
                 success=True,
                 posted_by_user_id=str(ctx.user.id),

--- a/src/services/core/telegram_callbacks_core.py
+++ b/src/services/core/telegram_callbacks_core.py
@@ -12,7 +12,7 @@ from src.config.settings import settings
 from src.repositories.history_repository import HistoryCreateParams
 from src.utils.logger import logger
 from src.utils.resilience import telegram_edit_with_retry
-from datetime import datetime
+from datetime import datetime, timezone
 
 if TYPE_CHECKING:
     from src.services.core.telegram_service import TelegramService
@@ -127,13 +127,14 @@ class TelegramCallbackCore:
 
     def _create_history_params(self, queue_id, queue_item, user, status, success):
         """Build HistoryCreateParams for a queue action."""
+        now = datetime.now(timezone.utc)
         return HistoryCreateParams(
             media_item_id=str(queue_item.media_item_id),
             queue_item_id=queue_id,
             queue_created_at=queue_item.created_at,
-            queue_deleted_at=datetime.utcnow(),
+            queue_deleted_at=now,
             scheduled_for=queue_item.scheduled_for,
-            posted_at=datetime.utcnow(),
+            posted_at=now,
             status=status,
             success=success,
             posted_by_user_id=str(user.id),

--- a/src/services/core/telegram_commands.py
+++ b/src/services/core/telegram_commands.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup
@@ -115,7 +115,7 @@ class TelegramCommandHandlers:
     def _get_last_posted_display(self, recent_posts) -> str:
         """Get formatted display for last post time."""
         if recent_posts:
-            time_diff = datetime.utcnow() - recent_posts[0].posted_at
+            time_diff = datetime.now(timezone.utc) - recent_posts[0].posted_at
             hours = int(time_diff.total_seconds() / 3600)
             return f"{hours}h ago" if hours > 0 else "< 1h ago"
         return "Never"
@@ -144,11 +144,11 @@ class TelegramCommandHandlers:
             if not last_sent:
                 return "Due now"
 
-            if last_sent.tzinfo:
-                last_sent = last_sent.replace(tzinfo=None)
+            if last_sent.tzinfo is None:
+                last_sent = last_sent.replace(tzinfo=timezone.utc)
 
             next_due = last_sent + timedelta(seconds=interval_seconds)
-            now = datetime.utcnow()
+            now = datetime.now(timezone.utc)
 
             if next_due <= now:
                 return "Due now"

--- a/src/services/integrations/backfill_downloader.py
+++ b/src/services/integrations/backfill_downloader.py
@@ -2,7 +2,7 @@
 
 import hashlib
 import mimetypes
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
@@ -124,7 +124,7 @@ class BackfillDownloader:
 
         # Set backfill tracking fields directly on the returned object
         media_item.instagram_media_id = ig_media_id
-        media_item.backfilled_at = datetime.utcnow()
+        media_item.backfilled_at = datetime.now(timezone.utc)
         self.service.media_repo.db.commit()
 
         logger.info(

--- a/src/services/integrations/cloud_storage.py
+++ b/src/services/integrations/cloud_storage.py
@@ -1,6 +1,6 @@
 """Cloud storage service for temporary media uploads (Cloudinary)."""
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Optional
 
@@ -124,7 +124,7 @@ class CloudStorageService(BaseService):
 
                 result = cloudinary.uploader.upload(upload_source, **upload_options)
 
-                uploaded_at = datetime.utcnow()
+                uploaded_at = datetime.now(timezone.utc)
                 expires_at = uploaded_at + timedelta(
                     hours=settings.CLOUD_UPLOAD_RETENTION_HOURS
                 )
@@ -283,7 +283,7 @@ class CloudStorageService(BaseService):
         ) as run_id:
             deleted_count = 0
             retention_hours = settings.CLOUD_UPLOAD_RETENTION_HOURS
-            cutoff = datetime.utcnow() - timedelta(hours=retention_hours)
+            cutoff = datetime.now(timezone.utc) - timedelta(hours=retention_hours)
 
             try:
                 # List all resources in the folder
@@ -301,7 +301,7 @@ class CloudStorageService(BaseService):
                             # Cloudinary format: "2024-01-11T12:00:00Z"
                             created_at = datetime.fromisoformat(
                                 created_at_str.replace("Z", "+00:00")
-                            ).replace(tzinfo=None)
+                            )
 
                             if created_at < cutoff:
                                 if self.delete_media(resource["public_id"]):

--- a/src/services/integrations/google_drive_oauth.py
+++ b/src/services/integrations/google_drive_oauth.py
@@ -2,7 +2,7 @@
 
 import json
 import secrets
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 from urllib.parse import urlencode
 
@@ -173,7 +173,7 @@ class GoogleDriveOAuthService(BaseService):
             chat_settings_id = str(chat_settings.id)
 
             # Step 4: Encrypt and store tokens
-            expires_at = datetime.utcnow() + timedelta(seconds=expires_in)
+            expires_at = datetime.now(timezone.utc) + timedelta(seconds=expires_in)
 
             self.token_repo.create_or_update_for_chat(
                 service_name=self.SERVICE_NAME,

--- a/src/services/integrations/instagram_api.py
+++ b/src/services/integrations/instagram_api.py
@@ -1,7 +1,7 @@
 """Instagram Graph API service for Story posting."""
 
 import asyncio
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 import httpx
@@ -159,7 +159,7 @@ class InstagramAPIService(BaseService):
                     "success": True,
                     "story_id": story_id,
                     "container_id": container_id,
-                    "timestamp": datetime.utcnow(),
+                    "timestamp": datetime.now(timezone.utc),
                     "account_username": account_username,
                     "account_id": account_id,
                 }
@@ -352,7 +352,7 @@ class InstagramAPIService(BaseService):
         Returns:
             Number of posts remaining in the current hour window
         """
-        since = datetime.utcnow() - timedelta(hours=1)
+        since = datetime.now(timezone.utc) - timedelta(hours=1)
         recent_api_posts = self.history_repo.count_by_method(
             method="instagram_api",
             since=since,

--- a/src/services/integrations/instagram_login_oauth.py
+++ b/src/services/integrations/instagram_login_oauth.py
@@ -9,7 +9,7 @@ This is separate from OAuthService (Facebook Login) and coexists alongside it.
 
 import json
 import secrets
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 import httpx
@@ -176,7 +176,7 @@ class InstagramLoginOAuthService(BaseService):
             username = await self._get_username(long_token, ig_user_id)
 
             # Step 4: Create or update account
-            expires_at = datetime.utcnow() + timedelta(seconds=expires_in)
+            expires_at = datetime.now(timezone.utc) + timedelta(seconds=expires_in)
             existing = self.account_service.get_account_by_instagram_id(ig_user_id)
 
             if existing:

--- a/src/services/integrations/token_refresh.py
+++ b/src/services/integrations/token_refresh.py
@@ -1,6 +1,6 @@
 """Token refresh service for managing OAuth tokens."""
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 import httpx
@@ -144,7 +144,7 @@ class TokenRefreshService(BaseService):
 
             # Meta long-lived tokens expire after 60 days
             # We don't know the exact issue date, so assume issued now
-            issued_at = datetime.utcnow()
+            issued_at = datetime.now(timezone.utc)
             expires_at = issued_at + timedelta(days=60)
 
             # Store in database
@@ -265,7 +265,7 @@ class TokenRefreshService(BaseService):
                         return False
 
                     # Store the new token
-                    issued_at = datetime.utcnow()
+                    issued_at = datetime.now(timezone.utc)
                     expires_at = issued_at + timedelta(seconds=expires_in)
 
                     encrypted = self.encryption.encrypt(new_token)

--- a/tests/src/services/test_health_check.py
+++ b/tests/src/services/test_health_check.py
@@ -2,7 +2,7 @@
 
 import pytest
 from unittest.mock import Mock, patch
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from src.services.core.health_check import HealthCheckService
 
@@ -98,7 +98,7 @@ class TestHealthCheckService:
 
         # Create mock old queue item
         old_item = Mock()
-        old_item.created_at = datetime.utcnow() - timedelta(hours=8)
+        old_item.created_at = datetime.now(timezone.utc) - timedelta(hours=8)
         health_service.queue_repo.get_oldest_pending.return_value = old_item
 
         result = health_service._check_queue()
@@ -260,8 +260,8 @@ class TestHealthCheckService:
         mock_settings.MEDIA_SYNC_INTERVAL_SECONDS = 300
 
         mock_sync_info = {
-            "started_at": datetime.utcnow().isoformat(),
-            "completed_at": datetime.utcnow().isoformat(),
+            "started_at": datetime.now(timezone.utc).isoformat(),
+            "completed_at": datetime.now(timezone.utc).isoformat(),
             "success": True,
             "status": "completed",
             "result": {"new": 2, "errors": 0},
@@ -322,7 +322,7 @@ class TestHealthCheckService:
         mock_settings.MEDIA_SYNC_INTERVAL_SECONDS = 300  # 5 min
 
         # Last sync was 30 minutes ago (6x the interval)
-        old_time = datetime.utcnow() - timedelta(minutes=30)
+        old_time = datetime.now(timezone.utc) - timedelta(minutes=30)
         mock_sync_info = {
             "started_at": old_time.isoformat(),
             "completed_at": old_time.isoformat(),
@@ -382,7 +382,7 @@ class TestHealthCheckService:
         mock_settings.MEDIA_SOURCE_ROOT = "/media/stories"
 
         mock_sync_info = {
-            "started_at": datetime.utcnow().isoformat(),
+            "started_at": datetime.now(timezone.utc).isoformat(),
             "completed_at": None,
             "success": False,
             "status": "failed",

--- a/tests/src/services/test_instagram_api.py
+++ b/tests/src/services/test_instagram_api.py
@@ -2,7 +2,7 @@
 
 import pytest
 from unittest.mock import Mock, patch, AsyncMock
-from datetime import datetime
+from datetime import datetime, timezone
 
 import httpx
 
@@ -104,7 +104,7 @@ class TestInstagramAPIService:
         assert call_args[1]["method"] == "instagram_api"
         since = call_args[1]["since"]
         # Should be approximately 1 hour ago
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         assert (now - since).total_seconds() < 3610  # Within ~1 hour
 
     # ==================== get_rate_limit_status Tests ====================

--- a/tests/src/services/test_scheduler.py
+++ b/tests/src/services/test_scheduler.py
@@ -1,7 +1,7 @@
 """Tests for SchedulerService (JIT model)."""
 
 import pytest
-from datetime import datetime
+from datetime import datetime, timezone
 from decimal import Decimal
 from unittest.mock import AsyncMock, Mock, patch
 from uuid import uuid4
@@ -74,7 +74,7 @@ class TestIsSlotDue:
         )
 
         with patch("src.services.core.scheduler.datetime") as mock_dt:
-            mock_dt.utcnow.return_value = datetime(2026, 3, 21, 12, 0)
+            mock_dt.now.return_value = datetime(2026, 3, 21, 12, 0, tzinfo=timezone.utc)
             result = service.is_slot_due(cs)
 
         # Should be due (None = no category preference)
@@ -89,7 +89,7 @@ class TestIsSlotDue:
         )
 
         with patch("src.services.core.scheduler.datetime") as mock_dt:
-            mock_dt.utcnow.return_value = datetime(2026, 3, 21, 20, 0)
+            mock_dt.now.return_value = datetime(2026, 3, 21, 20, 0, tzinfo=timezone.utc)
             result = service.is_slot_due(cs)
 
         assert result is False
@@ -107,7 +107,7 @@ class TestIsSlotDue:
 
         with patch("src.services.core.scheduler.datetime") as mock_dt:
             # Only 1 hour since last post, interval is 4 hours
-            mock_dt.utcnow.return_value = datetime(2026, 3, 21, 12, 0)
+            mock_dt.now.return_value = datetime(2026, 3, 21, 12, 0, tzinfo=timezone.utc)
             result = service.is_slot_due(cs)
 
         assert result is False
@@ -127,7 +127,7 @@ class TestIsSlotDue:
 
         with patch("src.services.core.scheduler.datetime") as mock_dt:
             # 5 hours since last post, interval is 4 hours -> due
-            mock_dt.utcnow.return_value = datetime(2026, 3, 21, 13, 0)
+            mock_dt.now.return_value = datetime(2026, 3, 21, 13, 0, tzinfo=timezone.utc)
             result = service.is_slot_due(cs)
 
         # No category ratios -> None (due, no preference)
@@ -146,7 +146,7 @@ class TestIsSlotDue:
         )
 
         with patch("src.services.core.scheduler.datetime") as mock_dt:
-            mock_dt.utcnow.return_value = datetime(2026, 3, 21, 23, 0)
+            mock_dt.now.return_value = datetime(2026, 3, 21, 23, 0, tzinfo=timezone.utc)
             result = service.is_slot_due(cs)
 
         assert result is not False
@@ -165,7 +165,7 @@ class TestIsSlotDue:
 
         with patch("src.services.core.scheduler.datetime") as mock_dt:
             # Only 2 hours since last post, interval is 12 hours
-            mock_dt.utcnow.return_value = datetime(2026, 3, 21, 11, 0)
+            mock_dt.now.return_value = datetime(2026, 3, 21, 11, 0, tzinfo=timezone.utc)
             result = service.is_slot_due(cs)
 
         assert result is False
@@ -186,7 +186,7 @@ class TestIsSlotDue:
         )
 
         with patch("src.services.core.scheduler.datetime") as mock_dt:
-            mock_dt.utcnow.return_value = datetime(2026, 3, 21, 12, 0)
+            mock_dt.now.return_value = datetime(2026, 3, 21, 12, 0, tzinfo=timezone.utc)
             result = service.is_slot_due(cs)
 
         assert isinstance(result, str)

--- a/tests/src/services/test_setup_state_service.py
+++ b/tests/src/services/test_setup_state_service.py
@@ -1,6 +1,6 @@
 """Tests for SetupStateService."""
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 from unittest.mock import Mock, patch
@@ -92,7 +92,7 @@ class TestGetSetupState:
         """Fresh Google Drive token shows connected, not needing reconnect."""
         self.service.token_repo.get_token_for_chat.return_value = Mock(
             token_metadata={"email": "user@gmail.com"},
-            expires_at=datetime.utcnow() + timedelta(hours=1),
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
         )
 
         state = self.service.get_setup_state(-1001234567890)
@@ -105,7 +105,8 @@ class TestGetSetupState:
         """Token expired > 7 days ago triggers needs_reconnect."""
         self.service.token_repo.get_token_for_chat.return_value = Mock(
             token_metadata={"email": "old@gmail.com"},
-            expires_at=datetime.utcnow() - timedelta(days=TOKEN_STALE_DAYS + 1),
+            expires_at=datetime.now(timezone.utc)
+            - timedelta(days=TOKEN_STALE_DAYS + 1),
         )
 
         state = self.service.get_setup_state(-1001234567890)
@@ -134,7 +135,7 @@ class TestGetSetupState:
     def test_posting_active(self):
         """Recent post within 48h makes posting_active True."""
         self.service.history_repo.get_recent_posts.return_value = [
-            Mock(posted_at=datetime.utcnow() - timedelta(hours=1)),
+            Mock(posted_at=datetime.now(timezone.utc) - timedelta(hours=1)),
         ]
 
         state = self.service.get_setup_state(-1001234567890)
@@ -159,20 +160,20 @@ class TestIsTokenStale:
 
     def test_fresh_token_not_stale(self):
         """Token expiring in the future is not stale."""
-        token = Mock(expires_at=datetime.utcnow() + timedelta(hours=1))
+        token = Mock(expires_at=datetime.now(timezone.utc) + timedelta(hours=1))
         assert is_token_stale(token) is False
 
     def test_recently_expired_not_stale(self):
         """Token expired within 7 days is not stale."""
         token = Mock(
-            expires_at=datetime.utcnow() - timedelta(days=TOKEN_STALE_DAYS - 1)
+            expires_at=datetime.now(timezone.utc) - timedelta(days=TOKEN_STALE_DAYS - 1)
         )
         assert is_token_stale(token) is False
 
     def test_expired_over_threshold_is_stale(self):
         """Token expired > 7 days ago is stale."""
         token = Mock(
-            expires_at=datetime.utcnow() - timedelta(days=TOKEN_STALE_DAYS + 1)
+            expires_at=datetime.now(timezone.utc) - timedelta(days=TOKEN_STALE_DAYS + 1)
         )
         assert is_token_stale(token) is True
 

--- a/tests/src/services/test_telegram_commands.py
+++ b/tests/src/services/test_telegram_commands.py
@@ -2,7 +2,7 @@
 
 import pytest
 from unittest.mock import Mock, patch, AsyncMock
-from datetime import datetime
+from datetime import datetime, timezone
 from uuid import uuid4
 
 from src.services.core.telegram_commands import TelegramCommandHandlers
@@ -295,7 +295,7 @@ class TestGetNextPostDisplay:
             posting_hours_start=12,
             posting_hours_end=4,
             posts_per_day=15,
-            last_post_sent_at=datetime.utcnow(),
+            last_post_sent_at=datetime.now(timezone.utc),
         )
         result = TelegramCommandHandlers._get_next_post_display(mock_settings)
         assert "UTC" in result
@@ -322,14 +322,13 @@ class TestGetLastPostedDisplay:
         """Test shows hours ago for recent posts."""
         handlers = mock_command_handlers
         mock_post = Mock()
-        mock_post.posted_at = datetime.utcnow().replace(
-            hour=max(datetime.utcnow().hour - 3, 0)
-        )
 
         # Use a fixed time difference to avoid test flakiness
         with patch("src.services.core.telegram_commands.datetime") as mock_dt:
-            mock_dt.utcnow.return_value = datetime(2026, 3, 15, 15, 0, 0)
-            mock_post.posted_at = datetime(2026, 3, 15, 12, 0, 0)
+            mock_dt.now.return_value = datetime(
+                2026, 3, 15, 15, 0, 0, tzinfo=timezone.utc
+            )
+            mock_post.posted_at = datetime(2026, 3, 15, 12, 0, 0, tzinfo=timezone.utc)
             result = handlers._get_last_posted_display([mock_post])
 
         assert result == "3h ago"
@@ -340,8 +339,10 @@ class TestGetLastPostedDisplay:
         mock_post = Mock()
 
         with patch("src.services.core.telegram_commands.datetime") as mock_dt:
-            mock_dt.utcnow.return_value = datetime(2026, 3, 15, 15, 0, 0)
-            mock_post.posted_at = datetime(2026, 3, 15, 14, 45, 0)
+            mock_dt.now.return_value = datetime(
+                2026, 3, 15, 15, 0, 0, tzinfo=timezone.utc
+            )
+            mock_post.posted_at = datetime(2026, 3, 15, 14, 45, 0, tzinfo=timezone.utc)
             result = handlers._get_last_posted_display([mock_post])
 
         assert result == "< 1h ago"
@@ -807,7 +808,7 @@ class TestSetupStatusGoogleDrive:
 
         mock_token = Mock()
         # Expired 10 days ago (>7 day threshold)
-        mock_token.expires_at = datetime.utcnow() - timedelta(days=10)
+        mock_token.expires_at = datetime.now(timezone.utc) - timedelta(days=10)
         assert is_token_stale(mock_token) is True
 
     def test_gdrive_recently_expired_not_stale(self):
@@ -818,7 +819,7 @@ class TestSetupStatusGoogleDrive:
 
         mock_token = Mock()
         # Expired 2 days ago (within 7 day threshold)
-        mock_token.expires_at = datetime.utcnow() - timedelta(days=2)
+        mock_token.expires_at = datetime.now(timezone.utc) - timedelta(days=2)
         assert is_token_stale(mock_token) is False
 
 

--- a/tests/src/services/test_token_refresh.py
+++ b/tests/src/services/test_token_refresh.py
@@ -2,7 +2,7 @@
 
 import pytest
 from unittest.mock import Mock, patch, AsyncMock
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from src.exceptions import TokenExpiredError
 from tests.src.services.conftest import mock_track_execution
@@ -35,13 +35,13 @@ class TestTokenRefreshService:
         token = Mock()
         token.token_value = "encrypted_token_value"
         token.is_expired = False
-        token.expires_at = datetime.utcnow() + timedelta(days=30)
-        token.last_refreshed_at = datetime.utcnow() - timedelta(days=10)
+        token.expires_at = datetime.now(timezone.utc) + timedelta(days=30)
+        token.last_refreshed_at = datetime.now(timezone.utc) - timedelta(days=10)
 
         def hours_until_expiry():
             if token.expires_at is None:
                 return None
-            delta = token.expires_at - datetime.utcnow()
+            delta = token.expires_at - datetime.now(timezone.utc)
             return delta.total_seconds() / 3600
 
         token.hours_until_expiry = hours_until_expiry
@@ -156,9 +156,9 @@ class TestTokenRefreshService:
         mock_settings.INSTAGRAM_ACCESS_TOKEN = "token"
         token_service._encryption.encrypt.return_value = "encrypted"
 
-        before_call = datetime.utcnow()
+        before_call = datetime.now(timezone.utc)
         token_service.bootstrap_from_env("instagram")
-        after_call = datetime.utcnow()
+        after_call = datetime.now(timezone.utc)
 
         call_kwargs = token_service.token_repo.create_or_update.call_args[1]
         expires_at = call_kwargs["expires_at"]
@@ -176,7 +176,7 @@ class TestTokenRefreshService:
 
     def test_check_token_health_valid_token(self, token_service, mock_db_token):
         """Test health check for valid token."""
-        mock_db_token.expires_at = datetime.utcnow() + timedelta(days=30)
+        mock_db_token.expires_at = datetime.now(timezone.utc) + timedelta(days=30)
         token_service.token_repo.get_token.return_value = mock_db_token
 
         result = token_service.check_token_health("instagram")
@@ -190,7 +190,7 @@ class TestTokenRefreshService:
     def test_check_token_health_expired_token(self, token_service, mock_db_token):
         """Test health check for expired token."""
         mock_db_token.is_expired = True
-        mock_db_token.expires_at = datetime.utcnow() - timedelta(days=1)
+        mock_db_token.expires_at = datetime.now(timezone.utc) - timedelta(days=1)
         token_service.token_repo.get_token.return_value = mock_db_token
 
         result = token_service.check_token_health("instagram")
@@ -202,7 +202,7 @@ class TestTokenRefreshService:
     def test_check_token_health_needs_refresh(self, token_service, mock_db_token):
         """Test health check identifies tokens needing refresh."""
         # Token expires in 5 days (within 7-day buffer)
-        mock_db_token.expires_at = datetime.utcnow() + timedelta(days=5)
+        mock_db_token.expires_at = datetime.now(timezone.utc) + timedelta(days=5)
         token_service.token_repo.get_token.return_value = mock_db_token
 
         result = token_service.check_token_health("instagram")
@@ -213,7 +213,7 @@ class TestTokenRefreshService:
     def test_check_token_health_no_refresh_needed(self, token_service, mock_db_token):
         """Test health check when token doesn't need refresh."""
         # Token expires in 30 days (outside 7-day buffer)
-        mock_db_token.expires_at = datetime.utcnow() + timedelta(days=30)
+        mock_db_token.expires_at = datetime.now(timezone.utc) + timedelta(days=30)
         token_service.token_repo.get_token.return_value = mock_db_token
 
         result = token_service.check_token_health("instagram")
@@ -253,7 +253,7 @@ class TestTokenRefreshService:
     ):
         """Access token expired + valid refresh token = healthy (auto-refreshable)."""
         mock_db_token.is_expired = True
-        mock_db_token.expires_at = datetime.utcnow() - timedelta(hours=1)
+        mock_db_token.expires_at = datetime.now(timezone.utc) - timedelta(hours=1)
 
         refresh_token = Mock()
         refresh_token.expires_at = None  # Refresh tokens don't expire
@@ -277,7 +277,7 @@ class TestTokenRefreshService:
     ):
         """Access token expired + no refresh token = unhealthy."""
         mock_db_token.is_expired = True
-        mock_db_token.expires_at = datetime.utcnow() - timedelta(hours=1)
+        mock_db_token.expires_at = datetime.now(timezone.utc) - timedelta(hours=1)
 
         token_service.token_repo.get_token_for_chat.side_effect = (
             lambda svc, token_type, cid: (
@@ -297,10 +297,10 @@ class TestTokenRefreshService:
     ):
         """Both access and refresh tokens expired = unhealthy."""
         mock_db_token.is_expired = True
-        mock_db_token.expires_at = datetime.utcnow() - timedelta(hours=1)
+        mock_db_token.expires_at = datetime.now(timezone.utc) - timedelta(hours=1)
 
         refresh_token = Mock()
-        refresh_token.expires_at = datetime.utcnow() - timedelta(days=1)
+        refresh_token.expires_at = datetime.now(timezone.utc) - timedelta(days=1)
         refresh_token.is_expired = True
 
         token_service.token_repo.get_token_for_chat.side_effect = (


### PR DESCRIPTION
## Summary

- Replace all 30+ `datetime.utcnow()` calls across `src/services/` (16 files + `base_service.py`) with `datetime.now(timezone.utc)`, eliminating Python 3.12 deprecation warnings
- Invert `.replace(tzinfo=None)` patterns to `.replace(tzinfo=timezone.utc)` where comparisons need both sides timezone-aware
- Update 6 test files with aware mock values and `mock.now` instead of `mock.utcnow`
- Extract single `now` variable in `HistoryCreateParams` constructors to avoid redundant calls

## Test plan

- [x] All 1618 tests pass (0 failures, 16 skipped)
- [x] Verified zero remaining `datetime.utcnow()` or `utcnow` references in `src/services/`
- [x] `/simplify` review completed — fixed redundant calls, dead test code, comment quality
- [x] Naive/aware comparison points validated via test suite (mocks use `tzinfo=timezone.utc`)

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)