### PR TITLE
fix: guard cleanup_transactions in finally blocks to prevent scheduler crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Guard `cleanup_transactions()` in background loop finally blocks** (#264) — Wrapped 7 unguarded `cleanup_transactions()` / `end_read_transaction()` calls in `try/except` across all background loops (scheduler, retention tick, pool/token health ticks, lock cleanup, cloud storage cleanup, media sync). An unhandled exception in a `finally` block could crash the loop via `_guarded()` while the worker process stayed alive — causing the scheduler to silently stop posting.
 - **Narrow broad `except Exception` catches** (#250) — Audited 88 `except Exception` catches across `src/services/`. Narrowed catches to specific types (`TelegramError`, `SQLAlchemyError`, `InvalidToken`, etc.) where failure modes are known. Added `noqa: BLE001` annotations with justification comments to intentionally broad catches (best-effort logging, cleanup, health checks). Added `exc_info=True` to health check error handlers.
 - **Replace deprecated `datetime.utcnow()` calls** (#249) — Replaced 30+ `datetime.utcnow()` calls across `src/services/` with timezone-aware `datetime.now(timezone.utc)`, eliminating Python 3.12 deprecation warnings. Inverted `.replace(tzinfo=None)` patterns to ensure consistent aware-to-aware datetime comparisons.
 

--- a/src/main.py
+++ b/src/main.py
@@ -202,7 +202,12 @@ async def _retention_cleanup_tick(
     except Exception as e:
         logger.warning(f"Service runs retention cleanup failed: {e}")
     finally:
-        service_run_repo.end_read_transaction()
+        try:
+            service_run_repo.end_read_transaction()
+        except Exception as cleanup_err:
+            logger.warning(
+                f"cleanup_transactions failed for ServiceRunRepository: {cleanup_err}"
+            )
 
 
 async def _pool_health_tick(
@@ -243,7 +248,12 @@ async def _pool_health_tick(
     except Exception as e:
         logger.warning(f"Pool depletion check failed: {e}")
     finally:
-        health_check_service.cleanup_transactions()
+        try:
+            health_check_service.cleanup_transactions()
+        except Exception as cleanup_err:
+            logger.warning(
+                f"cleanup_transactions failed for HealthCheckService: {cleanup_err}"
+            )
 
 
 async def _token_health_tick(
@@ -285,7 +295,12 @@ async def _token_health_tick(
     except Exception as e:
         logger.warning(f"Token health check failed: {e}")
     finally:
-        health_check_service.cleanup_transactions()
+        try:
+            health_check_service.cleanup_transactions()
+        except Exception as cleanup_err:
+            logger.warning(
+                f"cleanup_transactions failed for HealthCheckService: {cleanup_err}"
+            )
 
 
 async def run_scheduler_loop(
@@ -330,8 +345,14 @@ async def run_scheduler_loop(
         except Exception as e:
             logger.error(f"Error in scheduler loop: {e}", exc_info=True)
         finally:
-            scheduler_service.cleanup_transactions()
-            posting_service.cleanup_transactions()
+            for svc in (scheduler_service, posting_service):
+                try:
+                    svc.cleanup_transactions()
+                except Exception as cleanup_err:
+                    logger.warning(
+                        f"cleanup_transactions failed for "
+                        f"{type(svc).__name__}: {cleanup_err}"
+                    )
 
         # --- Hourly retention: purge old service_runs ---
         retention_tick_counter += 1
@@ -389,8 +410,12 @@ async def cleanup_locks_loop(lock_service: MediaLockService):
         except Exception as e:
             logger.error(f"Error in cleanup loop: {e}", exc_info=True)
         finally:
-            # Clean up open transactions
-            lock_service.cleanup_transactions()
+            try:
+                lock_service.cleanup_transactions()
+            except Exception as cleanup_err:
+                logger.warning(
+                    f"cleanup_transactions failed for MediaLockService: {cleanup_err}"
+                )
 
 
 async def cleanup_cloud_storage_loop(cloud_service):
@@ -423,8 +448,18 @@ async def cleanup_cloud_storage_loop(cloud_service):
         except Exception as e:
             logger.error(f"Error in cloud storage cleanup loop: {e}", exc_info=True)
         finally:
-            cloud_service.cleanup_transactions()
-            media_repo.end_read_transaction()
+            try:
+                cloud_service.cleanup_transactions()
+            except Exception as cleanup_err:
+                logger.warning(
+                    f"cleanup_transactions failed for CloudStorageService: {cleanup_err}"
+                )
+            try:
+                media_repo.end_read_transaction()
+            except Exception as cleanup_err:
+                logger.warning(
+                    f"cleanup_transactions failed for MediaRepository: {cleanup_err}"
+                )
 
 
 async def transaction_cleanup_loop(services: list):
@@ -549,9 +584,19 @@ async def media_sync_loop(
                 )
 
         finally:
-            sync_service.cleanup_transactions()
+            try:
+                sync_service.cleanup_transactions()
+            except Exception as cleanup_err:
+                logger.warning(
+                    f"cleanup_transactions failed for MediaSyncService: {cleanup_err}"
+                )
             if settings_service:
-                settings_service.cleanup_transactions()
+                try:
+                    settings_service.cleanup_transactions()
+                except Exception as cleanup_err:
+                    logger.warning(
+                        f"cleanup_transactions failed for SettingsService: {cleanup_err}"
+                    )
 
         await asyncio.sleep(settings.MEDIA_SYNC_INTERVAL_SECONDS)
 


### PR DESCRIPTION
## Summary

- Wraps all 7 unguarded `cleanup_transactions()` / `end_read_transaction()` calls in `finally` blocks with `try/except` so a failure in cleanup can never crash a background loop
- Root cause of scheduler outage: if `cleanup_transactions()` threw in the scheduler loop's `finally` block, the exception propagated through `_guarded()`, killing the scheduler task permanently while cleanup loops continued — making the failure silent
- Affected loops: scheduler, retention tick, pool/token health ticks, lock cleanup, cloud storage cleanup, media sync

## Context

Investigation found posts stopped serving after 2026-04-19 12:00 UTC. The worker process was alive (cleanup tasks running hourly) but the scheduler asyncio task had died. The `_guarded()` wrapper catches unhandled exceptions from background tasks and stops the loop — but the scheduler loop's `finally` block called `cleanup_transactions()` without guarding it, providing a path for exceptions to escape the inner `try/except`.

## Test plan

- [x] All 1728 tests pass
- [x] `/simplify` review clean (fixed variable shadowing + standardized log format)
- [ ] After merge: restart Railway worker service to revive the scheduler loop
- [ ] Verify posts resume within the posting window

🤖 Generated with [Claude Code](https://claude.com/claude-code)