### PR TITLE
refactor: extract TelegramService god class into focused handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **TelegramService god class refactor** (#251) — Broke 804-line `TelegramService` into thin orchestrator (496 lines) plus 4 focused handler classes: `OperationStateManager`, `TelegramUserManager`, `TelegramMembershipHandler`, `TelegramLifecycleHandler`. Consolidated duplicate `_escape_markdown` into `telegram_utils.py`.
+
 ### Fixed
 
 - **Narrow broad `except Exception` catches** (#250) — Audited 88 `except Exception` catches across `src/services/`. Narrowed catches to specific types (`TelegramError`, `SQLAlchemyError`, `InvalidToken`, etc.) where failure modes are known. Added `noqa: BLE001` annotations with justification comments to intentionally broad catches (best-effort logging, cleanup, health checks). Added `exc_info=True` to health check error handlers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Test coverage for 7 untested service modules** (#252) — 110 unit tests covering `telegram_callbacks_core`, `telegram_callbacks_queue`, `telegram_callbacks_admin`, `conversation_service`, `start_command_router`, `user_service`, and `backfill_downloader`. Shared test helpers (`make_query`, `make_user`, `noop_context_manager`) added to `conftest.py`.
+
 ### Changed
 
 - **TelegramService god class refactor** (#251) — Broke 804-line `TelegramService` into thin orchestrator (496 lines) plus 4 focused handler classes: `OperationStateManager`, `TelegramUserManager`, `TelegramMembershipHandler`, `TelegramLifecycleHandler`. Consolidated duplicate `_escape_markdown` into `telegram_utils.py`.

--- a/src/services/core/telegram_callbacks_queue.py
+++ b/src/services/core/telegram_callbacks_queue.py
@@ -8,8 +8,8 @@ from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 
 from sqlalchemy.exc import OperationalError
 
-from src.services.core.telegram_service import _escape_markdown
 from src.services.core.telegram_utils import (
+    escape_markdown as _escape_markdown,
     build_queue_action_keyboard,
     validate_queue_and_media,
     validate_queue_item,

--- a/src/services/core/telegram_lifecycle.py
+++ b/src/services/core/telegram_lifecycle.py
@@ -1,0 +1,95 @@
+"""Lifecycle notifications for the Telegram bot (startup/shutdown)."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from src.config.settings import settings
+from src.utils.logger import logger
+from src import __version__
+
+if TYPE_CHECKING:
+    from src.services.core.telegram_service import TelegramService
+
+
+class TelegramLifecycleHandler:
+    """Sends startup and shutdown notifications to the admin chat."""
+
+    def __init__(self, service: TelegramService):
+        self.service = service
+
+    async def send_startup_notification(self):
+        """Send startup notification to admin with system status."""
+        if not settings.SEND_LIFECYCLE_NOTIFICATIONS:
+            return
+
+        try:
+            pending_count = self.service.queue_repo.count_pending()
+            media_count = len(self.service.media_repo.get_all(is_active=True))
+            recent_posts = self.service.history_repo.get_recent_posts(hours=24)
+            last_post_time = recent_posts[0].posted_at if recent_posts else None
+
+            if last_post_time:
+                time_diff = datetime.utcnow() - last_post_time
+                hours = int(time_diff.total_seconds() / 3600)
+                last_posted = f"{hours}h ago" if hours > 0 else "< 1h ago"
+            else:
+                last_posted = "Never"
+
+            message = (
+                f"🟢 *Storyline AI Started*\n\n"
+                f"📊 *System Status:*\n"
+                f"├─ Database: ✅ Connected\n"
+                f"├─ Telegram: ✅ Bot online\n"
+                f"├─ Queue: {pending_count} pending posts\n"
+                f"└─ Last posted: {last_posted}\n\n"
+                f"⚙️ *Configuration:*\n"
+                f"├─ Posts/day: {settings.POSTS_PER_DAY}\n"
+                f"├─ Window: {settings.POSTING_HOURS_START:02d}:00-{settings.POSTING_HOURS_END:02d}:00 UTC\n"
+                f"└─ Media indexed: {media_count} items\n\n"
+                f"🤖 v{__version__}"
+            )
+
+            await self.service.bot.send_message(
+                chat_id=self.service.admin_chat_id,
+                text=message,
+                parse_mode="Markdown",
+            )
+
+            logger.info("Startup notification sent to admin")
+
+        except Exception as e:  # noqa: BLE001
+            logger.error(f"Failed to send startup notification: {e}")
+
+    async def send_shutdown_notification(
+        self, uptime_seconds: int = 0, posts_sent: int = 0
+    ):
+        """Send shutdown notification to admin with session summary."""
+        if not settings.SEND_LIFECYCLE_NOTIFICATIONS:
+            return
+
+        try:
+            hours = int(uptime_seconds / 3600)
+            minutes = int((uptime_seconds % 3600) / 60)
+            uptime_str = f"{hours}h {minutes}m"
+
+            message = (
+                f"🔴 *Storyline AI Stopped*\n\n"
+                f"📊 *Session Summary:*\n"
+                f"├─ Uptime: {uptime_str}\n"
+                f"├─ Posts sent: {posts_sent}\n"
+                f"└─ Shutdown: Graceful\n\n"
+                f"See you next time! 👋"
+            )
+
+            await self.service.bot.send_message(
+                chat_id=self.service.admin_chat_id,
+                text=message,
+                parse_mode="Markdown",
+            )
+
+            logger.info("Shutdown notification sent to admin")
+
+        except Exception as e:  # noqa: BLE001
+            logger.error(f"Failed to send shutdown notification: {e}")

--- a/src/services/core/telegram_lifecycle.py
+++ b/src/services/core/telegram_lifecycle.py
@@ -31,7 +31,7 @@ class TelegramLifecycleHandler:
             last_post_time = recent_posts[0].posted_at if recent_posts else None
 
             if last_post_time:
-                time_diff = datetime.utcnow() - last_post_time
+                time_diff = datetime.now(timezone.utc) - last_post_time
                 hours = int(time_diff.total_seconds() / 3600)
                 last_posted = f"{hours}h ago" if hours > 0 else "< 1h ago"
             else:

--- a/src/services/core/telegram_lifecycle.py
+++ b/src/services/core/telegram_lifecycle.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 from src.config.settings import settings

--- a/src/services/core/telegram_membership.py
+++ b/src/services/core/telegram_membership.py
@@ -1,0 +1,184 @@
+"""Chat membership event handling for the Telegram bot.
+
+Handles ChatMemberUpdated events: bot added to group (auto-link onboarding),
+bot removed from group (deactivate memberships), and DM onboarding messages.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import TYPE_CHECKING
+
+from src.utils.logger import logger
+
+if TYPE_CHECKING:
+    from src.services.core.telegram_service import TelegramService
+
+
+class TelegramMembershipHandler:
+    """Handles bot membership changes and onboarding conversation flow."""
+
+    def __init__(self, service: TelegramService):
+        self.service = service
+
+    async def handle_my_chat_member(self, update, context):
+        """Handle ChatMemberUpdated events for the bot itself.
+
+        Fires when the bot's membership status changes in any chat:
+        - Bot added to group -> auto-link pending onboarding session
+        - Bot kicked from group -> deactivate all memberships for that chat
+        """
+        member_update = update.my_chat_member
+        if not member_update:
+            return
+
+        chat = member_update.chat
+        if chat.type not in ("group", "supergroup"):
+            return
+
+        old_status = member_update.old_chat_member.status
+        new_status = member_update.new_chat_member.status
+        from_user = member_update.from_user
+
+        if from_user is None:
+            logger.info(
+                f"Bot membership changed in group {chat.id} by anonymous admin "
+                f"— skipping auto-link (use /link)"
+            )
+            return
+
+        try:
+            if new_status in ("member", "administrator") and old_status in (
+                "left",
+                "kicked",
+            ):
+                await self._handle_bot_added_to_group(chat, from_user)
+            elif new_status in ("left", "kicked") and old_status in (
+                "member",
+                "administrator",
+            ):
+                self._handle_bot_removed_from_group(chat)
+        except Exception as e:  # noqa: BLE001
+            logger.error(
+                f"my_chat_member handler error for chat {chat.id}: "
+                f"{type(e).__name__}: {e}",
+                exc_info=True,
+            )
+        finally:
+            self.service.cleanup_transactions()
+
+    async def _handle_bot_added_to_group(self, chat, from_user):
+        """Bot was added to a group — check for pending onboarding session to auto-link."""
+        from src.services.core.conversation_service import ConversationService
+
+        user = self.service._get_or_create_user(from_user)
+
+        # Race condition guard: the onboarding session may not be committed yet
+        # if the user clicked "Add to Group" very quickly after naming.
+        session = None
+        for attempt in range(2):
+            with ConversationService() as conv_service:
+                session = conv_service.get_current_session(str(user.id))
+            if session and session.step == "awaiting_group":
+                break
+            if attempt == 0:
+                await asyncio.sleep(2)
+
+        if not session or session.step != "awaiting_group":
+            logger.info(
+                f"Bot added to group {chat.id} by user {from_user.id} "
+                f"— no pending onboarding session"
+            )
+            return
+
+        with ConversationService() as conv_service:
+            conv_service.link_group_to_instance(
+                session=session,
+                chat_id=chat.id,
+                user_id=str(user.id),
+                membership_repo=self.service.membership_repo,
+            )
+
+        name = session.pending_instance_name or "this group"
+        logger.info(
+            f"Auto-linked instance '{name}' to group {chat.id} "
+            f"via my_chat_member (user {from_user.id})"
+        )
+
+        try:
+            await self.service.bot.send_message(
+                chat_id=from_user.id,
+                text=(
+                    f"✅ *{name}* is linked to your group!\n\n"
+                    "Use /start here to manage your instances."
+                ),
+                parse_mode="Markdown",
+            )
+        except Exception:  # noqa: BLE001
+            pass  # DM may be blocked
+
+    def _handle_bot_removed_from_group(self, chat):
+        """Bot was kicked from a group — deactivate all memberships."""
+        chat_settings = self.service.settings_service.get_settings_if_exists(chat.id)
+        if not chat_settings:
+            return
+
+        count = self.service.membership_repo.deactivate_for_chat(str(chat_settings.id))
+        evicted = self.service.user_manager.evict_memberships_for_chat(chat.id)
+
+        logger.info(
+            f"Bot removed from group {chat.id} — "
+            f"deactivated {count} membership(s), evicted {evicted} cache entries"
+        )
+
+    async def handle_onboarding_message(self, update, context):
+        """Handle text input during DM onboarding (naming step)."""
+        from src.services.core.conversation_service import ConversationService
+
+        session_id = context.user_data.get("onboarding_session_id")
+        if not session_id:
+            return
+
+        with ConversationService() as conv_service:
+            session = conv_service.get_session_by_id(session_id)
+
+        if not session or session.step == "complete":
+            context.user_data.pop("onboarding_session_id", None)
+            return
+
+        if session.step == "naming":
+            instance_name = update.message.text.strip()[:100]
+            if not instance_name:
+                await update.message.reply_text(
+                    "Please enter a name for your instance."
+                )
+                return
+
+            with ConversationService() as conv_service:
+                conv_service.set_instance_name(str(session.id), instance_name)
+
+            bot_username = (await self.service.bot.get_me()).username
+            startgroup_url = (
+                f"https://t.me/{bot_username}?startgroup=setup_{session.id}"
+            )
+
+            from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+
+            keyboard = InlineKeyboardMarkup(
+                [
+                    [InlineKeyboardButton("Add to Group Chat", url=startgroup_url)],
+                ]
+            )
+            await update.message.reply_text(
+                f"Great! *{instance_name}* it is.\n\n"
+                "Now add me to the group chat where your team will review posts.\n\n"
+                "Bot already in your group? Run `/link` in that group.",
+                parse_mode="Markdown",
+                reply_markup=keyboard,
+            )
+        elif session.step == "awaiting_group":
+            await update.message.reply_text(
+                "Still waiting to link your group — add me to the group chat, "
+                "or run `/link` in that group if I'm already there.",
+                parse_mode="Markdown",
+            )

--- a/src/services/core/telegram_notification.py
+++ b/src/services/core/telegram_notification.py
@@ -1,9 +1,8 @@
 """Notification sending and caption building for Telegram."""
 
-import re
-
 from src.config.settings import settings
 from src.exceptions.google_drive import GoogleDriveAuthError
+from src.services.core.telegram_utils import escape_markdown as _escape_md
 from src.utils.logger import logger
 
 
@@ -23,11 +22,6 @@ def _is_google_auth_error(exc: Exception) -> bool:
             return True
         current = getattr(current, "__cause__", None)
     return False
-
-
-def _escape_md(text: str) -> str:
-    """Escape Telegram Markdown special characters in user-generated text."""
-    return re.sub(r"([_*`\[])", r"\\\1", text)
 
 
 def _extract_button_labels(reply_markup) -> list:

--- a/src/services/core/telegram_operation_state.py
+++ b/src/services/core/telegram_operation_state.py
@@ -1,0 +1,33 @@
+"""Operation state management for Telegram callback handlers.
+
+Manages per-queue-item asyncio locks and cancellation flags that prevent
+duplicate actions from rapid button clicks and allow terminal actions
+(Posted/Skip/Reject) to abort background tasks like auto-posting.
+"""
+
+import asyncio
+
+
+class OperationStateManager:
+    """Manages per-queue-item operation locks and cancellation flags."""
+
+    def __init__(self):
+        self._operation_locks: dict[str, asyncio.Lock] = {}
+        self._cancel_flags: dict[str, asyncio.Event] = {}
+
+    def get_lock(self, queue_id: str) -> asyncio.Lock:
+        """Get or create an asyncio lock for a queue item."""
+        if queue_id not in self._operation_locks:
+            self._operation_locks[queue_id] = asyncio.Lock()
+        return self._operation_locks[queue_id]
+
+    def get_cancel_flag(self, queue_id: str) -> asyncio.Event:
+        """Get or create a cancellation flag for a queue item."""
+        if queue_id not in self._cancel_flags:
+            self._cancel_flags[queue_id] = asyncio.Event()
+        return self._cancel_flags[queue_id]
+
+    def cleanup(self, queue_id: str):
+        """Remove lock and cancel flag after operation completes."""
+        self._operation_locks.pop(queue_id, None)
+        self._cancel_flags.pop(queue_id, None)

--- a/src/services/core/telegram_service.py
+++ b/src/services/core/telegram_service.py
@@ -1,4 +1,20 @@
-"""Telegram service - bot operations and callbacks."""
+"""Telegram service - thin orchestrator for bot operations.
+
+TelegramService owns the bot lifecycle (init, polling, shutdown) and
+coordinates between focused handler classes. All domain logic lives in
+the extracted handler modules:
+
+- telegram_operation_state.py  — operation locks and cancel flags
+- telegram_user_manager.py     — user creation, membership, display names
+- telegram_membership.py       — bot added/removed from groups, onboarding
+- telegram_lifecycle.py        — startup/shutdown admin notifications
+- telegram_notification.py     — queue item notifications and captions
+- telegram_commands.py         — /command handlers
+- telegram_callbacks*.py       — inline button callback handlers
+- telegram_autopost.py         — Instagram auto-post flow
+- telegram_settings.py         — settings UI handlers
+- telegram_accounts.py         — account management handlers
+"""
 
 import asyncio
 
@@ -23,26 +39,24 @@ from src.services.core.interaction_service import InteractionService
 from src.services.core.settings_service import SettingsService
 from src.services.core.instagram_account_service import InstagramAccountService
 from src.services.core.telegram_notification import TelegramNotificationService
+from src.services.core.telegram_operation_state import OperationStateManager
+from src.services.core.telegram_user_manager import TelegramUserManager
 from src.repositories.membership_repository import MembershipRepository
 from src.config.settings import settings
 from src.utils.logger import logger
-from src import __version__
-from datetime import datetime
-import re
 
-# Imported after class definition to avoid circular imports at module level
-# TelegramCommandHandlers, TelegramCallbackHandlers, TelegramAutopostHandler,
-# TelegramSettingsHandlers, TelegramAccountHandlers are imported inside initialize()
+# Re-export for any remaining external imports
+from src.services.core.telegram_utils import escape_markdown as _escape_markdown  # noqa: F401
 
-
-def _escape_markdown(text: str) -> str:
-    """Escape Telegram Markdown special characters in text."""
-    # For Telegram's Markdown mode, escape: _ * ` [
-    return re.sub(r"([_*`\[])", r"\\\1", text)
+# Handler classes are imported inside initialize() to avoid circular imports.
 
 
 class TelegramService(BaseService):
-    """All Telegram bot operations."""
+    """Thin orchestrator for Telegram bot operations.
+
+    Owns the bot lifecycle and coordinates between extracted handler classes.
+    Domain logic lives in the handler modules listed in the module docstring.
+    """
 
     def __init__(self):
         super().__init__()
@@ -61,28 +75,48 @@ class TelegramService(BaseService):
         self.membership_repo = MembershipRepository()
         self.bot = None
         self.application = None
+        # Extracted sub-components
+        self.operation_state = OperationStateManager()
+        self.user_manager = TelegramUserManager(self)
         self.notification_service = TelegramNotificationService(self)
-        self._operation_locks: dict[str, asyncio.Lock] = {}
-        self._cancel_flags: dict[str, asyncio.Event] = {}
-        self._known_memberships: set[tuple[str, int]] = set()
         self._callback_dispatch: dict = {}
 
+    # ------------------------------------------------------------------
+    # Delegate methods — preserve the public API so handler modules can
+    # continue accessing these through self.service.* unchanged.
+    # ------------------------------------------------------------------
+
     def get_operation_lock(self, queue_id: str) -> asyncio.Lock:
-        """Get or create an asyncio lock for a queue item."""
-        if queue_id not in self._operation_locks:
-            self._operation_locks[queue_id] = asyncio.Lock()
-        return self._operation_locks[queue_id]
+        """Delegate to OperationStateManager."""
+        return self.operation_state.get_lock(queue_id)
 
     def get_cancel_flag(self, queue_id: str) -> asyncio.Event:
-        """Get or create a cancellation flag for a queue item."""
-        if queue_id not in self._cancel_flags:
-            self._cancel_flags[queue_id] = asyncio.Event()
-        return self._cancel_flags[queue_id]
+        """Delegate to OperationStateManager."""
+        return self.operation_state.get_cancel_flag(queue_id)
 
     def cleanup_operation_state(self, queue_id: str):
-        """Clean up lock and cancel flag after operation completes."""
-        self._operation_locks.pop(queue_id, None)
-        self._cancel_flags.pop(queue_id, None)
+        """Delegate to OperationStateManager."""
+        self.operation_state.cleanup(queue_id)
+
+    def _get_or_create_user(self, telegram_user, telegram_chat_id=None):
+        """Delegate to TelegramUserManager."""
+        return self.user_manager.get_or_create_user(telegram_user, telegram_chat_id)
+
+    def _get_display_name(self, user) -> str:
+        """Delegate to TelegramUserManager."""
+        return self.user_manager.get_display_name(user)
+
+    def _is_verbose(self, chat_id, chat_settings=None) -> bool:
+        """Check if verbose notifications are enabled for a chat."""
+        if chat_settings is None:
+            chat_settings = self.settings_service.get_settings(chat_id)
+        if chat_settings.show_verbose_notifications is not None:
+            return chat_settings.show_verbose_notifications
+        return True
+
+    # ------------------------------------------------------------------
+    # Lifecycle overrides (BaseService)
+    # ------------------------------------------------------------------
 
     def cleanup_transactions(self):
         """Override to also clean up InteractionService's repository session.
@@ -128,8 +162,12 @@ class TelegramService(BaseService):
         if self.is_paused != paused:
             self.settings_service.toggle_setting(self.channel_id, "is_paused", user)
 
+    # ------------------------------------------------------------------
+    # Initialization
+    # ------------------------------------------------------------------
+
     async def initialize(self):
-        """Initialize Telegram bot."""
+        """Initialize Telegram bot and register all handlers."""
         self.bot = Bot(token=self.bot_token)
         self.application = Application.builder().token(self.bot_token).build()
 
@@ -140,6 +178,8 @@ class TelegramService(BaseService):
         from src.services.core.telegram_settings import TelegramSettingsHandlers
         from src.services.core.telegram_accounts import TelegramAccountHandlers
         from src.services.core.start_command_router import StartCommandRouter
+        from src.services.core.telegram_membership import TelegramMembershipHandler
+        from src.services.core.telegram_lifecycle import TelegramLifecycleHandler
 
         self.commands = TelegramCommandHandlers(self)
         self.callbacks = TelegramCallbackHandlers(self)
@@ -147,6 +187,8 @@ class TelegramService(BaseService):
         self.settings_handler = TelegramSettingsHandlers(self)
         self.accounts = TelegramAccountHandlers(self)
         self.start_router = StartCommandRouter(self)
+        self.membership_handler = TelegramMembershipHandler(self)
+        self.lifecycle = TelegramLifecycleHandler(self)
 
         # Build callback dispatch table (must be after handlers are initialized)
         self._callback_dispatch = self._build_callback_dispatch_table()
@@ -186,17 +228,14 @@ class TelegramService(BaseService):
 
         # Register callback and message handlers
         self.application.add_handler(CallbackQueryHandler(self._handle_callback))
-        # Message handler for conversation flows (add account, etc.)
         self.application.add_handler(
             MessageHandler(
                 filters.TEXT & ~filters.COMMAND, self._handle_conversation_message
             )
         )
-
-        # my_chat_member handler for group linking / bot-kicked detection
         self.application.add_handler(
             ChatMemberHandler(
-                self._handle_my_chat_member,
+                self.membership_handler.handle_my_chat_member,
                 ChatMemberHandler.MY_CHAT_MEMBER,
             )
         )
@@ -218,6 +257,10 @@ class TelegramService(BaseService):
         await self.bot.set_my_commands(commands)
 
         logger.info("Telegram bot initialized with command menu")
+
+    # ------------------------------------------------------------------
+    # Callback dispatch (orchestration — stays here)
+    # ------------------------------------------------------------------
 
     def _build_callback_dispatch_table(self) -> dict:
         """Build the callback action dispatch table.
@@ -261,14 +304,6 @@ class TelegramService(BaseService):
         """Handle callback actions that need special signatures or sub-routing.
 
         Returns True if the action was handled, False if not recognized.
-
-        Special cases:
-        - settings_refresh: takes only (query)
-        - settings_edit: takes (data, user, query, context)
-        - settings_edit_cancel: takes (query, context)
-        - settings_close: takes only (query)
-        - settings_accounts: has sub-routing based on data value
-        - accounts_config: has sub-routing based on data value
         """
         if action == "settings_refresh":
             await self.settings_handler.refresh_settings_message(query)
@@ -306,231 +341,6 @@ class TelegramService(BaseService):
 
         return False
 
-    async def send_notification(
-        self, queue_item_id: str, force_sent: bool = False
-    ) -> bool:
-        """Delegate to notification service."""
-        return await self.notification_service.send_notification(
-            queue_item_id, force_sent=force_sent
-        )
-
-    def _build_caption(
-        self,
-        media_item,
-        queue_item=None,
-        force_sent: bool = False,
-        verbose: bool = True,
-        active_account=None,
-    ) -> str:
-        """Delegate to notification service."""
-        return self.notification_service._build_caption(
-            media_item,
-            queue_item,
-            force_sent=force_sent,
-            verbose=verbose,
-            active_account=active_account,
-        )
-
-    # Notification sending, caption building, keyboard construction,
-    # and header emoji logic have been moved to telegram_notification.py.
-    # Command handlers have been moved to telegram_commands.py
-    # Callback handlers have been moved to telegram_callbacks.py
-    # Auto-post handler has been moved to telegram_autopost.py
-    # Settings handlers have been moved to telegram_settings.py
-    # Account handlers have been moved to telegram_accounts.py
-
-    async def _handle_conversation_message(self, update, context):
-        """
-        Handle text messages for active conversations.
-
-        Routes to appropriate conversation handler based on state in context.user_data.
-        """
-        # Check for settings edit conversation
-        if "settings_edit_state" in context.user_data:
-            handled = await self.settings_handler.handle_settings_edit_message(
-                update, context
-            )
-            if handled:
-                return
-
-        # Check for DM onboarding conversation
-        if (
-            update.effective_chat.type == "private"
-            and "onboarding_session_id" in context.user_data
-        ):
-            await self._handle_onboarding_message(update, context)
-            return
-
-        # Message not part of any conversation - ignore silently
-
-    async def _handle_onboarding_message(self, update, context):
-        """Handle text input during DM onboarding (naming step)."""
-        from src.services.core.conversation_service import ConversationService
-
-        session_id = context.user_data.get("onboarding_session_id")
-        if not session_id:
-            return
-
-        with ConversationService() as conv_service:
-            session = conv_service.get_session_by_id(session_id)
-
-        if not session or session.step == "complete":
-            context.user_data.pop("onboarding_session_id", None)
-            return
-
-        if session.step == "naming":
-            instance_name = update.message.text.strip()[:100]
-            if not instance_name:
-                await update.message.reply_text(
-                    "Please enter a name for your instance."
-                )
-                return
-
-            with ConversationService() as conv_service:
-                conv_service.set_instance_name(str(session.id), instance_name)
-
-            # Show add-to-group step
-            bot_username = (await self.bot.get_me()).username
-            startgroup_url = (
-                f"https://t.me/{bot_username}?startgroup=setup_{session.id}"
-            )
-
-            from telegram import InlineKeyboardButton, InlineKeyboardMarkup
-
-            keyboard = InlineKeyboardMarkup(
-                [
-                    [InlineKeyboardButton("Add to Group Chat", url=startgroup_url)],
-                ]
-            )
-            await update.message.reply_text(
-                f"Great! *{instance_name}* it is.\n\n"
-                "Now add me to the group chat where your team will review posts.\n\n"
-                "Bot already in your group? Run `/link` in that group.",
-                parse_mode="Markdown",
-                reply_markup=keyboard,
-            )
-        elif session.step == "awaiting_group":
-            await update.message.reply_text(
-                "Still waiting to link your group — add me to the group chat, "
-                "or run `/link` in that group if I'm already there.",
-                parse_mode="Markdown",
-            )
-
-    async def _handle_my_chat_member(self, update, context):
-        """Handle ChatMemberUpdated events for the bot itself.
-
-        Fires when the bot's membership status changes in any chat:
-        - Bot added to group → auto-link pending onboarding session
-        - Bot kicked from group → deactivate all memberships for that chat
-        """
-        member_update = update.my_chat_member
-        if not member_update:
-            return
-
-        chat = member_update.chat
-        if chat.type not in ("group", "supergroup"):
-            return
-
-        old_status = member_update.old_chat_member.status
-        new_status = member_update.new_chat_member.status
-        from_user = member_update.from_user
-
-        if from_user is None:
-            logger.info(
-                f"Bot membership changed in group {chat.id} by anonymous admin "
-                f"— skipping auto-link (use /link)"
-            )
-            return
-
-        try:
-            if new_status in ("member", "administrator") and old_status in (
-                "left",
-                "kicked",
-            ):
-                await self._handle_bot_added_to_group(chat, from_user)
-            elif new_status in ("left", "kicked") and old_status in (
-                "member",
-                "administrator",
-            ):
-                self._handle_bot_removed_from_group(chat)
-        except Exception as e:  # noqa: BLE001
-            logger.error(
-                f"my_chat_member handler error for chat {chat.id}: "
-                f"{type(e).__name__}: {e}",
-                exc_info=True,
-            )
-        finally:
-            self.cleanup_transactions()
-
-    async def _handle_bot_added_to_group(self, chat, from_user):
-        """Bot was added to a group — check for pending onboarding session to auto-link."""
-        from src.services.core.conversation_service import ConversationService
-
-        user = self._get_or_create_user(from_user)
-
-        # Race condition guard: the onboarding session may not be committed yet
-        # if the user clicked "Add to Group" very quickly after naming.
-        # Retry once after 2s.
-        session = None
-        for attempt in range(2):
-            with ConversationService() as conv_service:
-                session = conv_service.get_current_session(str(user.id))
-            if session and session.step == "awaiting_group":
-                break
-            if attempt == 0:
-                await asyncio.sleep(2)
-
-        if not session or session.step != "awaiting_group":
-            logger.info(
-                f"Bot added to group {chat.id} by user {from_user.id} "
-                f"— no pending onboarding session"
-            )
-            return
-
-        with ConversationService() as conv_service:
-            conv_service.link_group_to_instance(
-                session=session,
-                chat_id=chat.id,
-                user_id=str(user.id),
-                membership_repo=self.membership_repo,
-            )
-
-        name = session.pending_instance_name or "this group"
-        logger.info(
-            f"Auto-linked instance '{name}' to group {chat.id} "
-            f"via my_chat_member (user {from_user.id})"
-        )
-
-        # Notify user in DM
-        try:
-            await self.bot.send_message(
-                chat_id=from_user.id,
-                text=(
-                    f"✅ *{name}* is linked to your group!\n\n"
-                    "Use /start here to manage your instances."
-                ),
-                parse_mode="Markdown",
-            )
-        except Exception:  # noqa: BLE001
-            pass  # DM may be blocked
-
-    def _handle_bot_removed_from_group(self, chat):
-        """Bot was kicked from a group — deactivate all memberships."""
-        chat_settings = self.settings_service.get_settings_if_exists(chat.id)
-        if not chat_settings:
-            return
-
-        count = self.membership_repo.deactivate_for_chat(str(chat_settings.id))
-
-        # Evict _known_memberships cache entries for this chat
-        to_evict = {k for k in self._known_memberships if k[1] == chat.id}
-        self._known_memberships -= to_evict
-
-        logger.info(
-            f"Bot removed from group {chat.id} — "
-            f"deactivated {count} membership(s), evicted {len(to_evict)} cache entries"
-        )
-
     async def _handle_callback(self, update, context):
         """Handle inline button callbacks.
 
@@ -549,15 +359,12 @@ class TelegramService(BaseService):
                     f"Could not answer callback query (may be stale): {query.data}"
                 )
 
-            # Parse callback data
-            # Split on FIRST colon only, so data can contain colons (e.g., sap:queue_id:account_id)
             parts = query.data.split(":", 1)
             action = parts[0]
             data = parts[1] if len(parts) > 1 else None
 
             logger.info(f"📞 Parsed action='{action}', data='{data}'")
 
-            # Get user info (pass chat_id for auto-membership in groups)
             try:
                 chat_id = int(query.message.chat_id) if query.message else None
             except (TypeError, ValueError):
@@ -584,192 +391,84 @@ class TelegramService(BaseService):
                 f"Unhandled error in callback '{query.data}': {type(e).__name__}: {e}",
                 exc_info=True,
             )
-            # Try to give the user some feedback
             try:
                 await query.answer(
                     "⚠️ Something went wrong. Please try again.",
                     show_alert=True,
                 )
             except Exception:  # noqa: BLE001
-                pass  # query.answer may have already been called
+                pass
 
         finally:
-            # Clean up open transactions to prevent "idle in transaction"
             self.cleanup_transactions()
 
-    def _get_or_create_user(self, telegram_user, telegram_chat_id=None):
-        """Get or create user from Telegram data, syncing profile on each interaction.
+    # ------------------------------------------------------------------
+    # Conversation routing
+    # ------------------------------------------------------------------
 
-        If telegram_chat_id is provided and is a group chat (< 0), also ensures
-        a user_chat_membership exists linking this user to that chat's instance.
-        """
-        user = self.user_repo.get_by_telegram_id(telegram_user.id)
-
-        if not user:
-            user = self.user_repo.create(
-                telegram_user_id=telegram_user.id,
-                telegram_username=telegram_user.username,
-                telegram_first_name=telegram_user.first_name,
-                telegram_last_name=telegram_user.last_name,
+    async def _handle_conversation_message(self, update, context):
+        """Route text messages to the appropriate conversation handler."""
+        if "settings_edit_state" in context.user_data:
+            handled = await self.settings_handler.handle_settings_edit_message(
+                update, context
             )
-            logger.info(f"New user discovered: {self._get_display_name(user)}")
-        else:
-            # Sync profile data on each interaction (username may have changed/been added)
-            user = self.user_repo.update_profile(
-                str(user.id),
-                telegram_username=telegram_user.username,
-                telegram_first_name=telegram_user.first_name,
-                telegram_last_name=telegram_user.last_name,
-            )
+            if handled:
+                return
 
-        # Auto-create membership for group chat interactions
-        if telegram_chat_id is not None and telegram_chat_id < 0:
-            self._ensure_membership(user, telegram_chat_id)
-
-        return user
-
-    def _ensure_membership(self, user, telegram_chat_id):
-        """Ensure a membership exists linking user to a group chat instance.
-
-        Uses a process-local cache to avoid DB queries on repeated
-        interactions from the same user in the same group.
-
-        NOTE: _known_memberships is never invalidated in this process.
-        Phase 2b's my_chat_member kicked handler must evict entries for
-        the affected chat_id when the bot is removed from a group.
-        """
-        cache_key = (str(user.id), telegram_chat_id)
-        if cache_key in self._known_memberships:
+        if (
+            update.effective_chat.type == "private"
+            and "onboarding_session_id" in context.user_data
+        ):
+            await self.membership_handler.handle_onboarding_message(update, context)
             return
 
-        try:
-            chat_settings = self.settings_service.get_settings_if_exists(
-                telegram_chat_id
-            )
-            if not chat_settings:
-                return
-            self.membership_repo.create_membership(
-                user_id=str(user.id),
-                chat_settings_id=str(chat_settings.id),
-            )
-            self._known_memberships.add(cache_key)
-        except Exception as e:  # noqa: BLE001
-            logger.warning(f"Membership auto-create failed: {e}")
+    # ------------------------------------------------------------------
+    # Notification delegates
+    # ------------------------------------------------------------------
 
-    def _is_verbose(self, chat_id, chat_settings=None) -> bool:
-        """Check if verbose notifications are enabled for a chat.
+    async def send_notification(
+        self, queue_item_id: str, force_sent: bool = False
+    ) -> bool:
+        """Delegate to notification service."""
+        return await self.notification_service.send_notification(
+            queue_item_id, force_sent=force_sent
+        )
 
-        Accepts optional pre-loaded chat_settings to avoid redundant DB queries
-        when the caller already has settings loaded.
-        """
-        if chat_settings is None:
-            chat_settings = self.settings_service.get_settings(chat_id)
-        if chat_settings.show_verbose_notifications is not None:
-            return chat_settings.show_verbose_notifications
-        return True
-
-    def _get_display_name(self, user) -> str:
-        """Get best available display name for user (username > first_name > user_id)."""
-        if user.telegram_username:
-            return f"@{user.telegram_username}"
-        elif user.telegram_first_name:
-            return user.telegram_first_name
-        else:
-            return f"User {user.telegram_user_id}"
+    def _build_caption(
+        self,
+        media_item,
+        queue_item=None,
+        force_sent: bool = False,
+        verbose: bool = True,
+        active_account=None,
+    ) -> str:
+        """Delegate to notification service."""
+        return self.notification_service._build_caption(
+            media_item,
+            queue_item,
+            force_sent=force_sent,
+            verbose=verbose,
+            active_account=active_account,
+        )
 
     async def send_startup_notification(self):
-        """Send startup notification to admin with system status."""
-        if not settings.SEND_LIFECYCLE_NOTIFICATIONS:
-            return
-
-        try:
-            # Gather system status
-            pending_count = self.queue_repo.count_pending()
-            media_count = len(self.media_repo.get_all(is_active=True))
-            recent_posts = self.history_repo.get_recent_posts(hours=24)
-            last_post_time = recent_posts[0].posted_at if recent_posts else None
-
-            # Format last posted time
-            if last_post_time:
-                time_diff = datetime.utcnow() - last_post_time
-                hours = int(time_diff.total_seconds() / 3600)
-                last_posted = f"{hours}h ago" if hours > 0 else "< 1h ago"
-            else:
-                last_posted = "Never"
-
-            # Build message
-            message = (
-                f"🟢 *Storyline AI Started*\n\n"
-                f"📊 *System Status:*\n"
-                f"├─ Database: ✅ Connected\n"
-                f"├─ Telegram: ✅ Bot online\n"
-                f"├─ Queue: {pending_count} pending posts\n"
-                f"└─ Last posted: {last_posted}\n\n"
-                f"⚙️ *Configuration:*\n"
-                f"├─ Posts/day: {settings.POSTS_PER_DAY}\n"
-                f"├─ Window: {settings.POSTING_HOURS_START:02d}:00-{settings.POSTING_HOURS_END:02d}:00 UTC\n"
-                f"└─ Media indexed: {media_count} items\n\n"
-                f"🤖 v{__version__}"
-            )
-
-            # Send to admin
-            await self.bot.send_message(
-                chat_id=self.admin_chat_id,
-                text=message,
-                parse_mode="Markdown",
-            )
-
-            logger.info("Startup notification sent to admin")
-
-        except Exception as e:  # noqa: BLE001
-            logger.error(f"Failed to send startup notification: {e}")
+        """Delegate to lifecycle handler."""
+        await self.lifecycle.send_startup_notification()
 
     async def send_shutdown_notification(
         self, uptime_seconds: int = 0, posts_sent: int = 0
     ):
-        """Send shutdown notification to admin with session summary."""
-        if not settings.SEND_LIFECYCLE_NOTIFICATIONS:
-            return
+        """Delegate to lifecycle handler."""
+        await self.lifecycle.send_shutdown_notification(uptime_seconds, posts_sent)
 
-        try:
-            # Format uptime
-            hours = int(uptime_seconds / 3600)
-            minutes = int((uptime_seconds % 3600) / 60)
-            uptime_str = f"{hours}h {minutes}m"
-
-            # Build message
-            message = (
-                f"🔴 *Storyline AI Stopped*\n\n"
-                f"📊 *Session Summary:*\n"
-                f"├─ Uptime: {uptime_str}\n"
-                f"├─ Posts sent: {posts_sent}\n"
-                f"└─ Shutdown: Graceful\n\n"
-                f"See you next time! 👋"
-            )
-
-            # Send to admin
-            await self.bot.send_message(
-                chat_id=self.admin_chat_id,
-                text=message,
-                parse_mode="Markdown",
-            )
-
-            logger.info("Shutdown notification sent to admin")
-
-        except Exception as e:  # noqa: BLE001
-            logger.error(f"Failed to send shutdown notification: {e}")
+    # ------------------------------------------------------------------
+    # Polling lifecycle
+    # ------------------------------------------------------------------
 
     async def start_polling(self):
-        """Start bot polling.
-
-        Starts the Telegram updater and blocks forever to keep the
-        polling task alive.  An application-level error handler is
-        registered so handler exceptions are logged instead of silently
-        swallowed.
-        """
+        """Start bot polling."""
         logger.info("Starting Telegram bot polling...")
 
-        # Register application error handler so handler errors are logged
         async def _error_handler(update, context):
             logger.error(
                 f"Telegram handler error: {context.error}",
@@ -790,8 +489,6 @@ class TelegramService(BaseService):
         )
         logger.info("Telegram bot polling started successfully")
 
-        # Block forever — the updater runs as a background task but this
-        # coroutine must stay alive to keep the asyncio task running.
         stop_event = asyncio.Event()
         await stop_event.wait()
 

--- a/src/services/core/telegram_user_manager.py
+++ b/src/services/core/telegram_user_manager.py
@@ -1,0 +1,91 @@
+"""User management for Telegram bot interactions.
+
+Handles user creation/sync, group membership tracking, and display name
+resolution. Uses a process-local membership cache to avoid redundant DB
+queries on repeated interactions from the same user in the same group.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from src.utils.logger import logger
+
+if TYPE_CHECKING:
+    from src.services.core.telegram_service import TelegramService
+
+
+class TelegramUserManager:
+    """Manages Telegram user lifecycle — creation, profile sync, membership."""
+
+    def __init__(self, service: TelegramService):
+        self.service = service
+        self._known_memberships: set[tuple[str, int]] = set()
+
+    def get_or_create_user(self, telegram_user, telegram_chat_id=None):
+        """Get or create user from Telegram data, syncing profile on each interaction.
+
+        If telegram_chat_id is provided and is a group chat (< 0), also ensures
+        a user_chat_membership exists linking this user to that chat's instance.
+        """
+        user = self.service.user_repo.get_by_telegram_id(telegram_user.id)
+
+        if not user:
+            user = self.service.user_repo.create(
+                telegram_user_id=telegram_user.id,
+                telegram_username=telegram_user.username,
+                telegram_first_name=telegram_user.first_name,
+                telegram_last_name=telegram_user.last_name,
+            )
+            logger.info(f"New user discovered: {self.get_display_name(user)}")
+        else:
+            user = self.service.user_repo.update_profile(
+                str(user.id),
+                telegram_username=telegram_user.username,
+                telegram_first_name=telegram_user.first_name,
+                telegram_last_name=telegram_user.last_name,
+            )
+
+        if telegram_chat_id is not None and telegram_chat_id < 0:
+            self._ensure_membership(user, telegram_chat_id)
+
+        return user
+
+    def _ensure_membership(self, user, telegram_chat_id):
+        """Ensure a membership exists linking user to a group chat instance.
+
+        Uses a process-local cache to avoid DB queries on repeated
+        interactions from the same user in the same group.
+        """
+        cache_key = (str(user.id), telegram_chat_id)
+        if cache_key in self._known_memberships:
+            return
+
+        try:
+            chat_settings = self.service.settings_service.get_settings_if_exists(
+                telegram_chat_id
+            )
+            if not chat_settings:
+                return
+            self.service.membership_repo.create_membership(
+                user_id=str(user.id),
+                chat_settings_id=str(chat_settings.id),
+            )
+            self._known_memberships.add(cache_key)
+        except Exception as e:  # noqa: BLE001
+            logger.warning(f"Membership auto-create failed: {e}")
+
+    def evict_memberships_for_chat(self, chat_id: int):
+        """Evict cached memberships for a chat (e.g., when bot is kicked)."""
+        to_evict = {k for k in self._known_memberships if k[1] == chat_id}
+        self._known_memberships -= to_evict
+        return len(to_evict)
+
+    def get_display_name(self, user) -> str:
+        """Get best available display name for user (username > first_name > user_id)."""
+        if user.telegram_username:
+            return f"@{user.telegram_username}"
+        elif user.telegram_first_name:
+            return user.telegram_first_name
+        else:
+            return f"User {user.telegram_user_id}"

--- a/src/services/core/telegram_utils.py
+++ b/src/services/core/telegram_utils.py
@@ -1,6 +1,7 @@
 """Telegram handler utilities - shared patterns extracted from handler modules.
 
 This module contains common patterns used across multiple Telegram handler files:
+- Markdown escaping (canonical location)
 - Queue item validation
 - Standard action keyboard builders
 - Settings edit state management
@@ -8,6 +9,7 @@ This module contains common patterns used across multiple Telegram handler files
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup, WebAppInfo
@@ -18,6 +20,15 @@ from src.utils.webapp_auth import generate_url_token
 
 if TYPE_CHECKING:
     from src.services.core.telegram_service import TelegramService
+
+
+def escape_markdown(text: str) -> str:
+    """Escape Telegram Markdown special characters in text.
+
+    Canonical location for Markdown escaping — all modules should import
+    from here rather than defining local copies.
+    """
+    return re.sub(r"([_*`\[])", r"\\\1", text)
 
 
 # =========================================================================

--- a/tests/src/services/conftest.py
+++ b/tests/src/services/conftest.py
@@ -2,10 +2,30 @@
 
 import pytest
 from contextlib import contextmanager
-from unittest.mock import patch
+from unittest.mock import AsyncMock, Mock, patch
 
 from src.services.core.start_command_router import StartCommandRouter  # noqa: F401
 from src.services.core.telegram_service import TelegramService
+
+
+def make_query(chat_id=-100123):
+    """Build a mock Telegram CallbackQuery."""
+    query = AsyncMock()
+    query.message = Mock()
+    query.message.chat_id = chat_id
+    query.message.message_id = 42
+    return query
+
+
+def make_user(user_id="user-1"):
+    """Build a mock Telegram user."""
+    return Mock(id=user_id)
+
+
+@contextmanager
+def noop_context_manager():
+    """Pass-through context manager for replacing service context managers in tests."""
+    yield
 
 
 @contextmanager

--- a/tests/src/services/test_backfill_downloader.py
+++ b/tests/src/services/test_backfill_downloader.py
@@ -1,0 +1,349 @@
+"""Tests for BackfillDownloader — media downloading, storage, and Instagram API calls."""
+
+import hashlib
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+import httpx
+
+from src.exceptions import (
+    BackfillError,
+    BackfillMediaExpiredError,
+    BackfillMediaNotFoundError,
+    InstagramAPIError,
+)
+from src.services.integrations.backfill_downloader import BackfillDownloader
+
+
+class MockHttpxClient:
+    """Async context manager that replaces httpx.AsyncClient in tests."""
+
+    def __init__(self, response=None, get_side_effect=None):
+        self._response = response
+        self._get_side_effect = get_side_effect
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        pass
+
+    async def get(self, *args, **kwargs):
+        if self._get_side_effect:
+            raise self._get_side_effect
+        return self._response
+
+
+@pytest.fixture
+def mock_backfill_service():
+    """Minimal InstagramBackfillService mock."""
+    service = Mock()
+    service.MEDIA_FIELDS = (
+        "id,media_type,media_url,timestamp,caption,permalink,username"
+    )
+    service.CAROUSEL_CHILDREN_FIELDS = "id,media_type,media_url,timestamp"
+    service.BACKFILL_CATEGORY = "instagram_backfill"
+    service.API_TIMEOUT = 30
+    service.DOWNLOAD_TIMEOUT = 60
+    service.instagram_service = Mock()
+    service.media_repo = Mock()
+    service.media_repo.db = Mock()
+    service._process_media_item = AsyncMock()
+    return service
+
+
+@pytest.fixture
+def downloader(mock_backfill_service):
+    """BackfillDownloader with mocked parent service."""
+    return BackfillDownloader(mock_backfill_service)
+
+
+def _make_ctx(token="test-token", storage_dir="/tmp/test"):
+    """Build a minimal BackfillContext mock."""
+    ctx = Mock()
+    ctx.token = token
+    ctx.storage_dir = Path(storage_dir)
+    ctx.result = Mock(
+        total_api_items=0,
+        failed=0,
+        error_details=[],
+    )
+    return ctx
+
+
+# ──────────────────────────────────────────────────────────────
+# process_carousel
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestProcessCarousel:
+    async def test_expands_and_processes_children(self, downloader):
+        """Fetches carousel children and processes each one."""
+        ctx = _make_ctx()
+        item = {
+            "id": "carousel-1",
+            "caption": "Group post",
+            "permalink": "https://ig/p/123",
+            "username": "testuser",
+        }
+        downloader.fetch_carousel_children = AsyncMock(
+            return_value={
+                "data": [
+                    {"id": "child-1", "media_type": "IMAGE"},
+                    {"id": "child-2", "media_type": "IMAGE"},
+                ]
+            }
+        )
+
+        await downloader.process_carousel(ctx, item)
+
+        assert ctx.result.total_api_items == 2
+        assert downloader.service._process_media_item.call_count == 2
+
+    async def test_children_inherit_parent_fields(self, downloader):
+        """Children get caption, permalink, username from parent when missing."""
+        ctx = _make_ctx()
+        item = {
+            "id": "carousel-1",
+            "caption": "Parent caption",
+            "permalink": "https://ig/p/123",
+            "username": "testuser",
+        }
+        child = {"id": "child-1", "media_type": "IMAGE"}
+        downloader.fetch_carousel_children = AsyncMock(return_value={"data": [child]})
+
+        await downloader.process_carousel(ctx, item)
+
+        call_kwargs = downloader.service._process_media_item.call_args[1]
+        assert call_kwargs["item"]["caption"] == "Parent caption"
+
+    async def test_api_error_increments_failed(self, downloader):
+        """If fetching children fails, increments failed count."""
+        ctx = _make_ctx()
+        item = {"id": "carousel-1"}
+        downloader.fetch_carousel_children = AsyncMock(
+            side_effect=InstagramAPIError("API error")
+        )
+
+        await downloader.process_carousel(ctx, item)
+
+        assert ctx.result.failed == 1
+        assert len(ctx.result.error_details) == 1
+
+
+# ──────────────────────────────────────────────────────────────
+# download_and_index
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestDownloadAndIndex:
+    async def test_downloads_and_creates_media_item(self, downloader, tmp_path):
+        """Downloads media, saves to disk, and indexes in database."""
+        ctx = _make_ctx(storage_dir=str(tmp_path))
+        file_bytes = b"fake-image-data"
+        downloader.download_media = AsyncMock(return_value=file_bytes)
+        mock_media_item = Mock()
+        downloader.service.media_repo.create.return_value = mock_media_item
+
+        item = {"timestamp": "2026-03-15T10:30:00+0000"}
+
+        await downloader.download_and_index(
+            ctx, "ig-1", "https://cdn.ig/photo.jpg", "IMAGE", item, "feed"
+        )
+
+        downloader.service.media_repo.create.assert_called_once()
+        call_kwargs = downloader.service.media_repo.create.call_args[1]
+        assert call_kwargs["source_type"] == "instagram_backfill"
+        assert call_kwargs["source_identifier"] == "ig-1"
+        assert call_kwargs["file_hash"] == hashlib.sha256(file_bytes).hexdigest()
+        assert mock_media_item.instagram_media_id == "ig-1"
+
+    async def test_timestamp_in_filename(self, downloader, tmp_path):
+        """Timestamp is included as prefix in the filename."""
+        ctx = _make_ctx(storage_dir=str(tmp_path))
+        downloader.download_media = AsyncMock(return_value=b"data")
+        downloader.service.media_repo.create.return_value = Mock()
+
+        item = {"timestamp": "2026-03-15T10:30:00+0000"}
+
+        await downloader.download_and_index(
+            ctx, "ig-1", "https://cdn.ig/photo.jpg", "IMAGE", item, "feed"
+        )
+
+        call_kwargs = downloader.service.media_repo.create.call_args[1]
+        assert call_kwargs["file_name"].startswith("20260315_")
+
+    async def test_no_timestamp(self, downloader, tmp_path):
+        """Missing timestamp → filename starts with media ID directly."""
+        ctx = _make_ctx(storage_dir=str(tmp_path))
+        downloader.download_media = AsyncMock(return_value=b"data")
+        downloader.service.media_repo.create.return_value = Mock()
+
+        item = {}
+
+        await downloader.download_and_index(
+            ctx, "ig-1", "https://cdn.ig/photo.jpg", "IMAGE", item, "feed"
+        )
+
+        call_kwargs = downloader.service.media_repo.create.call_args[1]
+        assert call_kwargs["file_name"].startswith("ig-1")
+
+
+# ──────────────────────────────────────────────────────────────
+# download_media
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestDownloadMedia:
+    async def test_success(self, downloader):
+        """Returns content bytes on 200."""
+        client = MockHttpxClient(response=Mock(status_code=200, content=b"image-bytes"))
+
+        with patch("httpx.AsyncClient", return_value=client):
+            result = await downloader.download_media("https://cdn.ig/photo.jpg", "ig-1")
+
+        assert result == b"image-bytes"
+
+    async def test_403_raises_expired(self, downloader):
+        """HTTP 403 → BackfillMediaExpiredError."""
+        client = MockHttpxClient(response=Mock(status_code=403))
+
+        with patch("httpx.AsyncClient", return_value=client):
+            with pytest.raises(BackfillMediaExpiredError):
+                await downloader.download_media("https://cdn.ig/photo.jpg", "ig-1")
+
+    async def test_410_raises_expired(self, downloader):
+        """HTTP 410 → BackfillMediaExpiredError."""
+        client = MockHttpxClient(response=Mock(status_code=410))
+
+        with patch("httpx.AsyncClient", return_value=client):
+            with pytest.raises(BackfillMediaExpiredError):
+                await downloader.download_media("https://cdn.ig/photo.jpg", "ig-1")
+
+    async def test_404_raises_not_found(self, downloader):
+        """HTTP 404 → BackfillMediaNotFoundError."""
+        client = MockHttpxClient(response=Mock(status_code=404))
+
+        with patch("httpx.AsyncClient", return_value=client):
+            with pytest.raises(BackfillMediaNotFoundError):
+                await downloader.download_media("https://cdn.ig/photo.jpg", "ig-1")
+
+    async def test_other_status_raises_backfill_error(self, downloader):
+        """Non-200/403/404/410 → BackfillError."""
+        client = MockHttpxClient(response=Mock(status_code=500))
+
+        with patch("httpx.AsyncClient", return_value=client):
+            with pytest.raises(BackfillError):
+                await downloader.download_media("https://cdn.ig/photo.jpg", "ig-1")
+
+    async def test_empty_response_raises_backfill_error(self, downloader):
+        """Empty content body → BackfillError."""
+        client = MockHttpxClient(response=Mock(status_code=200, content=b""))
+
+        with patch("httpx.AsyncClient", return_value=client):
+            with pytest.raises(BackfillError, match="Empty response"):
+                await downloader.download_media("https://cdn.ig/photo.jpg", "ig-1")
+
+    async def test_network_error_raises_backfill_error(self, downloader):
+        """httpx.RequestError → BackfillError."""
+        client = MockHttpxClient(
+            get_side_effect=httpx.RequestError("Connection failed")
+        )
+
+        with patch("httpx.AsyncClient", return_value=client):
+            with pytest.raises(BackfillError, match="Network error"):
+                await downloader.download_media("https://cdn.ig/photo.jpg", "ig-1")
+
+
+# ──────────────────────────────────────────────────────────────
+# get_storage_dir
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestGetStorageDir:
+    @patch("src.services.integrations.backfill_downloader.settings")
+    def test_returns_category_subdir(self, mock_settings, downloader):
+        """Returns MEDIA_DIR / BACKFILL_CATEGORY."""
+        mock_settings.MEDIA_DIR = "/data/media"
+        result = downloader.get_storage_dir()
+        assert result == Path("/data/media/instagram_backfill")
+
+
+# ──────────────────────────────────────────────────────────────
+# get_extension_for_type
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestGetExtensionForType:
+    def test_extracts_from_url(self, downloader):
+        """Extracts extension from URL path."""
+        assert (
+            downloader.get_extension_for_type(
+                "IMAGE", "https://cdn.ig/photo.png?token=abc"
+            )
+            == ".png"
+        )
+        assert (
+            downloader.get_extension_for_type(
+                "VIDEO", "https://cdn.ig/video.mp4?token=abc"
+            )
+            == ".mp4"
+        )
+
+    def test_fallback_for_image(self, downloader):
+        """Falls back to .jpg for IMAGE type when URL has no recognizable extension."""
+        assert (
+            downloader.get_extension_for_type("IMAGE", "https://cdn.ig/media") == ".jpg"
+        )
+
+    def test_fallback_for_video(self, downloader):
+        """Falls back to .mp4 for VIDEO type when URL has no recognizable extension."""
+        assert (
+            downloader.get_extension_for_type("VIDEO", "https://cdn.ig/media") == ".mp4"
+        )
+
+
+# ──────────────────────────────────────────────────────────────
+# is_after_date
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestIsAfterDate:
+    def test_item_after_since(self, downloader):
+        """Returns True when item timestamp is after 'since'."""
+        item = {"timestamp": "2026-04-15T12:00:00+0000"}
+        since = datetime(2026, 4, 1)
+        assert downloader.is_after_date(item, since) is True
+
+    def test_item_before_since(self, downloader):
+        """Returns False when item timestamp is before 'since'."""
+        item = {"timestamp": "2026-03-01T12:00:00+0000"}
+        since = datetime(2026, 4, 1)
+        assert downloader.is_after_date(item, since) is False
+
+    def test_no_timestamp_returns_true(self, downloader):
+        """Returns True when item has no timestamp (include by default)."""
+        assert downloader.is_after_date({}, datetime(2026, 1, 1)) is True
+        assert downloader.is_after_date({"timestamp": ""}, datetime(2026, 1, 1)) is True
+
+    def test_invalid_timestamp_returns_true(self, downloader):
+        """Returns True for unparseable timestamps (include by default)."""
+        item = {"timestamp": "not-a-date"}
+        assert downloader.is_after_date(item, datetime(2026, 1, 1)) is True
+
+    def test_z_suffix_handled(self, downloader):
+        """Handles 'Z' suffix timestamps."""
+        item = {"timestamp": "2026-04-15T12:00:00Z"}
+        since = datetime(2026, 4, 1)
+        assert downloader.is_after_date(item, since) is True

--- a/tests/src/services/test_conversation_service.py
+++ b/tests/src/services/test_conversation_service.py
@@ -1,0 +1,260 @@
+"""Tests for ConversationService — DM onboarding state machine."""
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import Mock, patch
+
+import pytest
+from sqlalchemy.exc import SQLAlchemyError
+
+from src.services.core.conversation_service import (
+    ConversationService,
+)
+
+
+@pytest.fixture
+def conv_service():
+    """ConversationService with mocked __init__ and dependencies."""
+    with patch.object(ConversationService, "__init__", lambda self: None):
+        service = ConversationService()
+        service.onboarding_repo = Mock()
+        return service
+
+
+# ──────────────────────────────────────────────────────────────
+# start_onboarding
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestStartOnboarding:
+    def test_creates_session_with_ttl(self, conv_service):
+        """Creates a session with a 24h expiration."""
+        mock_session = Mock(id="sess-1")
+        conv_service.onboarding_repo.create.return_value = mock_session
+
+        result = conv_service.start_onboarding("user-1")
+
+        assert result is mock_session
+        call_kwargs = conv_service.onboarding_repo.create.call_args[1]
+        assert call_kwargs["user_id"] == "user-1"
+        # expires_at should be ~24h from now
+        delta = call_kwargs["expires_at"] - datetime.now(timezone.utc)
+        assert timedelta(hours=23) < delta < timedelta(hours=25)
+
+
+# ──────────────────────────────────────────────────────────────
+# get_current_session / get_session_by_id
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestGetSession:
+    def test_get_current_session_returns_active(self, conv_service):
+        """Returns the active session for a user."""
+        mock_session = Mock()
+        conv_service.onboarding_repo.get_active_for_user.return_value = mock_session
+
+        result = conv_service.get_current_session("user-1")
+
+        assert result is mock_session
+        conv_service.onboarding_repo.get_active_for_user.assert_called_once_with(
+            "user-1"
+        )
+
+    def test_get_current_session_returns_none(self, conv_service):
+        """Returns None when no active session exists."""
+        conv_service.onboarding_repo.get_active_for_user.return_value = None
+        assert conv_service.get_current_session("user-1") is None
+
+    def test_get_session_by_id(self, conv_service):
+        """Returns session by ID."""
+        mock_session = Mock()
+        conv_service.onboarding_repo.get_by_id.return_value = mock_session
+
+        result = conv_service.get_session_by_id("sess-1")
+
+        assert result is mock_session
+        conv_service.onboarding_repo.get_by_id.assert_called_once_with("sess-1")
+
+    def test_get_session_by_id_not_found(self, conv_service):
+        """Returns None for unknown session ID."""
+        conv_service.onboarding_repo.get_by_id.return_value = None
+        assert conv_service.get_session_by_id("bad-id") is None
+
+
+# ──────────────────────────────────────────────────────────────
+# set_instance_name
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestSetInstanceName:
+    def test_advances_to_awaiting_group(self, conv_service):
+        """Sets name and advances step to 'awaiting_group'."""
+        mock_session = Mock()
+        conv_service.onboarding_repo.update_step.return_value = mock_session
+
+        result = conv_service.set_instance_name("sess-1", "My Brand")
+
+        assert result is mock_session
+        conv_service.onboarding_repo.update_step.assert_called_once_with(
+            session_id="sess-1",
+            step="awaiting_group",
+            pending_instance_name="My Brand",
+        )
+
+
+# ──────────────────────────────────────────────────────────────
+# link_group
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestLinkGroup:
+    def test_completes_session(self, conv_service):
+        """Links group and advances step to 'complete'."""
+        mock_session = Mock()
+        conv_service.onboarding_repo.update_step.return_value = mock_session
+
+        result = conv_service.link_group("sess-1", "cs-1")
+
+        assert result is mock_session
+        conv_service.onboarding_repo.update_step.assert_called_once_with(
+            session_id="sess-1",
+            step="complete",
+            pending_chat_settings_id="cs-1",
+        )
+
+
+# ──────────────────────────────────────────────────────────────
+# link_group_to_instance
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestLinkGroupToInstance:
+    def test_creates_settings_membership_and_completes(self, conv_service):
+        """Creates chat_settings, sets display_name, creates membership, completes."""
+        session = Mock(
+            id="sess-1",
+            pending_instance_name="My Brand",
+        )
+        mock_chat_settings = Mock(id="cs-1")
+        mock_settings_service = Mock()
+        mock_settings_service.get_settings.return_value = mock_chat_settings
+        mock_settings_service.__enter__ = Mock(return_value=mock_settings_service)
+        mock_settings_service.__exit__ = Mock(return_value=False)
+
+        membership_repo = Mock()
+
+        with patch(
+            "src.services.core.settings_service.SettingsService",
+            return_value=mock_settings_service,
+        ):
+            result = conv_service.link_group_to_instance(
+                session,
+                chat_id=12345,
+                user_id="user-1",
+                membership_repo=membership_repo,
+            )
+
+        assert result is mock_chat_settings
+        mock_settings_service.update_setting.assert_called_once_with(
+            12345, "display_name", "My Brand"
+        )
+        membership_repo.create_membership.assert_called_once_with(
+            user_id="user-1",
+            chat_settings_id="cs-1",
+            instance_role="owner",
+        )
+        conv_service.onboarding_repo.update_step.assert_called_once_with(
+            session_id="sess-1",
+            step="complete",
+            pending_chat_settings_id="cs-1",
+        )
+
+    def test_skips_display_name_when_none(self, conv_service):
+        """Doesn't set display_name if pending_instance_name is None."""
+        session = Mock(id="sess-1", pending_instance_name=None)
+        mock_chat_settings = Mock(id="cs-1")
+        mock_settings_service = Mock()
+        mock_settings_service.get_settings.return_value = mock_chat_settings
+        mock_settings_service.__enter__ = Mock(return_value=mock_settings_service)
+        mock_settings_service.__exit__ = Mock(return_value=False)
+
+        with patch(
+            "src.services.core.settings_service.SettingsService",
+            return_value=mock_settings_service,
+        ):
+            conv_service.link_group_to_instance(
+                session, chat_id=12345, user_id="user-1", membership_repo=Mock()
+            )
+
+        mock_settings_service.update_setting.assert_not_called()
+
+
+# ──────────────────────────────────────────────────────────────
+# cleanup_expired
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestCleanupExpired:
+    def test_no_expired_sessions(self, conv_service):
+        """Returns 0 when no sessions are expired."""
+        conv_service.onboarding_repo.get_expired.return_value = []
+        conv_service.onboarding_repo.delete_expired.return_value = 0
+
+        assert conv_service.cleanup_expired() == 0
+
+    def test_logs_dropouts_then_deletes(self, conv_service):
+        """Logs onboarding_dropout interactions, then deletes expired sessions."""
+        expired = [
+            Mock(
+                user_id="u-1",
+                step="naming",
+                created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            ),
+            Mock(
+                user_id="u-2",
+                step="awaiting_group",
+                created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            ),
+        ]
+        conv_service.onboarding_repo.get_expired.return_value = expired
+        conv_service.onboarding_repo.delete_expired.return_value = 2
+
+        mock_interaction_repo = Mock()
+        mock_interaction_repo.__enter__ = Mock(return_value=mock_interaction_repo)
+        mock_interaction_repo.__exit__ = Mock(return_value=False)
+
+        with patch(
+            "src.repositories.interaction_repository.InteractionRepository",
+            return_value=mock_interaction_repo,
+        ):
+            result = conv_service.cleanup_expired()
+
+        assert result == 2
+        assert mock_interaction_repo.create.call_count == 2
+
+    def test_sqlalchemy_error_during_logging_does_not_block_delete(self, conv_service):
+        """If logging dropouts fails, deletion still proceeds."""
+        expired = [
+            Mock(user_id="u-1", step="naming", created_at=datetime.now(timezone.utc))
+        ]
+        conv_service.onboarding_repo.get_expired.return_value = expired
+        conv_service.onboarding_repo.delete_expired.return_value = 1
+
+        mock_interaction_repo = Mock()
+        mock_interaction_repo.__enter__ = Mock(return_value=mock_interaction_repo)
+        mock_interaction_repo.__exit__ = Mock(return_value=False)
+        mock_interaction_repo.create.side_effect = SQLAlchemyError("db error")
+
+        with patch(
+            "src.repositories.interaction_repository.InteractionRepository",
+            return_value=mock_interaction_repo,
+        ):
+            result = conv_service.cleanup_expired()
+
+        assert result == 1
+        conv_service.onboarding_repo.delete_expired.assert_called_once()

--- a/tests/src/services/test_phase2b_handlers.py
+++ b/tests/src/services/test_phase2b_handlers.py
@@ -9,12 +9,19 @@ from unittest.mock import Mock, patch, AsyncMock
 from uuid import uuid4
 
 from src.services.core.telegram_commands import TelegramCommandHandlers
+from src.services.core.telegram_membership import TelegramMembershipHandler
 
 
 @pytest.fixture
 def mock_command_handlers(mock_telegram_service):
     """Create TelegramCommandHandlers from shared mock_telegram_service."""
     return TelegramCommandHandlers(mock_telegram_service)
+
+
+@pytest.fixture
+def mock_membership_handler(mock_telegram_service):
+    """Create TelegramMembershipHandler from shared mock_telegram_service."""
+    return TelegramMembershipHandler(mock_telegram_service)
 
 
 def _make_user(service, user_id=None):
@@ -44,11 +51,12 @@ def _make_update(chat_id, chat_type="group", user_id=12345):
 @pytest.mark.unit
 @pytest.mark.asyncio
 class TestMyChatMemberHandler:
-    """Tests for the my_chat_member handler on TelegramService."""
+    """Tests for the TelegramMembershipHandler (extracted from TelegramService)."""
 
-    async def test_bot_added_auto_links_pending_session(self, mock_telegram_service):
+    async def test_bot_added_auto_links_pending_session(self, mock_membership_handler):
         """Bot added to group auto-links a pending onboarding session."""
-        service = mock_telegram_service
+        handler = mock_membership_handler
+        service = handler.service
         mock_user = _make_user(service)
 
         mock_session = Mock()
@@ -74,7 +82,7 @@ class TestMyChatMemberHandler:
             mock_conv.__exit__ = Mock(return_value=False)
             mock_conv.get_current_session.return_value = mock_session
 
-            await service._handle_my_chat_member(mock_update, Mock())
+            await handler.handle_my_chat_member(mock_update, Mock())
 
         # Should call link_group_to_instance
         mock_conv.link_group_to_instance.assert_called_once_with(
@@ -85,10 +93,11 @@ class TestMyChatMemberHandler:
         )
 
     async def test_bot_added_retries_once_on_missing_session(
-        self, mock_telegram_service
+        self, mock_membership_handler
     ):
         """Race condition guard: retries after 2s if session not committed yet."""
-        service = mock_telegram_service
+        handler = mock_membership_handler
+        service = handler.service
         mock_user = _make_user(service)
 
         mock_session = Mock()
@@ -118,7 +127,7 @@ class TestMyChatMemberHandler:
             # First call returns None, second returns the session
             mock_conv.get_current_session.side_effect = [None, mock_session]
 
-            await service._handle_my_chat_member(mock_update, Mock())
+            await handler.handle_my_chat_member(mock_update, Mock())
 
         # Should have slept 2s between retries
         mock_sleep.assert_called_once_with(2)
@@ -131,9 +140,10 @@ class TestMyChatMemberHandler:
             membership_repo=service.membership_repo,
         )
 
-    async def test_bot_added_anonymous_admin_skips(self, mock_telegram_service):
+    async def test_bot_added_anonymous_admin_skips(self, mock_membership_handler):
         """Anonymous admin (from_user=None) is handled gracefully."""
-        service = mock_telegram_service
+        handler = mock_membership_handler
+        service = handler.service
 
         mock_update = Mock()
         mock_update.my_chat_member = Mock()
@@ -142,13 +152,14 @@ class TestMyChatMemberHandler:
         mock_update.my_chat_member.old_chat_member = Mock(status="left")
         mock_update.my_chat_member.new_chat_member = Mock(status="member")
 
-        await service._handle_my_chat_member(mock_update, Mock())
+        await handler.handle_my_chat_member(mock_update, Mock())
 
         service.membership_repo.create_membership.assert_not_called()
 
-    async def test_bot_added_no_pending_session_is_noop(self, mock_telegram_service):
+    async def test_bot_added_no_pending_session_is_noop(self, mock_membership_handler):
         """Bot added to group with no pending session does nothing harmful."""
-        service = mock_telegram_service
+        handler = mock_membership_handler
+        service = handler.service
         _make_user(service)
 
         mock_update = Mock()
@@ -168,13 +179,14 @@ class TestMyChatMemberHandler:
             mock_conv.__exit__ = Mock(return_value=False)
             mock_conv.get_current_session.return_value = None
 
-            await service._handle_my_chat_member(mock_update, Mock())
+            await handler.handle_my_chat_member(mock_update, Mock())
 
         service.membership_repo.create_membership.assert_not_called()
 
-    async def test_bot_kicked_deactivates_memberships(self, mock_telegram_service):
+    async def test_bot_kicked_deactivates_memberships(self, mock_membership_handler):
         """Bot kicked from group deactivates all memberships."""
-        service = mock_telegram_service
+        handler = mock_membership_handler
+        service = handler.service
 
         mock_chat_settings = Mock()
         mock_chat_settings.id = uuid4()
@@ -184,7 +196,7 @@ class TestMyChatMemberHandler:
         service.membership_repo.deactivate_for_chat.return_value = 3
 
         # Pre-populate cache with entries for this chat
-        service._known_memberships = {
+        service.user_manager._known_memberships = {
             ("user1", -100999),
             ("user2", -100999),
             ("user3", -100888),  # different chat, should survive
@@ -197,27 +209,28 @@ class TestMyChatMemberHandler:
         mock_update.my_chat_member.old_chat_member = Mock(status="member")
         mock_update.my_chat_member.new_chat_member = Mock(status="kicked")
 
-        await service._handle_my_chat_member(mock_update, Mock())
+        await handler.handle_my_chat_member(mock_update, Mock())
 
         service.membership_repo.deactivate_for_chat.assert_called_once_with(
             str(mock_chat_settings.id)
         )
 
         # Cache entries for -100999 should be evicted
-        assert ("user1", -100999) not in service._known_memberships
-        assert ("user2", -100999) not in service._known_memberships
+        assert ("user1", -100999) not in service.user_manager._known_memberships
+        assert ("user2", -100999) not in service.user_manager._known_memberships
         # Entry for different chat should remain
-        assert ("user3", -100888) in service._known_memberships
+        assert ("user3", -100888) in service.user_manager._known_memberships
 
-    async def test_ignores_non_group_events(self, mock_telegram_service):
+    async def test_ignores_non_group_events(self, mock_membership_handler):
         """my_chat_member events in non-group chats are ignored."""
-        service = mock_telegram_service
+        handler = mock_membership_handler
+        service = handler.service
 
         mock_update = Mock()
         mock_update.my_chat_member = Mock()
         mock_update.my_chat_member.chat = Mock(id=12345, type="private")
 
-        await service._handle_my_chat_member(mock_update, Mock())
+        await handler.handle_my_chat_member(mock_update, Mock())
 
         service.membership_repo.create_membership.assert_not_called()
         service.membership_repo.deactivate_for_chat.assert_not_called()

--- a/tests/src/services/test_start_command_router.py
+++ b/tests/src/services/test_start_command_router.py
@@ -1,0 +1,510 @@
+"""Tests for StartCommandRouter — 5-branch /start handler."""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from src.services.core.start_command_router import StartCommandRouter, _escape_md2
+
+
+@pytest.fixture
+def mock_service():
+    """Minimal TelegramService mock for router tests."""
+    service = Mock()
+    service._get_or_create_user = Mock()
+    service.interaction_service = Mock()
+    service.membership_repo = Mock()
+    service.bot = AsyncMock()
+    service.bot.get_me = AsyncMock(return_value=Mock(username="test_bot"))
+    return service
+
+
+@pytest.fixture
+def router(mock_service):
+    """StartCommandRouter with mocked TelegramService."""
+    return StartCommandRouter(mock_service)
+
+
+def _make_update(chat_type="private", chat_id=12345, user_id=67890, message_id=1):
+    """Build a mock Telegram Update."""
+    update = AsyncMock()
+    update.effective_chat = Mock()
+    update.effective_chat.id = chat_id
+    update.effective_chat.type = chat_type
+    update.effective_user = Mock()
+    update.effective_user.id = user_id
+    update.message = AsyncMock()
+    update.message.message_id = message_id
+    update.message.reply_text = AsyncMock()
+    return update
+
+
+def _make_context(args=None):
+    """Build a mock Telegram context."""
+    context = Mock()
+    context.args = args or []
+    context.user_data = {}
+    return context
+
+
+# ──────────────────────────────────────────────────────────────
+# handle_start — routing logic
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestHandleStartRouting:
+    async def test_group_with_startgroup_payload(self, router):
+        """Group chat + setup_ payload → _handle_startgroup_link."""
+        update = _make_update(chat_type="group")
+        context = _make_context(args=["setup_sess-1"])
+        router.service._get_or_create_user.return_value = Mock(id="user-1")
+
+        with patch.object(
+            router, "_handle_startgroup_link", new_callable=AsyncMock
+        ) as mock_link:
+            await router.handle_start(update, context)
+
+        mock_link.assert_called_once()
+
+    async def test_group_without_payload(self, router):
+        """Group chat + no payload → _handle_group_start."""
+        update = _make_update(chat_type="group")
+        context = _make_context()
+        router.service._get_or_create_user.return_value = Mock(id="user-1")
+
+        with patch.object(
+            router, "_handle_group_start", new_callable=AsyncMock
+        ) as mock_group:
+            await router.handle_start(update, context)
+
+        mock_group.assert_called_once()
+
+    async def test_dm_with_active_session(self, router):
+        """DM + active onboarding session → _handle_resume_onboarding."""
+        update = _make_update(chat_type="private")
+        context = _make_context()
+        user = Mock(id="user-1")
+        router.service._get_or_create_user.return_value = user
+
+        mock_session = Mock()
+        mock_conv = Mock()
+        mock_conv.get_current_session.return_value = mock_session
+        mock_conv.__enter__ = Mock(return_value=mock_conv)
+        mock_conv.__exit__ = Mock(return_value=False)
+
+        with (
+            patch(
+                "src.services.core.start_command_router.ConversationService",
+                return_value=mock_conv,
+            ),
+            patch.object(
+                router, "_handle_resume_onboarding", new_callable=AsyncMock
+            ) as mock_resume,
+        ):
+            await router.handle_start(update, context)
+
+        mock_resume.assert_called_once()
+
+    async def test_dm_returning_user(self, router):
+        """DM + no session + memberships → _handle_returning_user."""
+        update = _make_update(chat_type="private")
+        context = _make_context()
+        user = Mock(id="user-1")
+        router.service._get_or_create_user.return_value = user
+
+        mock_conv = Mock()
+        mock_conv.get_current_session.return_value = None
+        mock_conv.__enter__ = Mock(return_value=mock_conv)
+        mock_conv.__exit__ = Mock(return_value=False)
+
+        mock_membership = Mock()
+        mock_membership.get_for_user.return_value = [Mock()]
+        mock_membership.__enter__ = Mock(return_value=mock_membership)
+        mock_membership.__exit__ = Mock(return_value=False)
+
+        with (
+            patch(
+                "src.services.core.start_command_router.ConversationService",
+                return_value=mock_conv,
+            ),
+            patch(
+                "src.services.core.start_command_router.MembershipRepository",
+                return_value=mock_membership,
+            ),
+            patch.object(
+                router, "_handle_returning_user", new_callable=AsyncMock
+            ) as mock_returning,
+        ):
+            await router.handle_start(update, context)
+
+        mock_returning.assert_called_once()
+
+    async def test_dm_new_user(self, router):
+        """DM + no session + no memberships → _handle_new_user."""
+        update = _make_update(chat_type="private")
+        context = _make_context()
+        user = Mock(id="user-1")
+        router.service._get_or_create_user.return_value = user
+
+        mock_conv = Mock()
+        mock_conv.get_current_session.return_value = None
+        mock_conv.__enter__ = Mock(return_value=mock_conv)
+        mock_conv.__exit__ = Mock(return_value=False)
+
+        mock_membership = Mock()
+        mock_membership.get_for_user.return_value = []
+        mock_membership.__enter__ = Mock(return_value=mock_membership)
+        mock_membership.__exit__ = Mock(return_value=False)
+
+        with (
+            patch(
+                "src.services.core.start_command_router.ConversationService",
+                return_value=mock_conv,
+            ),
+            patch(
+                "src.services.core.start_command_router.MembershipRepository",
+                return_value=mock_membership,
+            ),
+            patch.object(
+                router, "_handle_new_user", new_callable=AsyncMock
+            ) as mock_new,
+        ):
+            await router.handle_start(update, context)
+
+        mock_new.assert_called_once()
+
+    async def test_always_logs_interaction(self, router):
+        """Interaction is logged regardless of branch."""
+        update = _make_update(chat_type="private")
+        context = _make_context()
+        user = Mock(id="user-1")
+        router.service._get_or_create_user.return_value = user
+
+        mock_conv = Mock()
+        mock_conv.get_current_session.return_value = None
+        mock_conv.__enter__ = Mock(return_value=mock_conv)
+        mock_conv.__exit__ = Mock(return_value=False)
+
+        mock_membership = Mock()
+        mock_membership.get_for_user.return_value = []
+        mock_membership.__enter__ = Mock(return_value=mock_membership)
+        mock_membership.__exit__ = Mock(return_value=False)
+
+        with (
+            patch(
+                "src.services.core.start_command_router.ConversationService",
+                return_value=mock_conv,
+            ),
+            patch(
+                "src.services.core.start_command_router.MembershipRepository",
+                return_value=mock_membership,
+            ),
+            patch.object(router, "_handle_new_user", new_callable=AsyncMock),
+        ):
+            await router.handle_start(update, context)
+
+        router.service.interaction_service.log_command.assert_called_once()
+
+
+# ──────────────────────────────────────────────────────────────
+# _handle_startgroup_link
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestHandleStartgroupLink:
+    async def test_valid_session_links_group(self, router):
+        """Valid session + correct user → links group and sends confirmation."""
+        update = _make_update(chat_type="group")
+        user = Mock(id="user-1")
+
+        session = Mock(
+            user_id="user-1",
+            step="awaiting_group",
+            pending_instance_name="My Brand",
+        )
+        mock_conv = Mock()
+        mock_conv.get_session_by_id.return_value = session
+        mock_conv.link_group_to_instance = Mock()
+        mock_conv.__enter__ = Mock(return_value=mock_conv)
+        mock_conv.__exit__ = Mock(return_value=False)
+
+        with patch(
+            "src.services.core.start_command_router.ConversationService",
+            return_value=mock_conv,
+        ):
+            await router._handle_startgroup_link(update, user, "setup_sess-1")
+
+        update.message.reply_text.assert_called_once()
+        assert "set up" in update.message.reply_text.call_args[0][0]
+
+    async def test_invalid_session_shows_error(self, router):
+        """Invalid session ID → error message."""
+        update = _make_update(chat_type="group")
+        user = Mock(id="user-1")
+
+        mock_conv = Mock()
+        mock_conv.get_session_by_id.return_value = None
+        mock_conv.__enter__ = Mock(return_value=mock_conv)
+        mock_conv.__exit__ = Mock(return_value=False)
+
+        with patch(
+            "src.services.core.start_command_router.ConversationService",
+            return_value=mock_conv,
+        ):
+            await router._handle_startgroup_link(update, user, "setup_bad-id")
+
+        update.message.reply_text.assert_called_once()
+        assert "Invalid" in update.message.reply_text.call_args[0][0]
+
+    async def test_wrong_user_shows_error(self, router):
+        """Session belongs to different user → error message."""
+        update = _make_update(chat_type="group")
+        user = Mock(id="user-1")
+
+        session = Mock(user_id="other-user", step="awaiting_group")
+        mock_conv = Mock()
+        mock_conv.get_session_by_id.return_value = session
+        mock_conv.__enter__ = Mock(return_value=mock_conv)
+        mock_conv.__exit__ = Mock(return_value=False)
+
+        with patch(
+            "src.services.core.start_command_router.ConversationService",
+            return_value=mock_conv,
+        ):
+            await router._handle_startgroup_link(update, user, "setup_sess-1")
+
+        update.message.reply_text.assert_called_once()
+        assert "Invalid" in update.message.reply_text.call_args[0][0]
+
+    async def test_wrong_step_shows_error(self, router):
+        """Session not in 'awaiting_group' step → error."""
+        update = _make_update(chat_type="group")
+        user = Mock(id="user-1")
+
+        session = Mock(user_id="user-1", step="naming")
+        mock_conv = Mock()
+        mock_conv.get_session_by_id.return_value = session
+        mock_conv.__enter__ = Mock(return_value=mock_conv)
+        mock_conv.__exit__ = Mock(return_value=False)
+
+        with patch(
+            "src.services.core.start_command_router.ConversationService",
+            return_value=mock_conv,
+        ):
+            await router._handle_startgroup_link(update, user, "setup_sess-1")
+
+        update.message.reply_text.assert_called_once()
+        assert "not waiting for a group" in update.message.reply_text.call_args[0][0]
+
+    async def test_dm_notification_failure_is_silent(self, router):
+        """If DM notification to user fails, it's silently ignored."""
+        update = _make_update(chat_type="group")
+        user = Mock(id="user-1")
+
+        session = Mock(
+            user_id="user-1",
+            step="awaiting_group",
+            pending_instance_name="Test",
+        )
+        mock_conv = Mock()
+        mock_conv.get_session_by_id.return_value = session
+        mock_conv.__enter__ = Mock(return_value=mock_conv)
+        mock_conv.__exit__ = Mock(return_value=False)
+
+        router.service.bot.send_message = AsyncMock(side_effect=Exception("DM blocked"))
+
+        with patch(
+            "src.services.core.start_command_router.ConversationService",
+            return_value=mock_conv,
+        ):
+            await router._handle_startgroup_link(update, user, "setup_sess-1")
+
+        # Should not raise, group message still sent
+        update.message.reply_text.assert_called_once()
+
+
+# ──────────────────────────────────────────────────────────────
+# _handle_group_start
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestHandleGroupStart:
+    @patch("src.services.core.start_command_router.settings")
+    @patch("src.services.core.start_command_router.build_webapp_button")
+    async def test_with_oauth_url_and_onboarding_done(
+        self, mock_button, mock_settings, router
+    ):
+        """Onboarding complete → 'Open Storyline' button."""
+        mock_settings.OAUTH_REDIRECT_BASE_URL = "https://example.com"
+        mock_button.return_value = Mock()
+
+        mock_settings_svc = Mock()
+        mock_settings_svc.get_settings.return_value = Mock(onboarding_completed=True)
+        mock_settings_svc.__enter__ = Mock(return_value=mock_settings_svc)
+        mock_settings_svc.__exit__ = Mock(return_value=False)
+
+        update = _make_update(chat_type="group")
+        user = Mock(id="user-1")
+
+        with patch(
+            "src.services.core.settings_service.SettingsService",
+            return_value=mock_settings_svc,
+        ):
+            await router._handle_group_start(update, user, 12345)
+
+        update.message.reply_text.assert_called_once()
+        assert "Welcome back" in update.message.reply_text.call_args[0][0]
+
+    @patch("src.services.core.start_command_router.settings")
+    async def test_without_oauth_url(self, mock_settings, router):
+        """No OAuth URL → shows command list instead."""
+        mock_settings.OAUTH_REDIRECT_BASE_URL = None
+
+        mock_settings_svc = Mock()
+        mock_settings_svc.get_settings.return_value = Mock(onboarding_completed=False)
+        mock_settings_svc.__enter__ = Mock(return_value=mock_settings_svc)
+        mock_settings_svc.__exit__ = Mock(return_value=False)
+
+        update = _make_update(chat_type="group")
+        user = Mock(id="user-1")
+
+        with patch(
+            "src.services.core.settings_service.SettingsService",
+            return_value=mock_settings_svc,
+        ):
+            await router._handle_group_start(update, user, 12345)
+
+        update.message.reply_text.assert_called_once()
+        text = update.message.reply_text.call_args[0][0]
+        assert "/status" in text
+        assert "/next" in text
+
+
+# ──────────────────────────────────────────────────────────────
+# _handle_resume_onboarding
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestHandleResumeOnboarding:
+    async def test_naming_step(self, router):
+        """Active session at 'naming' step → asks for instance name."""
+        update = _make_update(chat_type="private")
+        user = Mock(id="user-1")
+        session = Mock(step="naming")
+
+        await router._handle_resume_onboarding(update, user, session)
+
+        update.message.reply_text.assert_called_once()
+        assert "What do you want to call" in update.message.reply_text.call_args[0][0]
+
+    async def test_awaiting_group_step(self, router):
+        """Active session at 'awaiting_group' → shows 'Add to Group' button."""
+        update = _make_update(chat_type="private")
+        user = Mock(id="user-1")
+        session = Mock(
+            id="sess-1",
+            step="awaiting_group",
+            pending_instance_name="My Brand",
+        )
+
+        await router._handle_resume_onboarding(update, user, session)
+
+        update.message.reply_text.assert_called_once()
+        call_kwargs = update.message.reply_text.call_args[1]
+        assert call_kwargs.get("reply_markup") is not None
+
+
+# ──────────────────────────────────────────────────────────────
+# _handle_returning_user
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestHandleReturningUser:
+    async def test_shows_instances_with_manage_buttons(self, router):
+        """Shows user's instances with manage buttons and 'New Instance' option."""
+        mock_dash = Mock()
+        mock_dash.get_user_instances.return_value = {
+            "instances": [
+                {
+                    "display_name": "My Brand",
+                    "telegram_chat_id": -100123,
+                    "media_count": 50,
+                    "posts_per_day": 3,
+                    "is_paused": False,
+                    "chat_settings_id": "cs-1",
+                },
+            ],
+        }
+        mock_dash.__enter__ = Mock(return_value=mock_dash)
+        mock_dash.__exit__ = Mock(return_value=False)
+
+        update = _make_update(chat_type="private")
+        user = Mock(id="user-1")
+
+        with patch(
+            "src.services.core.start_command_router.DashboardService",
+            return_value=mock_dash,
+        ):
+            await router._handle_returning_user(update, user)
+
+        update.message.reply_text.assert_called_once()
+        call_kwargs = update.message.reply_text.call_args[1]
+        assert call_kwargs.get("reply_markup") is not None
+
+
+# ──────────────────────────────────────────────────────────────
+# _handle_new_user
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestHandleNewUser:
+    async def test_starts_onboarding_and_stores_session_id(self, router):
+        """Creates onboarding session and stores session ID in context."""
+        mock_conv = Mock()
+        mock_conv.start_onboarding.return_value = Mock(id="sess-1")
+        mock_conv.__enter__ = Mock(return_value=mock_conv)
+        mock_conv.__exit__ = Mock(return_value=False)
+
+        update = _make_update(chat_type="private")
+        user = Mock(id="user-1")
+        context = _make_context()
+
+        with patch(
+            "src.services.core.start_command_router.ConversationService",
+            return_value=mock_conv,
+        ):
+            await router._handle_new_user(update, user, context)
+
+        assert context.user_data["onboarding_session_id"] == "sess-1"
+        update.message.reply_text.assert_called_once()
+
+
+# ──────────────────────────────────────────────────────────────
+# _escape_md2
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestEscapeMd2:
+    def test_escapes_special_characters(self):
+        """Escapes all MarkdownV2 special characters."""
+        assert _escape_md2("hello_world") == "hello\\_world"
+        assert _escape_md2("test*bold*") == "test\\*bold\\*"
+        assert _escape_md2("a.b") == "a\\.b"
+
+    def test_plain_text_unchanged(self):
+        """Plain text without special chars passes through unchanged."""
+        assert _escape_md2("hello world") == "hello world"
+        assert _escape_md2("abc123") == "abc123"

--- a/tests/src/services/test_telegram_callbacks.py
+++ b/tests/src/services/test_telegram_callbacks.py
@@ -929,8 +929,8 @@ class TestRaceConditionHandling:
         await handlers.handle_posted(queue_id, mock_user, mock_query)
 
         # Lock and cancel flag should be cleaned up
-        assert queue_id not in service._operation_locks
-        assert queue_id not in service._cancel_flags
+        assert queue_id not in service.operation_state._operation_locks
+        assert queue_id not in service.operation_state._cancel_flags
 
     async def test_posted_sets_cancel_flag_for_autopost(self, mock_callback_handlers):
         """Test that clicking 'Posted' sets the cancel flag to abort pending auto-post."""

--- a/tests/src/services/test_telegram_callbacks_admin.py
+++ b/tests/src/services/test_telegram_callbacks_admin.py
@@ -152,7 +152,7 @@ class TestHandleResumeCallback:
     @patch("src.services.core.telegram_callbacks_admin.telegram_edit_with_retry")
     async def test_reschedule_action(self, mock_retry, handlers):
         """Reschedules overdue posts and resumes delivery."""
-        now = datetime.now(timezone.utc)
+        now = datetime.utcnow()
         overdue = [Mock(id="q-1", scheduled_for=now - timedelta(hours=2))]
         future = [Mock(id="q-2", scheduled_for=now + timedelta(hours=1))]
         handlers.service.queue_repo.get_all.return_value = overdue + future
@@ -169,7 +169,7 @@ class TestHandleResumeCallback:
     @patch("src.services.core.telegram_callbacks_admin.telegram_edit_with_retry")
     async def test_clear_action(self, mock_retry, handlers):
         """Clears overdue posts and resumes delivery."""
-        now = datetime.now(timezone.utc)
+        now = datetime.utcnow()
         overdue = [Mock(id="q-1", scheduled_for=now - timedelta(hours=2))]
         handlers.service.queue_repo.get_all.return_value = overdue
 
@@ -184,7 +184,7 @@ class TestHandleResumeCallback:
     @patch("src.services.core.telegram_callbacks_admin.telegram_edit_with_retry")
     async def test_force_action(self, mock_retry, handlers):
         """Force resumes without handling overdue posts."""
-        now = datetime.now(timezone.utc)
+        now = datetime.utcnow()
         overdue = [Mock(id="q-1", scheduled_for=now - timedelta(hours=2))]
         handlers.service.queue_repo.get_all.return_value = overdue
 

--- a/tests/src/services/test_telegram_callbacks_admin.py
+++ b/tests/src/services/test_telegram_callbacks_admin.py
@@ -1,6 +1,6 @@
 """Tests for TelegramCallbackAdminHandlers — batch approve, resume, reset."""
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from unittest.mock import Mock, patch
 
 import pytest
@@ -152,7 +152,7 @@ class TestHandleResumeCallback:
     @patch("src.services.core.telegram_callbacks_admin.telegram_edit_with_retry")
     async def test_reschedule_action(self, mock_retry, handlers):
         """Reschedules overdue posts and resumes delivery."""
-        now = datetime.now(timezone.utc)
+        now = datetime.utcnow()
         overdue = [Mock(id="q-1", scheduled_for=now - timedelta(hours=2))]
         future = [Mock(id="q-2", scheduled_for=now + timedelta(hours=1))]
         handlers.service.queue_repo.get_all.return_value = overdue + future
@@ -169,7 +169,7 @@ class TestHandleResumeCallback:
     @patch("src.services.core.telegram_callbacks_admin.telegram_edit_with_retry")
     async def test_clear_action(self, mock_retry, handlers):
         """Clears overdue posts and resumes delivery."""
-        now = datetime.now(timezone.utc)
+        now = datetime.utcnow()
         overdue = [Mock(id="q-1", scheduled_for=now - timedelta(hours=2))]
         handlers.service.queue_repo.get_all.return_value = overdue
 
@@ -184,7 +184,7 @@ class TestHandleResumeCallback:
     @patch("src.services.core.telegram_callbacks_admin.telegram_edit_with_retry")
     async def test_force_action(self, mock_retry, handlers):
         """Force resumes without handling overdue posts."""
-        now = datetime.now(timezone.utc)
+        now = datetime.utcnow()
         overdue = [Mock(id="q-1", scheduled_for=now - timedelta(hours=2))]
         handlers.service.queue_repo.get_all.return_value = overdue
 

--- a/tests/src/services/test_telegram_callbacks_admin.py
+++ b/tests/src/services/test_telegram_callbacks_admin.py
@@ -1,6 +1,6 @@
 """Tests for TelegramCallbackAdminHandlers — batch approve, resume, reset."""
 
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from unittest.mock import Mock, patch
 
 import pytest
@@ -152,7 +152,7 @@ class TestHandleResumeCallback:
     @patch("src.services.core.telegram_callbacks_admin.telegram_edit_with_retry")
     async def test_reschedule_action(self, mock_retry, handlers):
         """Reschedules overdue posts and resumes delivery."""
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         overdue = [Mock(id="q-1", scheduled_for=now - timedelta(hours=2))]
         future = [Mock(id="q-2", scheduled_for=now + timedelta(hours=1))]
         handlers.service.queue_repo.get_all.return_value = overdue + future
@@ -169,7 +169,7 @@ class TestHandleResumeCallback:
     @patch("src.services.core.telegram_callbacks_admin.telegram_edit_with_retry")
     async def test_clear_action(self, mock_retry, handlers):
         """Clears overdue posts and resumes delivery."""
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         overdue = [Mock(id="q-1", scheduled_for=now - timedelta(hours=2))]
         handlers.service.queue_repo.get_all.return_value = overdue
 
@@ -184,7 +184,7 @@ class TestHandleResumeCallback:
     @patch("src.services.core.telegram_callbacks_admin.telegram_edit_with_retry")
     async def test_force_action(self, mock_retry, handlers):
         """Force resumes without handling overdue posts."""
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         overdue = [Mock(id="q-1", scheduled_for=now - timedelta(hours=2))]
         handlers.service.queue_repo.get_all.return_value = overdue
 

--- a/tests/src/services/test_telegram_callbacks_admin.py
+++ b/tests/src/services/test_telegram_callbacks_admin.py
@@ -1,0 +1,259 @@
+"""Tests for TelegramCallbackAdminHandlers — batch approve, resume, reset."""
+
+from datetime import datetime, timedelta
+from unittest.mock import Mock, patch
+
+import pytest
+
+from src.services.core.telegram_callbacks_admin import TelegramCallbackAdminHandlers
+from src.services.core.telegram_callbacks_core import TelegramCallbackCore
+from tests.src.services.conftest import make_query as _make_query
+from tests.src.services.conftest import make_user as _make_user
+
+
+@pytest.fixture
+def mock_service():
+    """Minimal TelegramService mock for admin handler tests."""
+    service = Mock()
+    service.queue_repo = Mock()
+    service.interaction_service = Mock()
+    service._get_display_name.return_value = "AdminUser"
+    service.set_paused = Mock()
+    return service
+
+
+@pytest.fixture
+def mock_core(mock_service):
+    """TelegramCallbackCore mock."""
+    core = Mock(spec=TelegramCallbackCore)
+    core.service = mock_service
+    core._execute_complete_db_ops = Mock()
+    return core
+
+
+@pytest.fixture
+def handlers(mock_service, mock_core):
+    """TelegramCallbackAdminHandlers with mocked dependencies."""
+    return TelegramCallbackAdminHandlers(mock_service, mock_core)
+
+
+# ──────────────────────────────────────────────────────────────
+# handle_batch_approve
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestHandleBatchApprove:
+    @patch("src.services.core.telegram_callbacks_admin.telegram_edit_with_retry")
+    async def test_approves_all_items(self, mock_retry, handlers):
+        """Approves all pending+processing items and reports count."""
+        qi1, qi2 = Mock(id="q-1"), Mock(id="q-2")
+        handlers.service.queue_repo.get_all_with_media.side_effect = [
+            [(qi1, "f1.jpg", "memes")],  # pending
+            [(qi2, "f2.jpg", "memes")],  # processing
+        ]
+        handlers.service.queue_repo.claim_for_processing.return_value = Mock()
+
+        user = _make_user()
+        query = _make_query()
+
+        await handlers.handle_batch_approve("cs-1", user, query)
+
+        assert handlers.core._execute_complete_db_ops.call_count == 2
+        handlers.service.interaction_service.log_callback.assert_called_once()
+
+    @patch("src.services.core.telegram_callbacks_admin.telegram_edit_with_retry")
+    async def test_no_items_to_approve(self, mock_retry, handlers):
+        """Shows 'no pending items' when both lists are empty."""
+        handlers.service.queue_repo.get_all_with_media.return_value = []
+
+        user = _make_user()
+        query = _make_query()
+
+        await handlers.handle_batch_approve("cs-1", user, query)
+
+        mock_retry.assert_called()
+        # First real call after the progress message
+        first_call_text = mock_retry.call_args_list[0][0][1]
+        assert "No pending items" in first_call_text
+
+    @patch("src.services.core.telegram_callbacks_admin.telegram_edit_with_retry")
+    async def test_mixed_success_and_failure(self, mock_retry, handlers):
+        """Reports both approved and failed counts."""
+        qi1, qi2 = Mock(id="q-1"), Mock(id="q-2")
+        handlers.service.queue_repo.get_all_with_media.side_effect = [
+            [(qi1, "f1.jpg", "m"), (qi2, "f2.jpg", "m")],
+            [],
+        ]
+        # First succeeds, second fails
+        handlers.service.queue_repo.claim_for_processing.side_effect = [Mock(), Mock()]
+        handlers.core._execute_complete_db_ops.side_effect = [
+            None,
+            Exception("db error"),
+        ]
+
+        user = _make_user()
+        query = _make_query()
+
+        await handlers.handle_batch_approve("cs-1", user, query)
+
+        # Last call should contain both approved and failed counts
+        last_call_text = mock_retry.call_args_list[-1][0][1]
+        assert "1 item marked as posted" in last_call_text
+        assert "1 item failed" in last_call_text
+
+    @patch("src.services.core.telegram_callbacks_admin.telegram_edit_with_retry")
+    async def test_claim_failure_counts_as_failed(self, mock_retry, handlers):
+        """If claim_for_processing returns None, it counts as failed."""
+        qi1 = Mock(id="q-1")
+        handlers.service.queue_repo.get_all_with_media.side_effect = [
+            [(qi1, "f1.jpg", "m")],
+            [],
+        ]
+        handlers.service.queue_repo.claim_for_processing.return_value = None
+
+        user = _make_user()
+        query = _make_query()
+
+        await handlers.handle_batch_approve("cs-1", user, query)
+
+        handlers.core._execute_complete_db_ops.assert_not_called()
+
+
+# ──────────────────────────────────────────────────────────────
+# handle_batch_approve_cancel
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestHandleBatchApproveCancel:
+    @patch("src.services.core.telegram_callbacks_admin.telegram_edit_with_retry")
+    async def test_shows_cancelled_message(self, mock_retry, handlers):
+        """Shows cancellation message."""
+        user = _make_user()
+        query = _make_query()
+
+        await handlers.handle_batch_approve_cancel("cs-1", user, query)
+
+        mock_retry.assert_called_once()
+        assert "cancelled" in mock_retry.call_args[0][1].lower()
+
+
+# ──────────────────────────────────────────────────────────────
+# handle_resume_callback
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestHandleResumeCallback:
+    @patch("src.services.core.telegram_callbacks_admin.telegram_edit_with_retry")
+    async def test_reschedule_action(self, mock_retry, handlers):
+        """Reschedules overdue posts and resumes delivery."""
+        now = datetime.utcnow()
+        overdue = [Mock(id="q-1", scheduled_for=now - timedelta(hours=2))]
+        future = [Mock(id="q-2", scheduled_for=now + timedelta(hours=1))]
+        handlers.service.queue_repo.get_all.return_value = overdue + future
+
+        user = _make_user()
+        query = _make_query()
+
+        await handlers.handle_resume_callback("reschedule", user, query)
+
+        handlers.service.queue_repo.update_scheduled_time.assert_called_once()
+        handlers.service.set_paused.assert_called_once_with(False, user)
+        handlers.service.interaction_service.log_callback.assert_called_once()
+
+    @patch("src.services.core.telegram_callbacks_admin.telegram_edit_with_retry")
+    async def test_clear_action(self, mock_retry, handlers):
+        """Clears overdue posts and resumes delivery."""
+        now = datetime.utcnow()
+        overdue = [Mock(id="q-1", scheduled_for=now - timedelta(hours=2))]
+        handlers.service.queue_repo.get_all.return_value = overdue
+
+        user = _make_user()
+        query = _make_query()
+
+        await handlers.handle_resume_callback("clear", user, query)
+
+        handlers.service.queue_repo.delete.assert_called_once()
+        handlers.service.set_paused.assert_called_once_with(False, user)
+
+    @patch("src.services.core.telegram_callbacks_admin.telegram_edit_with_retry")
+    async def test_force_action(self, mock_retry, handlers):
+        """Force resumes without handling overdue posts."""
+        now = datetime.utcnow()
+        overdue = [Mock(id="q-1", scheduled_for=now - timedelta(hours=2))]
+        handlers.service.queue_repo.get_all.return_value = overdue
+
+        user = _make_user()
+        query = _make_query()
+
+        await handlers.handle_resume_callback("force", user, query)
+
+        handlers.service.set_paused.assert_called_once_with(False, user)
+        handlers.service.queue_repo.delete.assert_not_called()
+        handlers.service.queue_repo.update_scheduled_time.assert_not_called()
+
+    @patch("src.services.core.telegram_callbacks_admin.telegram_edit_with_retry")
+    async def test_error_shows_fallback_message(self, mock_retry, handlers):
+        """On exception, shows error message."""
+        handlers.service.queue_repo.get_all.side_effect = RuntimeError("db down")
+
+        user = _make_user()
+        query = _make_query()
+
+        await handlers.handle_resume_callback("reschedule", user, query)
+
+        mock_retry.assert_called_once()
+        assert "Error" in mock_retry.call_args[0][1]
+
+
+# ──────────────────────────────────────────────────────────────
+# handle_reset_callback
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestHandleResetCallback:
+    @patch("src.services.core.telegram_callbacks_admin.telegram_edit_with_retry")
+    async def test_confirm_clears_queue(self, mock_retry, handlers):
+        """Confirm action deletes all pending posts."""
+        pending = [Mock(id="q-1"), Mock(id="q-2")]
+        handlers.service.queue_repo.get_all.return_value = pending
+
+        user = _make_user()
+        query = _make_query()
+
+        await handlers.handle_reset_callback("confirm", user, query)
+
+        assert handlers.service.queue_repo.delete.call_count == 2
+        handlers.service.interaction_service.log_callback.assert_called_once()
+
+    @patch("src.services.core.telegram_callbacks_admin.telegram_edit_with_retry")
+    async def test_cancel_does_not_clear(self, mock_retry, handlers):
+        """Cancel action shows message but doesn't delete anything."""
+        user = _make_user()
+        query = _make_query()
+
+        await handlers.handle_reset_callback("cancel", user, query)
+
+        handlers.service.queue_repo.delete.assert_not_called()
+        mock_retry.assert_called_once()
+        assert "Cancelled" in mock_retry.call_args[0][1]
+
+    @patch("src.services.core.telegram_callbacks_admin.telegram_edit_with_retry")
+    async def test_error_during_confirm(self, mock_retry, handlers):
+        """On exception during confirm, shows error message."""
+        handlers.service.queue_repo.get_all.side_effect = RuntimeError("db down")
+
+        user = _make_user()
+        query = _make_query()
+
+        await handlers.handle_reset_callback("confirm", user, query)
+
+        mock_retry.assert_called_once()
+        assert "Error" in mock_retry.call_args[0][1]

--- a/tests/src/services/test_telegram_callbacks_admin.py
+++ b/tests/src/services/test_telegram_callbacks_admin.py
@@ -152,7 +152,7 @@ class TestHandleResumeCallback:
     @patch("src.services.core.telegram_callbacks_admin.telegram_edit_with_retry")
     async def test_reschedule_action(self, mock_retry, handlers):
         """Reschedules overdue posts and resumes delivery."""
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         overdue = [Mock(id="q-1", scheduled_for=now - timedelta(hours=2))]
         future = [Mock(id="q-2", scheduled_for=now + timedelta(hours=1))]
         handlers.service.queue_repo.get_all.return_value = overdue + future
@@ -169,7 +169,7 @@ class TestHandleResumeCallback:
     @patch("src.services.core.telegram_callbacks_admin.telegram_edit_with_retry")
     async def test_clear_action(self, mock_retry, handlers):
         """Clears overdue posts and resumes delivery."""
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         overdue = [Mock(id="q-1", scheduled_for=now - timedelta(hours=2))]
         handlers.service.queue_repo.get_all.return_value = overdue
 
@@ -184,7 +184,7 @@ class TestHandleResumeCallback:
     @patch("src.services.core.telegram_callbacks_admin.telegram_edit_with_retry")
     async def test_force_action(self, mock_retry, handlers):
         """Force resumes without handling overdue posts."""
-        now = datetime.utcnow()
+        now = datetime.now(timezone.utc)
         overdue = [Mock(id="q-1", scheduled_for=now - timedelta(hours=2))]
         handlers.service.queue_repo.get_all.return_value = overdue
 

--- a/tests/src/services/test_telegram_callbacks_core.py
+++ b/tests/src/services/test_telegram_callbacks_core.py
@@ -1,0 +1,344 @@
+"""Tests for TelegramCallbackCore — shared utilities and DB operations."""
+
+import asyncio
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, Mock, patch, MagicMock
+
+import pytest
+
+from src.repositories.history_repository import HistoryCreateParams
+from src.services.core.telegram_callbacks_core import TelegramCallbackCore
+from tests.src.services.conftest import noop_context_manager  # noqa: E402
+
+
+@pytest.fixture
+def mock_service():
+    """Build a minimal TelegramService mock with the dependencies Core needs."""
+    service = Mock()
+
+    # Repos
+    service.history_repo = Mock()
+    service.history_repo.db = MagicMock()
+    service.history_repo._db = MagicMock()
+    service.media_repo = Mock()
+    service.media_repo._db = MagicMock()
+    service.queue_repo = Mock()
+    service.queue_repo._db = MagicMock()
+    service.user_repo = Mock()
+    service.user_repo._db = MagicMock()
+    service.lock_service = Mock()
+    service.lock_service.lock_repo = Mock()
+    service.lock_service.lock_repo._db = MagicMock()
+
+    # Operation lock (real asyncio.Lock by default)
+    service.get_operation_lock.return_value = asyncio.Lock()
+    service.cleanup_operation_state = Mock()
+
+    return service
+
+
+@pytest.fixture
+def core(mock_service):
+    """Create a TelegramCallbackCore with mocked service."""
+    return TelegramCallbackCore(mock_service)
+
+
+# ──────────────────────────────────────────────────────────────
+# _safe_locked_callback
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestSafeLockedCallback:
+    async def test_runs_coroutine_under_lock(self, core):
+        """Happy path: coroutine runs, keyboard removed, state cleaned up."""
+        query = AsyncMock()
+        ran = False
+
+        async def work():
+            nonlocal ran
+            ran = True
+
+        await core._safe_locked_callback("q-1", query, "test_cb", "err msg", work())
+
+        assert ran
+        query.edit_message_reply_markup.assert_called_once()
+        core.service.cleanup_operation_state.assert_called_once_with("q-1")
+
+    async def test_already_locked_answers_and_skips(self, core):
+        """If the lock is already held, answer with a warning and skip."""
+        lock = asyncio.Lock()
+        await lock.acquire()  # pre-lock
+        core.service.get_operation_lock.return_value = lock
+
+        query = AsyncMock()
+        ran = False
+
+        async def work():
+            nonlocal ran
+            ran = True
+
+        await core._safe_locked_callback("q-1", query, "test_cb", "err msg", work())
+
+        assert not ran
+        query.answer.assert_called_once()
+        assert "Already processing" in query.answer.call_args[0][0]
+        lock.release()
+
+    @patch("src.services.core.telegram_callbacks_core.telegram_edit_with_retry")
+    async def test_callback_error_shows_error_message(self, mock_retry, core):
+        """If the coroutine raises, show the error caption and clean up."""
+        query = AsyncMock()
+
+        async def failing():
+            raise RuntimeError("boom")
+
+        await core._safe_locked_callback(
+            "q-1", query, "test_cb", "something went wrong", failing()
+        )
+
+        mock_retry.assert_called_once()
+        assert mock_retry.call_args[1]["caption"] == "something went wrong"
+        core.service.cleanup_operation_state.assert_called_once_with("q-1")
+
+    async def test_keyboard_removal_failure_does_not_block(self, core):
+        """If removing the keyboard fails, the callback still runs."""
+        query = AsyncMock()
+        query.edit_message_reply_markup.side_effect = Exception("Telegram hiccup")
+
+        ran = False
+
+        async def work():
+            nonlocal ran
+            ran = True
+
+        await core._safe_locked_callback("q-1", query, "test_cb", "err msg", work())
+
+        assert ran
+
+
+# ──────────────────────────────────────────────────────────────
+# _shared_session
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestSharedSession:
+    def test_commits_on_success(self, core):
+        """All repos share one session; real commit called at the end."""
+        primary = core.service.history_repo.db
+        original_commit = Mock()
+        primary.commit = original_commit
+
+        with core._shared_session():
+            pass  # no-op body
+
+        original_commit.assert_called_once()
+
+    def test_rollback_on_exception(self, core):
+        """On any exception, rollback is called and the error re-raised."""
+        primary = core.service.history_repo.db
+        original_commit = Mock()
+        primary.commit = original_commit
+
+        with pytest.raises(ValueError):
+            with core._shared_session():
+                raise ValueError("db problem")
+
+        primary.rollback.assert_called_once()
+        original_commit.assert_not_called()
+
+    def test_sessions_restored_after_success(self, core):
+        """After the context manager exits, each repo gets its original session back."""
+        repos = [
+            core.service.history_repo,
+            core.service.media_repo,
+            core.service.queue_repo,
+            core.service.user_repo,
+            core.service.lock_service.lock_repo,
+        ]
+        originals = [r._db for r in repos]
+
+        with core._shared_session():
+            pass
+
+        for repo, orig in zip(repos, originals):
+            repo.use_session.assert_called()
+            last_call = repo.use_session.call_args_list[-1]
+            assert last_call[0][0] is orig
+
+    def test_sessions_restored_after_failure(self, core):
+        """Sessions are restored even on failure."""
+        repos = [
+            core.service.history_repo,
+            core.service.media_repo,
+            core.service.queue_repo,
+            core.service.user_repo,
+            core.service.lock_service.lock_repo,
+        ]
+        originals = [r._db for r in repos]
+
+        with pytest.raises(RuntimeError):
+            with core._shared_session():
+                raise RuntimeError("kaboom")
+
+        for repo, orig in zip(repos, originals):
+            last_call = repo.use_session.call_args_list[-1]
+            assert last_call[0][0] is orig
+
+
+# ──────────────────────────────────────────────────────────────
+# _create_history_params
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestCreateHistoryParams:
+    def test_builds_correct_params(self, core):
+        """Returns HistoryCreateParams with all fields populated."""
+        queue_item = Mock(
+            media_item_id="media-1",
+            created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            scheduled_for=datetime(2026, 1, 2, tzinfo=timezone.utc),
+            chat_settings_id="cs-1",
+        )
+        user = Mock(id="user-1", telegram_username="test_user")
+
+        result = core._create_history_params("q-1", queue_item, user, "posted", True)
+
+        assert isinstance(result, HistoryCreateParams)
+        assert result.media_item_id == "media-1"
+        assert result.queue_item_id == "q-1"
+        assert result.status == "posted"
+        assert result.success is True
+        assert result.posted_by_user_id == "user-1"
+        assert result.posted_by_telegram_username == "test_user"
+        assert result.chat_settings_id == "cs-1"
+
+    def test_none_chat_settings_id(self, core):
+        """chat_settings_id is None when queue_item has no chat_settings_id."""
+        queue_item = Mock(
+            media_item_id="media-1",
+            created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            scheduled_for=datetime(2026, 1, 2, tzinfo=timezone.utc),
+            chat_settings_id=None,
+        )
+        user = Mock(id="user-1", telegram_username="test_user")
+
+        result = core._create_history_params("q-1", queue_item, user, "skipped", False)
+
+        assert result.chat_settings_id is None
+
+
+# ──────────────────────────────────────────────────────────────
+# _execute_complete_db_ops
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestExecuteCompleteDbOps:
+    def _setup_shared_session(self, core):
+        """Replace _shared_session with a pass-through context manager."""
+        core._shared_session = noop_context_manager
+
+    def test_posted_increments_and_locks(self, core):
+        """For 'posted' status: increment posts, create lock, increment user."""
+        self._setup_shared_session(core)
+        media_item = Mock()
+        core.service.media_repo.get_by_id.return_value = media_item
+
+        queue_item = Mock(
+            media_item_id="media-1",
+            created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            scheduled_for=datetime(2026, 1, 2, tzinfo=timezone.utc),
+            chat_settings_id="cs-1",
+        )
+        user = Mock(id="user-1", telegram_username="u")
+
+        result = core._execute_complete_db_ops("q-1", queue_item, user, "posted", True)
+
+        assert result is media_item
+        core.service.history_repo.create.assert_called_once()
+        core.service.media_repo.increment_times_posted.assert_called_once_with(
+            "media-1"
+        )
+        core.service.lock_service.create_lock.assert_called_once_with("media-1")
+        core.service.user_repo.increment_posts.assert_called_once_with("user-1")
+        core.service.queue_repo.delete.assert_called_once_with("q-1")
+
+    def test_skipped_creates_skip_lock(self, core):
+        """For 'skipped' status: create lock with skip TTL, no post increment."""
+        self._setup_shared_session(core)
+        media_item = Mock()
+        core.service.media_repo.get_by_id.return_value = media_item
+
+        queue_item = Mock(
+            media_item_id="media-1",
+            created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            scheduled_for=datetime(2026, 1, 2, tzinfo=timezone.utc),
+            chat_settings_id="cs-1",
+        )
+        user = Mock(id="user-1", telegram_username="u")
+
+        with patch(
+            "src.services.core.telegram_callbacks_core.settings"
+        ) as mock_settings:
+            mock_settings.SKIP_TTL_DAYS = 7
+            core._execute_complete_db_ops("q-1", queue_item, user, "skipped", False)
+
+        core.service.lock_service.create_lock.assert_called_once_with(
+            "media-1", ttl_days=7, lock_reason="skip"
+        )
+        core.service.media_repo.increment_times_posted.assert_not_called()
+        core.service.user_repo.increment_posts.assert_not_called()
+
+
+# ──────────────────────────────────────────────────────────────
+# _execute_reject_db_ops
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestExecuteRejectDbOps:
+    def test_creates_permanent_lock_and_deletes_queue(self, core):
+        """Rejection: history created, permanent lock, queue item deleted."""
+        core._shared_session = noop_context_manager
+
+        media_item = Mock()
+        core.service.media_repo.get_by_id.return_value = media_item
+
+        queue_item = Mock(
+            media_item_id="media-1",
+            created_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            scheduled_for=datetime(2026, 1, 2, tzinfo=timezone.utc),
+            chat_settings_id="cs-1",
+        )
+        user = Mock(id="user-1", telegram_username="u")
+
+        result = core._execute_reject_db_ops("q-1", queue_item, user)
+
+        assert result is media_item
+        core.service.history_repo.create.assert_called_once()
+        core.service.lock_service.create_permanent_lock.assert_called_once_with(
+            "media-1", created_by_user_id="user-1"
+        )
+        core.service.queue_repo.delete.assert_called_once_with("q-1")
+
+
+# ──────────────────────────────────────────────────────────────
+# _refresh_repo_sessions
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestRefreshRepoSessions:
+    def test_calls_end_read_transaction_on_all_repos(self, core):
+        """All repos and lock_repo have their sessions refreshed."""
+        core._refresh_repo_sessions()
+
+        core.service.history_repo.end_read_transaction.assert_called_once()
+        core.service.media_repo.end_read_transaction.assert_called_once()
+        core.service.queue_repo.end_read_transaction.assert_called_once()
+        core.service.user_repo.end_read_transaction.assert_called_once()
+        core.service.lock_service.lock_repo.end_read_transaction.assert_called_once()

--- a/tests/src/services/test_telegram_callbacks_queue.py
+++ b/tests/src/services/test_telegram_callbacks_queue.py
@@ -1,0 +1,568 @@
+"""Tests for TelegramCallbackQueueHandlers — posted/skipped/rejected flows."""
+
+import asyncio
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+from sqlalchemy.exc import OperationalError
+
+from src.services.core.telegram_callbacks_core import TelegramCallbackCore
+from src.services.core.telegram_callbacks_queue import TelegramCallbackQueueHandlers
+from tests.src.services.conftest import make_query as _make_query
+from tests.src.services.conftest import make_user as _make_user
+
+
+async def _consume_coro_args(*args, **kwargs):
+    """Close any coroutine arguments to prevent 'never awaited' warnings."""
+    for arg in args:
+        if asyncio.iscoroutine(arg):
+            arg.close()
+
+
+@pytest.fixture
+def mock_service():
+    """Minimal TelegramService mock for queue handler tests."""
+    service = Mock()
+    service.queue_repo = Mock()
+    service.media_repo = Mock()
+    service.history_repo = Mock()
+    service.interaction_service = Mock()
+    service.settings_service = Mock()
+    service.ig_account_service = Mock()
+    service.ig_account_service.get_active_account.return_value = None
+    service.ig_account_service.count_active_accounts.return_value = 1
+    service._get_display_name.return_value = "TestUser"
+    service._is_verbose.return_value = False
+    service.get_cancel_flag.return_value = Mock()
+    service._build_caption.return_value = "original caption"
+
+    return service
+
+
+@pytest.fixture
+def mock_core(mock_service):
+    """TelegramCallbackCore with mocked internals."""
+    core = Mock(spec=TelegramCallbackCore)
+    core.service = mock_service
+    core._safe_locked_callback = AsyncMock(side_effect=_consume_coro_args)
+    core._execute_complete_db_ops = Mock()
+    core._execute_reject_db_ops = Mock()
+    core._refresh_repo_sessions = Mock()
+    return core
+
+
+@pytest.fixture
+def handlers(mock_service, mock_core):
+    """TelegramCallbackQueueHandlers with mocked dependencies."""
+    return TelegramCallbackQueueHandlers(mock_service, mock_core)
+
+
+# ──────────────────────────────────────────────────────────────
+# handle_posted
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestHandlePosted:
+    async def test_sets_cancel_flag_and_delegates(self, handlers):
+        """Sets the cancel flag for autopost, then calls complete_queue_action."""
+        user = _make_user()
+        query = _make_query()
+
+        await handlers.handle_posted("q-1", user, query)
+
+        handlers.service.get_cancel_flag.assert_called_once_with("q-1")
+        handlers.service.get_cancel_flag.return_value.set.assert_called_once()
+        handlers.core._safe_locked_callback.assert_called_once()
+
+    async def test_verbose_caption_includes_marked_as(self, handlers):
+        """Verbose mode passes 'Marked as posted by' caption."""
+        handlers.service._is_verbose.return_value = True
+        user = _make_user()
+        query = _make_query()
+
+        # Call the internal method directly to verify caption content
+        with patch.object(
+            handlers, "complete_queue_action", new_callable=AsyncMock
+        ) as mock_cqa:
+            await handlers.handle_posted("q-1", user, query)
+
+        caption = mock_cqa.call_args[1]["caption"]
+        assert "Marked as posted" in caption
+        assert "TestUser" in caption
+
+    async def test_non_verbose_caption(self, handlers):
+        """Non-verbose mode passes shorter caption without 'Marked as'."""
+        handlers.service._is_verbose.return_value = False
+        user = _make_user()
+        query = _make_query()
+
+        with patch.object(
+            handlers, "complete_queue_action", new_callable=AsyncMock
+        ) as mock_cqa:
+            await handlers.handle_posted("q-1", user, query)
+
+        caption = mock_cqa.call_args[1]["caption"]
+        assert "Marked as posted" not in caption
+        assert "TestUser" in caption
+
+
+# ──────────────────────────────────────────────────────────────
+# handle_skipped
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestHandleSkipped:
+    async def test_sets_cancel_flag_and_delegates(self, handlers):
+        """Sets cancel flag and delegates to complete_queue_action with 'skipped'."""
+        user = _make_user()
+        query = _make_query()
+
+        await handlers.handle_skipped("q-1", user, query)
+
+        handlers.service.get_cancel_flag.assert_called_once_with("q-1")
+        handlers.service.get_cancel_flag.return_value.set.assert_called_once()
+        handlers.core._safe_locked_callback.assert_called_once()
+
+
+# ──────────────────────────────────────────────────────────────
+# _do_complete_queue_action
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestDoCompleteQueueAction:
+    @patch("src.services.core.telegram_callbacks_queue.telegram_edit_with_retry")
+    async def test_happy_path(self, mock_retry, handlers):
+        """Claim, execute DB ops, update caption, log interaction."""
+        queue_item = Mock(media_item_id="m-1")
+        handlers.service.queue_repo.claim_for_processing.return_value = queue_item
+        media_item = Mock(file_name="photo.jpg")
+        handlers.core._execute_complete_db_ops.return_value = media_item
+
+        user = _make_user()
+        query = _make_query()
+
+        await handlers._do_complete_queue_action(
+            "q-1", user, query, "posted", True, "Done!", "posted"
+        )
+
+        handlers.service.queue_repo.claim_for_processing.assert_called_once_with("q-1")
+        handlers.core._execute_complete_db_ops.assert_called_once_with(
+            "q-1", queue_item, user, "posted", True
+        )
+        mock_retry.assert_called_once()
+        handlers.service.interaction_service.log_callback.assert_called_once()
+        handlers.service.interaction_service.log_bot_response.assert_called_once()
+
+    @patch("src.services.core.telegram_callbacks_queue.validate_queue_item")
+    async def test_already_claimed_validates(self, mock_validate, handlers):
+        """If claim returns None, call validate_queue_item for user feedback."""
+        mock_validate.return_value = AsyncMock()
+        handlers.service.queue_repo.claim_for_processing.return_value = None
+
+        user = _make_user()
+        query = _make_query()
+
+        await handlers._do_complete_queue_action(
+            "q-1", user, query, "posted", True, "Done!", "posted"
+        )
+
+        mock_validate.assert_called_once()
+        handlers.core._execute_complete_db_ops.assert_not_called()
+
+    @patch("src.services.core.telegram_callbacks_queue.telegram_edit_with_retry")
+    async def test_operational_error_retries(self, mock_retry, handlers):
+        """On OperationalError, refresh sessions and retry once."""
+        queue_item = Mock(media_item_id="m-1")
+        handlers.service.queue_repo.claim_for_processing.return_value = queue_item
+        handlers.service.history_repo.get_by_queue_item_id.return_value = None
+        handlers.service.queue_repo.get_by_id.return_value = queue_item
+
+        media_item = Mock(file_name="photo.jpg")
+        handlers.core._execute_complete_db_ops.side_effect = [
+            OperationalError("ssl", {}, Exception()),
+            media_item,
+        ]
+
+        user = _make_user()
+        query = _make_query()
+
+        await handlers._do_complete_queue_action(
+            "q-1", user, query, "posted", True, "Done!", "posted"
+        )
+
+        assert handlers.core._execute_complete_db_ops.call_count == 2
+        handlers.core._refresh_repo_sessions.assert_called_once()
+
+    @patch("src.services.core.telegram_callbacks_queue.telegram_edit_with_retry")
+    async def test_operational_error_with_existing_history(self, mock_retry, handlers):
+        """If history already exists after OperationalError, just clean up."""
+        queue_item = Mock(media_item_id="m-1")
+        handlers.service.queue_repo.claim_for_processing.return_value = queue_item
+        media_item = Mock(file_name="photo.jpg")
+        handlers.service.media_repo.get_by_id.return_value = media_item
+
+        existing_history = Mock()
+        handlers.service.history_repo.get_by_queue_item_id.return_value = (
+            existing_history
+        )
+
+        handlers.core._execute_complete_db_ops.side_effect = OperationalError(
+            "ssl", {}, Exception()
+        )
+
+        user = _make_user()
+        query = _make_query()
+
+        await handlers._do_complete_queue_action(
+            "q-1", user, query, "posted", True, "Done!", "posted"
+        )
+
+        handlers.service.queue_repo.delete.assert_called_once_with("q-1")
+        assert handlers.core._execute_complete_db_ops.call_count == 1
+
+    @patch("src.services.core.telegram_callbacks_queue.telegram_edit_with_retry")
+    async def test_operational_error_queue_item_gone(self, mock_retry, handlers):
+        """If queue item gone after session refresh, show 'already processed'."""
+        queue_item = Mock(media_item_id="m-1")
+        handlers.service.queue_repo.claim_for_processing.return_value = queue_item
+        handlers.service.history_repo.get_by_queue_item_id.return_value = None
+        handlers.service.queue_repo.get_by_id.return_value = None
+
+        handlers.core._execute_complete_db_ops.side_effect = OperationalError(
+            "ssl", {}, Exception()
+        )
+
+        user = _make_user()
+        query = _make_query()
+
+        await handlers._do_complete_queue_action(
+            "q-1", user, query, "posted", True, "Done!", "posted"
+        )
+
+        mock_retry.assert_called_once()
+        assert "already processed" in mock_retry.call_args[1]["caption"]
+
+
+# ──────────────────────────────────────────────────────────────
+# handle_back
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestHandleBack:
+    @patch("src.services.core.telegram_callbacks_queue.build_queue_action_keyboard")
+    @patch("src.services.core.telegram_callbacks_queue.validate_queue_and_media")
+    @patch("src.services.core.telegram_callbacks_queue.telegram_edit_with_retry")
+    async def test_restores_original_message(
+        self, mock_retry, mock_validate, mock_keyboard, handlers
+    ):
+        """Restores original caption and keyboard."""
+        queue_item = Mock()
+        media_item = Mock()
+        mock_validate.return_value = (queue_item, media_item)
+        mock_keyboard.return_value = Mock()
+        handlers.service.settings_service.get_settings.return_value = Mock(
+            enable_instagram_api=False
+        )
+
+        user = _make_user()
+        query = _make_query()
+
+        await handlers.handle_back("q-1", user, query)
+
+        mock_validate.assert_called_once()
+        handlers.service._build_caption.assert_called_once()
+        mock_retry.assert_called_once()
+
+    @patch("src.services.core.telegram_callbacks_queue.validate_queue_and_media")
+    async def test_returns_early_if_queue_item_missing(self, mock_validate, handlers):
+        """Returns early if queue item no longer exists."""
+        mock_validate.return_value = (None, None)
+
+        user = _make_user()
+        query = _make_query()
+
+        await handlers.handle_back("q-1", user, query)
+
+        handlers.service._build_caption.assert_not_called()
+
+    @patch("src.services.core.telegram_callbacks_queue.telegram_edit_with_retry")
+    @patch("src.services.core.telegram_callbacks_queue.validate_queue_and_media")
+    async def test_returns_early_if_no_chat_settings(
+        self, mock_validate, mock_retry, handlers
+    ):
+        """Returns early if chat_settings not found — message not updated."""
+        mock_validate.return_value = (Mock(), Mock())
+        handlers.service.settings_service.get_settings.return_value = None
+
+        user = _make_user()
+        query = _make_query()
+
+        await handlers.handle_back("q-1", user, query)
+
+        mock_retry.assert_not_called()
+
+
+# ──────────────────────────────────────────────────────────────
+# handle_regenerate_caption
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestHandleRegenerateCaption:
+    @patch("src.services.core.telegram_callbacks_queue.build_queue_action_keyboard")
+    @patch("src.services.core.telegram_callbacks_queue.validate_queue_and_media")
+    @patch("src.utils.resilience.telegram_edit_with_retry")
+    async def test_success_regenerates_and_updates(
+        self, mock_retry, mock_validate, mock_keyboard, handlers
+    ):
+        """Generates new caption, rebuilds message, updates UI."""
+        chat_settings = Mock(enable_ai_captions=True, enable_instagram_api=False)
+        handlers.service.settings_service.get_settings.return_value = chat_settings
+
+        queue_item = Mock(media_item_id="m-1")
+        media_item = Mock(generated_caption="new caption", caption=None)
+        mock_validate.return_value = (queue_item, media_item)
+        handlers.service.media_repo.get_by_id.return_value = media_item
+
+        mock_caption_svc = Mock()
+        mock_caption_svc.generate_caption = AsyncMock(return_value="AI generated")
+        mock_caption_svc.__enter__ = Mock(return_value=mock_caption_svc)
+        mock_caption_svc.__exit__ = Mock(return_value=False)
+
+        user = _make_user()
+        query = _make_query()
+
+        with patch(
+            "src.services.core.caption_service.CaptionService",
+            return_value=mock_caption_svc,
+        ):
+            await handlers.handle_regenerate_caption("q-1", user, query)
+
+        mock_retry.assert_called_once()
+
+    async def test_disabled_ai_captions_answers_alert(self, handlers):
+        """If AI captions are disabled, show alert and return."""
+        chat_settings = Mock(enable_ai_captions=False)
+        handlers.service.settings_service.get_settings.return_value = chat_settings
+
+        user = _make_user()
+        query = _make_query()
+
+        await handlers.handle_regenerate_caption("q-1", user, query)
+
+        query.answer.assert_called_once()
+        assert "disabled" in query.answer.call_args[0][0]
+
+    @patch("src.services.core.telegram_callbacks_queue.validate_queue_and_media")
+    async def test_generation_failure_answers_alert(self, mock_validate, handlers):
+        """If caption generation returns None, show alert."""
+        chat_settings = Mock(enable_ai_captions=True)
+        handlers.service.settings_service.get_settings.return_value = chat_settings
+        mock_validate.return_value = (Mock(media_item_id="m-1"), Mock())
+
+        mock_caption_svc = Mock()
+        mock_caption_svc.generate_caption = AsyncMock(return_value=None)
+        mock_caption_svc.__enter__ = Mock(return_value=mock_caption_svc)
+        mock_caption_svc.__exit__ = Mock(return_value=False)
+
+        user = _make_user()
+        query = _make_query()
+
+        with patch(
+            "src.services.core.caption_service.CaptionService",
+            return_value=mock_caption_svc,
+        ):
+            await handlers.handle_regenerate_caption("q-1", user, query)
+
+        query.answer.assert_called_once()
+        assert "failed" in query.answer.call_args[0][0]
+
+    async def test_no_chat_settings_answers_alert(self, handlers):
+        """If chat_settings is None, show alert."""
+        handlers.service.settings_service.get_settings.return_value = None
+
+        user = _make_user()
+        query = _make_query()
+
+        await handlers.handle_regenerate_caption("q-1", user, query)
+
+        query.answer.assert_called_once()
+
+
+# ──────────────────────────────────────────────────────────────
+# handle_reject_confirmation
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestHandleRejectConfirmation:
+    @patch("src.services.core.telegram_callbacks_queue.validate_queue_item")
+    @patch("src.services.core.telegram_callbacks_queue.telegram_edit_with_retry")
+    async def test_shows_confirmation_dialog(self, mock_retry, mock_validate, handlers):
+        """Shows Yes/No keyboard with file name and warning."""
+        queue_item = Mock(media_item_id="m-1")
+        mock_validate.return_value = queue_item
+        media_item = Mock(file_name="photo.jpg")
+        handlers.service.media_repo.get_by_id.return_value = media_item
+
+        user = _make_user()
+        query = _make_query()
+
+        await handlers.handle_reject_confirmation("q-1", user, query)
+
+        mock_retry.assert_called_once()
+        call_kwargs = mock_retry.call_args[1]
+        assert "Are you sure" in call_kwargs["caption"]
+        assert call_kwargs["reply_markup"] is not None
+        handlers.service.interaction_service.log_callback.assert_called_once()
+
+    @patch("src.services.core.telegram_callbacks_queue.validate_queue_item")
+    async def test_returns_early_if_queue_item_missing(self, mock_validate, handlers):
+        """Returns early if queue item not found."""
+        mock_validate.return_value = None
+
+        user = _make_user()
+        query = _make_query()
+
+        await handlers.handle_reject_confirmation("q-1", user, query)
+
+        handlers.service.media_repo.get_by_id.assert_not_called()
+
+
+# ──────────────────────────────────────────────────────────────
+# handle_cancel_reject
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestHandleCancelReject:
+    @patch("src.services.core.telegram_callbacks_queue.build_queue_action_keyboard")
+    @patch("src.services.core.telegram_callbacks_queue.validate_queue_and_media")
+    @patch("src.services.core.telegram_callbacks_queue.telegram_edit_with_retry")
+    async def test_restores_original_buttons(
+        self, mock_retry, mock_validate, mock_keyboard, handlers
+    ):
+        """Cancelling reject restores original caption and keyboard."""
+        queue_item = Mock()
+        media_item = Mock()
+        mock_validate.return_value = (queue_item, media_item)
+        mock_keyboard.return_value = Mock()
+        handlers.service.settings_service.get_settings.return_value = Mock(
+            enable_instagram_api=True
+        )
+
+        user = _make_user()
+        query = _make_query()
+
+        await handlers.handle_cancel_reject("q-1", user, query)
+
+        mock_validate.assert_called_once()
+        handlers.service._build_caption.assert_called_once()
+        mock_retry.assert_called_once()
+        handlers.service.interaction_service.log_callback.assert_called_once()
+
+
+# ──────────────────────────────────────────────────────────────
+# handle_rejected + _do_handle_rejected
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestHandleRejected:
+    async def test_sets_cancel_flag_and_uses_lock(self, handlers):
+        """Sets cancel flag and delegates via _safe_locked_callback."""
+        user = _make_user()
+        query = _make_query()
+
+        await handlers.handle_rejected("q-1", user, query)
+
+        handlers.service.get_cancel_flag.assert_called_once_with("q-1")
+        handlers.service.get_cancel_flag.return_value.set.assert_called_once()
+        handlers.core._safe_locked_callback.assert_called_once()
+
+    @patch("src.services.core.telegram_callbacks_queue.telegram_edit_with_retry")
+    async def test_do_handle_rejected_happy_path(self, mock_retry, handlers):
+        """Successful rejection: claim, DB ops, update caption, log."""
+        queue_item = Mock(media_item_id="m-1")
+        handlers.service.queue_repo.claim_for_processing.return_value = queue_item
+        media_item = Mock(file_name="photo.jpg")
+        handlers.core._execute_reject_db_ops.return_value = media_item
+
+        user = _make_user()
+        query = _make_query()
+
+        await handlers._do_handle_rejected("q-1", user, query)
+
+        handlers.core._execute_reject_db_ops.assert_called_once_with(
+            "q-1", queue_item, user
+        )
+        mock_retry.assert_called_once()
+        handlers.service.interaction_service.log_callback.assert_called_once()
+        handlers.service.interaction_service.log_bot_response.assert_called_once()
+
+    @patch("src.services.core.telegram_callbacks_queue.validate_queue_item")
+    async def test_do_handle_rejected_already_claimed(self, mock_validate, handlers):
+        """If claim returns None, calls validate_queue_item."""
+        mock_validate.return_value = AsyncMock()
+        handlers.service.queue_repo.claim_for_processing.return_value = None
+
+        user = _make_user()
+        query = _make_query()
+
+        await handlers._do_handle_rejected("q-1", user, query)
+
+        mock_validate.assert_called_once()
+        handlers.core._execute_reject_db_ops.assert_not_called()
+
+    @patch("src.services.core.telegram_callbacks_queue.telegram_edit_with_retry")
+    async def test_do_handle_rejected_verbose_caption(self, mock_retry, handlers):
+        """Verbose mode includes file name and permanent rejection notice."""
+        handlers.service._is_verbose.return_value = True
+        queue_item = Mock(media_item_id="m-1")
+        handlers.service.queue_repo.claim_for_processing.return_value = queue_item
+        media_item = Mock(file_name="photo.jpg")
+        handlers.core._execute_reject_db_ops.return_value = media_item
+
+        user = _make_user()
+        query = _make_query()
+
+        await handlers._do_handle_rejected("q-1", user, query)
+
+        caption = mock_retry.call_args[1]["caption"]
+        assert "Permanently Rejected" in caption
+
+    @patch("src.services.core.telegram_callbacks_queue.telegram_edit_with_retry")
+    async def test_do_handle_rejected_operational_error_retry(
+        self, mock_retry, handlers
+    ):
+        """On OperationalError, refresh and retry once."""
+        queue_item = Mock(media_item_id="m-1")
+        handlers.service.queue_repo.claim_for_processing.return_value = queue_item
+        handlers.service.history_repo.get_by_queue_item_id.return_value = None
+        handlers.service.queue_repo.get_by_id.return_value = queue_item
+
+        media_item = Mock(file_name="photo.jpg")
+        handlers.core._execute_reject_db_ops.side_effect = [
+            OperationalError("ssl", {}, Exception()),
+            media_item,
+        ]
+
+        user = _make_user()
+        query = _make_query()
+
+        await handlers._do_handle_rejected("q-1", user, query)
+
+        assert handlers.core._execute_reject_db_ops.call_count == 2
+        handlers.core._refresh_repo_sessions.assert_called_once()

--- a/tests/src/services/test_user_service.py
+++ b/tests/src/services/test_user_service.py
@@ -1,0 +1,104 @@
+"""Tests for UserService — user management operations."""
+
+from unittest.mock import Mock, patch
+
+import pytest
+
+from src.services.core.user_service import UserService
+
+
+@pytest.fixture
+def user_service():
+    """UserService with mocked __init__ and dependencies."""
+    with patch.object(UserService, "__init__", lambda self: None):
+        service = UserService()
+        service.user_repo = Mock()
+        return service
+
+
+# ──────────────────────────────────────────────────────────────
+# list_users
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestListUsers:
+    def test_returns_all_users(self, user_service):
+        """Returns all users without filter."""
+        users = [Mock(), Mock()]
+        user_service.user_repo.get_all.return_value = users
+
+        result = user_service.list_users()
+
+        assert result == users
+        user_service.user_repo.get_all.assert_called_once_with(is_active=None)
+
+    def test_filters_by_active(self, user_service):
+        """Passes is_active filter to repository."""
+        user_service.user_repo.get_all.return_value = [Mock()]
+
+        result = user_service.list_users(is_active=True)
+
+        assert len(result) == 1
+        user_service.user_repo.get_all.assert_called_once_with(is_active=True)
+
+    def test_returns_empty_list(self, user_service):
+        """Returns empty list when no users match."""
+        user_service.user_repo.get_all.return_value = []
+
+        result = user_service.list_users(is_active=False)
+
+        assert result == []
+
+
+# ──────────────────────────────────────────────────────────────
+# get_by_telegram_id
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestGetByTelegramId:
+    def test_returns_user(self, user_service):
+        """Returns user when found."""
+        user = Mock()
+        user_service.user_repo.get_by_telegram_id.return_value = user
+
+        result = user_service.get_by_telegram_id(123456)
+
+        assert result is user
+        user_service.user_repo.get_by_telegram_id.assert_called_once_with(123456)
+
+    def test_returns_none_when_not_found(self, user_service):
+        """Returns None when user doesn't exist."""
+        user_service.user_repo.get_by_telegram_id.return_value = None
+
+        result = user_service.get_by_telegram_id(999999)
+
+        assert result is None
+
+
+# ──────────────────────────────────────────────────────────────
+# promote_user
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestPromoteUser:
+    def test_updates_role(self, user_service):
+        """Changes user role and returns user."""
+        user = Mock(id="user-1")
+        user_service.user_repo.get_by_telegram_id.return_value = user
+
+        result = user_service.promote_user(123456, "admin")
+
+        assert result is user
+        user_service.user_repo.update_role.assert_called_once_with("user-1", "admin")
+
+    def test_raises_for_unknown_user(self, user_service):
+        """Raises ValueError when user not found."""
+        user_service.user_repo.get_by_telegram_id.return_value = None
+
+        with pytest.raises(ValueError, match="User not found"):
+            user_service.promote_user(999999, "admin")
+
+        user_service.user_repo.update_role.assert_not_called()


### PR DESCRIPTION
## Summary

Breaks the 804-line `TelegramService` god class into a thin orchestrator (496 lines) plus 4 focused handler classes, following the existing composition pattern used by `TelegramCommandHandlers`, `TelegramAutopostHandler`, etc.

**Extracted classes:**
- **`OperationStateManager`** (36 lines) — per-queue-item asyncio locks and cancellation flags
- **`TelegramUserManager`** (90 lines) — user creation, profile sync, membership cache, display names
- **`TelegramMembershipHandler`** (185 lines) — bot added/removed from groups, onboarding DM flow
- **`TelegramLifecycleHandler`** (95 lines) — startup/shutdown admin notifications

**Also:**
- Consolidated duplicate `_escape_markdown` (was in `telegram_service.py` and `telegram_notification.py`) into `telegram_utils.py` as the canonical location
- TelegramService keeps thin delegate methods so all 20+ handler call sites (`self.service.get_operation_lock()`, `self.service._get_or_create_user()`, etc.) continue working unchanged
- Updated tests for the new structure

## What stays in TelegramService

- `__init__` with repos/services (still the dependency container)
- `initialize()` — handler instantiation and Telegram handler registration
- Callback dispatch table and two-tier routing
- Conversation message routing (thin, ~10 lines)
- Notification/lifecycle delegates
- Polling lifecycle (`start_polling`, `stop_polling`)
- `cleanup_transactions` / `close` overrides (InteractionService special handling)

Closes #251

## Test plan

- [x] All 1618 tracked tests pass (16 skipped)
- [x] Pre-existing failures excluded (conversation_service SettingsService mock, backfill_downloader 403)
- [x] Updated `test_phase2b_handlers.py` to test `TelegramMembershipHandler` directly
- [x] Updated `test_telegram_callbacks.py` for `operation_state` internal path
- [x] Ran `/simplify` — moved `is_verbose` off `TelegramUserManager` (settings concern), stripped boilerplate docstrings