### PR TITLE
feat: multi-instance DM view for /start, /status, and startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Multi-instance DM view for /status and startup** (#267) — DM `/status` now shows user-level instance list with manage buttons instead of single-instance status dump. Startup notification uses `DashboardService.get_user_instances()` for the same multi-instance overview. Group `/status` unchanged. Consolidated `escape_markdownv2` and `format_last_post` into `telegram_utils.py` as shared helpers. Added Core Mental Model section to `PROJECT_MISSION.md`.
+
 ### Added
 
 - **Test coverage for 7 untested service modules** (#252) — 110 unit tests covering `telegram_callbacks_core`, `telegram_callbacks_queue`, `telegram_callbacks_admin`, `conversation_service`, `start_command_router`, `user_service`, and `backfill_downloader`. Shared test helpers (`make_query`, `make_user`, `noop_context_manager`) added to `conftest.py`.

--- a/PROJECT_MISSION.md
+++ b/PROJECT_MISSION.md
@@ -9,6 +9,25 @@ The single control center for social media content. Upload or pull content from 
 ## North star
 Zero-friction content automation — from source to posted to optimized, with as few manual steps as possible.
 
+## Core Mental Model
+
+The entire product — data model, UI, and bot behavior — is anchored to this hierarchy:
+
+```
+User (Telegram identity)
+  → manages multiple Instances (group chats)
+    → each Instance has: social media accounts, media sources, queue, schedule, settings
+    → media sources contain: multiple files
+```
+
+**Surfaces map directly to this model:**
+
+- **DM** = management console (user-level view of all instances)
+- **Group chat** = where the instance lives (team review + posting)
+- **Web dashboard** = instance picker → instance management
+
+A user sees their instance list first. Tapping an instance drills into its config, media, and posting state. Every command, screen, and API endpoint should know whether it operates at the user level or the instance level — and behave accordingly.
+
 ## Guiding principles
 - **Simple over powerful.** If a feature needs explanation, simplify it.
 - **Web-first for management, Telegram-first for actions.** Approval flows and quick decisions live in Telegram. Everything else belongs on the web dashboard.

--- a/src/services/core/start_command_router.py
+++ b/src/services/core/start_command_router.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import re
 from typing import TYPE_CHECKING
 
 from telegram import InlineKeyboardButton, InlineKeyboardMarkup
@@ -11,7 +10,7 @@ from src.config.settings import settings
 from src.services.core.conversation_service import ConversationService
 from src.services.core.dashboard_service import DashboardService
 from src.repositories.membership_repository import MembershipRepository
-from src.services.core.telegram_utils import build_webapp_button
+from src.services.core.telegram_utils import build_webapp_button, escape_markdownv2
 
 if TYPE_CHECKING:
     from src.services.core.telegram_service import TelegramService
@@ -235,7 +234,7 @@ class StartCommandRouter:
             ppd = inst["posts_per_day"]
             status = "⏸️ paused" if inst["is_paused"] else "✅ active"
             lines.append(
-                f"{i}\\. *{_escape_md2(name)}* "
+                f"{i}\\. *{escape_markdownv2(name)}* "
                 f"\\({media} media · {ppd}/day · {status}\\)"
             )
 
@@ -276,9 +275,3 @@ class StartCommandRouter:
             '_\\(e\\.g\\. "TL Enterprises", "Personal Brand"\\)_',
             parse_mode="MarkdownV2",
         )
-
-
-def _escape_md2(text: str) -> str:
-    """Escape Telegram MarkdownV2 special characters."""
-
-    return re.sub(r"([_*\[\]()~`>#+\-=|{}.!\\])", r"\\\1", text)

--- a/src/services/core/telegram_commands.py
+++ b/src/services/core/telegram_commands.py
@@ -10,7 +10,12 @@ from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 from telegram.error import TelegramError
 
 from src.config.settings import settings
-from src.services.core.telegram_utils import build_webapp_button
+from src.services.core.dashboard_service import DashboardService
+from src.services.core.telegram_utils import (
+    build_webapp_button,
+    escape_markdownv2,
+    format_last_post,
+)
 from src.utils.logger import logger
 
 if TYPE_CHECKING:
@@ -34,15 +39,72 @@ class TelegramCommandHandlers:
     async def handle_status(self, update, context):
         """Handle /status command.
 
-        All data is scoped to the current chat's tenant (chat_settings_id)
-        and all configuration is read from the database, never from env vars.
+        In DMs: shows user-level instance list (multi-instance view).
+        In groups: shows instance-scoped status for this chat's tenant.
         """
         chat_id = update.effective_chat.id
         user = self.service._get_or_create_user(
             update.effective_user, telegram_chat_id=chat_id
         )
+        is_dm = update.effective_chat.type == "private"
 
-        # Load tenant-scoped settings from DB (single source of truth)
+        if is_dm:
+            await self._handle_dm_status(update, user)
+        else:
+            await self._handle_group_status(update, user, chat_id)
+
+    async def _handle_dm_status(self, update, user):
+        """Show user-level instance overview in DMs."""
+        with DashboardService() as dash:
+            data = dash.get_user_instances(update.effective_user.id)
+
+        instances = data["instances"]
+        lines = ["📊 *Storyline AI Status*\n\nYour instances:"]
+
+        keyboard_rows = []
+        if instances:
+            for i, inst in enumerate(instances, 1):
+                raw_name = inst["display_name"] or f"Chat {inst['telegram_chat_id']}"
+                name = escape_markdownv2(raw_name)
+                media = inst["media_count"]
+                ppd = inst["posts_per_day"]
+                last = format_last_post(inst["last_post_at"])
+                status = "⏸️ paused" if inst["is_paused"] else "✅ active"
+                lines.append(
+                    f"{i}\\. *{name}* "
+                    f"\\({ppd}/day · {media} media · last post {last} · {status}\\)"
+                )
+                keyboard_rows.append(
+                    [
+                        InlineKeyboardButton(
+                            f"Manage {raw_name}",
+                            callback_data=f"instance_manage:{inst['chat_settings_id']}",
+                        )
+                    ]
+                )
+        else:
+            lines.append("No instances configured yet\\.")
+
+        keyboard_rows.append(
+            [InlineKeyboardButton("+ New Instance", callback_data="instance_new")]
+        )
+
+        await update.message.reply_text(
+            "\n".join(lines),
+            parse_mode="MarkdownV2",
+            reply_markup=InlineKeyboardMarkup(keyboard_rows),
+        )
+
+        self.service.interaction_service.log_command(
+            user_id=str(user.id),
+            command="/status",
+            context={"view": "dm", "instance_count": len(instances)},
+            telegram_chat_id=update.effective_chat.id,
+            telegram_message_id=update.message.message_id,
+        )
+
+    async def _handle_group_status(self, update, user, chat_id):
+        """Show instance-scoped status in group chats."""
         chat_settings = self.service.settings_service.get_settings(chat_id)
         cs_id = str(chat_settings.id)
 
@@ -103,6 +165,7 @@ class TelegramCommandHandlers:
             user_id=str(user.id),
             command="/status",
             context={
+                "view": "group",
                 "posted": posted_count,
                 "never_posted": never_posted,
                 "posts_24h": len(recent_posts),
@@ -648,9 +711,6 @@ class TelegramCommandHandlers:
 
         user = self.service._get_or_create_user(update.effective_user)
 
-        from src.services.core.dashboard_service import DashboardService
-        from src.services.core.start_command_router import _escape_md2
-
         with DashboardService() as dash:
             data = dash.get_user_instances(update.effective_user.id)
 
@@ -670,7 +730,7 @@ class TelegramCommandHandlers:
             ppd = inst["posts_per_day"]
             status = "paused" if inst["is_paused"] else "active"
             lines.append(
-                f"{i}\\. *{_escape_md2(name)}* \\({media} media · {ppd}/day · {status}\\)"
+                f"{i}\\. *{escape_markdownv2(name)}* \\({media} media · {ppd}/day · {status}\\)"
             )
             keyboard_rows.append(
                 [

--- a/src/services/core/telegram_lifecycle.py
+++ b/src/services/core/telegram_lifecycle.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 from src.config.settings import settings
+from src.services.core.dashboard_service import DashboardService
+from src.services.core.telegram_utils import escape_markdown, format_last_post
 from src.utils.logger import logger
 from src import __version__
 
@@ -20,40 +21,40 @@ class TelegramLifecycleHandler:
         self.service = service
 
     async def send_startup_notification(self):
-        """Send startup notification to admin with system status."""
+        """Send startup notification to admin with multi-instance overview."""
         if not settings.SEND_LIFECYCLE_NOTIFICATIONS:
             return
 
         try:
-            pending_count = self.service.queue_repo.count_pending()
-            media_count = len(self.service.media_repo.get_all(is_active=True))
-            recent_posts = self.service.history_repo.get_recent_posts(hours=24)
-            last_post_time = recent_posts[0].posted_at if recent_posts else None
+            with DashboardService() as dash:
+                data = dash.get_user_instances(self.service.admin_chat_id)
 
-            if last_post_time:
-                time_diff = datetime.now(timezone.utc) - last_post_time
-                hours = int(time_diff.total_seconds() / 3600)
-                last_posted = f"{hours}h ago" if hours > 0 else "< 1h ago"
+            instances = data["instances"]
+            lines = ["🟢 *Storyline AI Started*\n"]
+
+            if instances:
+                lines.append("Your instances:")
+                for i, inst in enumerate(instances, 1):
+                    raw_name = (
+                        inst["display_name"] or f"Chat {inst['telegram_chat_id']}"
+                    )
+                    name = escape_markdown(raw_name)
+                    media = inst["media_count"]
+                    ppd = inst["posts_per_day"]
+                    last = format_last_post(inst["last_post_at"])
+                    status = "⏸️ paused" if inst["is_paused"] else "✅ active"
+                    lines.append(
+                        f"{i}. *{name}* — {ppd}/day, {media} media, "
+                        f"last post {last} ({status})"
+                    )
             else:
-                last_posted = "Never"
+                lines.append("No instances configured yet.")
 
-            message = (
-                f"🟢 *Storyline AI Started*\n\n"
-                f"📊 *System Status:*\n"
-                f"├─ Database: ✅ Connected\n"
-                f"├─ Telegram: ✅ Bot online\n"
-                f"├─ Queue: {pending_count} pending posts\n"
-                f"└─ Last posted: {last_posted}\n\n"
-                f"⚙️ *Configuration:*\n"
-                f"├─ Posts/day: {settings.POSTS_PER_DAY}\n"
-                f"├─ Window: {settings.POSTING_HOURS_START:02d}:00-{settings.POSTING_HOURS_END:02d}:00 UTC\n"
-                f"└─ Media indexed: {media_count} items\n\n"
-                f"🤖 v{__version__}"
-            )
+            lines.append(f"\n🤖 v{__version__}")
 
             await self.service.bot.send_message(
                 chat_id=self.service.admin_chat_id,
-                text=message,
+                text="\n".join(lines),
                 parse_mode="Markdown",
             )
 

--- a/src/services/core/telegram_utils.py
+++ b/src/services/core/telegram_utils.py
@@ -31,6 +31,28 @@ def escape_markdown(text: str) -> str:
     return re.sub(r"([_*`\[])", r"\\\1", text)
 
 
+def escape_markdownv2(text: str) -> str:
+    """Escape Telegram MarkdownV2 special characters."""
+    return re.sub(r"([_*\[\]()~`>#+\-=|{}.!\\])", r"\\\1", text)
+
+
+def format_last_post(last_post_at: str | None) -> str:
+    """Format an ISO timestamp into a human-readable 'X ago' string."""
+    if not last_post_at:
+        return "never"
+    from datetime import datetime, timezone
+
+    posted = datetime.fromisoformat(last_post_at)
+    if posted.tzinfo is None:
+        posted = posted.replace(tzinfo=timezone.utc)
+    diff = datetime.now(timezone.utc) - posted
+    days = diff.days
+    if days > 0:
+        return f"{days}d ago"
+    hours = int(diff.total_seconds() / 3600)
+    return f"{hours}h ago" if hours > 0 else "< 1h ago"
+
+
 # =========================================================================
 # Pattern 1: Queue Item Validation
 # =========================================================================

--- a/tests/src/services/test_phase2b_handlers.py
+++ b/tests/src/services/test_phase2b_handlers.py
@@ -426,7 +426,7 @@ class TestInstancesCommand:
 
         mock_update = _make_update(12345, chat_type="private")
 
-        with patch("src.services.core.dashboard_service.DashboardService") as MockDash:
+        with patch("src.services.core.telegram_commands.DashboardService") as MockDash:
             mock_dash = MockDash.return_value
             mock_dash.__enter__ = Mock(return_value=mock_dash)
             mock_dash.__exit__ = Mock(return_value=False)
@@ -458,7 +458,7 @@ class TestInstancesCommand:
 
         mock_update = _make_update(12345, chat_type="private")
 
-        with patch("src.services.core.dashboard_service.DashboardService") as MockDash:
+        with patch("src.services.core.telegram_commands.DashboardService") as MockDash:
             mock_dash = MockDash.return_value
             mock_dash.__enter__ = Mock(return_value=mock_dash)
             mock_dash.__exit__ = Mock(return_value=False)

--- a/tests/src/services/test_start_command_router.py
+++ b/tests/src/services/test_start_command_router.py
@@ -4,7 +4,8 @@ from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
-from src.services.core.start_command_router import StartCommandRouter, _escape_md2
+from src.services.core.start_command_router import StartCommandRouter
+from src.services.core.telegram_utils import escape_markdownv2
 
 
 @pytest.fixture
@@ -492,7 +493,7 @@ class TestHandleNewUser:
 
 
 # ──────────────────────────────────────────────────────────────
-# _escape_md2
+# escape_markdownv2
 # ──────────────────────────────────────────────────────────────
 
 
@@ -500,11 +501,11 @@ class TestHandleNewUser:
 class TestEscapeMd2:
     def test_escapes_special_characters(self):
         """Escapes all MarkdownV2 special characters."""
-        assert _escape_md2("hello_world") == "hello\\_world"
-        assert _escape_md2("test*bold*") == "test\\*bold\\*"
-        assert _escape_md2("a.b") == "a\\.b"
+        assert escape_markdownv2("hello_world") == "hello\\_world"
+        assert escape_markdownv2("test*bold*") == "test\\*bold\\*"
+        assert escape_markdownv2("a.b") == "a\\.b"
 
     def test_plain_text_unchanged(self):
         """Plain text without special chars passes through unchanged."""
-        assert _escape_md2("hello world") == "hello world"
-        assert _escape_md2("abc123") == "abc123"
+        assert escape_markdownv2("hello world") == "hello world"
+        assert escape_markdownv2("abc123") == "abc123"

--- a/tests/src/services/test_telegram_commands.py
+++ b/tests/src/services/test_telegram_commands.py
@@ -995,7 +995,7 @@ class TestStatusDashboardButton:
         mock_update.effective_user = Mock(
             id=123, username="test", first_name="Test", last_name=None
         )
-        mock_update.effective_chat = Mock(id=-100123, type="private")
+        mock_update.effective_chat = Mock(id=-100123, type="group")
         mock_update.message = AsyncMock()
         mock_update.message.message_id = 1
 
@@ -1063,7 +1063,7 @@ class TestStatusDashboardButton:
         mock_update.effective_user = Mock(
             id=123, username="test", first_name="Test", last_name=None
         )
-        mock_update.effective_chat = Mock(id=-100123, type="private")
+        mock_update.effective_chat = Mock(id=-100123, type="group")
         mock_update.message = AsyncMock()
         mock_update.message.message_id = 1
 

--- a/tests/src/services/test_telegram_commands_status.py
+++ b/tests/src/services/test_telegram_commands_status.py
@@ -1,0 +1,158 @@
+"""Tests for /status command — DM vs group routing."""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from src.services.core.telegram_commands import TelegramCommandHandlers
+
+
+@pytest.fixture
+def mock_service():
+    """Minimal TelegramService mock for command tests."""
+    service = Mock()
+    service._get_or_create_user = Mock(return_value=Mock(id="user-1"))
+    service.interaction_service = Mock()
+    service.settings_service = Mock()
+    service.history_repo = Mock()
+    service.media_repo = Mock()
+    return service
+
+
+@pytest.fixture
+def handlers(mock_service):
+    return TelegramCommandHandlers(mock_service)
+
+
+def _make_update(chat_type="private", chat_id=12345, user_id=67890, message_id=1):
+    update = AsyncMock()
+    update.effective_chat = Mock()
+    update.effective_chat.id = chat_id
+    update.effective_chat.type = chat_type
+    update.effective_user = Mock()
+    update.effective_user.id = user_id
+    update.message = AsyncMock()
+    update.message.message_id = message_id
+    update.message.reply_text = AsyncMock()
+    return update
+
+
+# ──────────────────────────────────────────────────────────────
+# /status routing
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestStatusRouting:
+    async def test_dm_routes_to_dm_handler(self, handlers):
+        """DM /status → _handle_dm_status."""
+        update = _make_update(chat_type="private")
+        context = Mock()
+
+        with patch.object(
+            handlers, "_handle_dm_status", new_callable=AsyncMock
+        ) as mock_dm:
+            await handlers.handle_status(update, context)
+
+        mock_dm.assert_called_once()
+
+    async def test_group_routes_to_group_handler(self, handlers):
+        """Group /status → _handle_group_status."""
+        update = _make_update(chat_type="group")
+        context = Mock()
+
+        with patch.object(
+            handlers, "_handle_group_status", new_callable=AsyncMock
+        ) as mock_group:
+            await handlers.handle_status(update, context)
+
+        mock_group.assert_called_once()
+
+
+# ──────────────────────────────────────────────────────────────
+# /status DM — multi-instance view
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestDmStatus:
+    async def test_shows_instance_list(self, handlers):
+        """DM /status shows user's instances with manage buttons."""
+        mock_dash = Mock()
+        mock_dash.get_user_instances.return_value = {
+            "instances": [
+                {
+                    "display_name": "My Brand",
+                    "telegram_chat_id": -100123,
+                    "media_count": 42,
+                    "posts_per_day": 5,
+                    "is_paused": False,
+                    "last_post_at": None,
+                    "chat_settings_id": "cs-1",
+                },
+            ],
+        }
+        mock_dash.__enter__ = Mock(return_value=mock_dash)
+        mock_dash.__exit__ = Mock(return_value=False)
+
+        update = _make_update(chat_type="private")
+        user = Mock(id="user-1")
+
+        with patch(
+            "src.services.core.telegram_commands.DashboardService",
+            return_value=mock_dash,
+        ):
+            await handlers._handle_dm_status(update, user)
+
+        update.message.reply_text.assert_called_once()
+        text = update.message.reply_text.call_args[0][0]
+        assert "My Brand" in text
+        assert "5/day" in text
+        assert "42 media" in text
+        assert update.message.reply_text.call_args[1]["parse_mode"] == "MarkdownV2"
+
+        # Should have manage button + new instance button
+        reply_markup = update.message.reply_text.call_args[1]["reply_markup"]
+        assert reply_markup is not None
+
+    async def test_no_instances_shows_new_button(self, handlers):
+        """DM /status with no instances shows '+ New Instance' button."""
+        mock_dash = Mock()
+        mock_dash.get_user_instances.return_value = {"instances": []}
+        mock_dash.__enter__ = Mock(return_value=mock_dash)
+        mock_dash.__exit__ = Mock(return_value=False)
+
+        update = _make_update(chat_type="private")
+        user = Mock(id="user-1")
+
+        with patch(
+            "src.services.core.telegram_commands.DashboardService",
+            return_value=mock_dash,
+        ):
+            await handlers._handle_dm_status(update, user)
+
+        text = update.message.reply_text.call_args[0][0]
+        assert "No instances configured" in text
+
+    async def test_logs_interaction(self, handlers):
+        """DM /status logs the interaction."""
+        mock_dash = Mock()
+        mock_dash.get_user_instances.return_value = {"instances": []}
+        mock_dash.__enter__ = Mock(return_value=mock_dash)
+        mock_dash.__exit__ = Mock(return_value=False)
+
+        update = _make_update(chat_type="private")
+        user = Mock(id="user-1")
+
+        with patch(
+            "src.services.core.telegram_commands.DashboardService",
+            return_value=mock_dash,
+        ):
+            await handlers._handle_dm_status(update, user)
+
+        handlers.service.interaction_service.log_command.assert_called_once()
+        call_kwargs = handlers.service.interaction_service.log_command.call_args[1]
+        assert call_kwargs["command"] == "/status"
+        assert call_kwargs["context"]["view"] == "dm"

--- a/tests/src/services/test_telegram_lifecycle.py
+++ b/tests/src/services/test_telegram_lifecycle.py
@@ -1,0 +1,155 @@
+"""Tests for TelegramLifecycleHandler — startup/shutdown notifications."""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from src.services.core.telegram_lifecycle import TelegramLifecycleHandler
+from src.services.core.telegram_utils import format_last_post
+
+
+@pytest.fixture
+def mock_service():
+    """Minimal TelegramService mock for lifecycle tests."""
+    service = Mock()
+    service.admin_chat_id = 12345
+    service.bot = AsyncMock()
+    return service
+
+
+@pytest.fixture
+def handler(mock_service):
+    return TelegramLifecycleHandler(mock_service)
+
+
+# ──────────────────────────────────────────────────────────────
+# send_startup_notification — multi-instance view
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestSendStartupNotification:
+    @patch("src.services.core.telegram_lifecycle.settings")
+    async def test_skips_when_notifications_disabled(self, mock_settings, handler):
+        mock_settings.SEND_LIFECYCLE_NOTIFICATIONS = False
+        await handler.send_startup_notification()
+        handler.service.bot.send_message.assert_not_called()
+
+    @patch("src.services.core.telegram_lifecycle.settings")
+    async def test_shows_instance_list(self, mock_settings, handler):
+        mock_settings.SEND_LIFECYCLE_NOTIFICATIONS = True
+
+        mock_dash = Mock()
+        mock_dash.get_user_instances.return_value = {
+            "instances": [
+                {
+                    "display_name": "TL Enterprises",
+                    "telegram_chat_id": -100123,
+                    "media_count": 50,
+                    "posts_per_day": 3,
+                    "is_paused": False,
+                    "last_post_at": None,
+                    "chat_settings_id": "cs-1",
+                },
+            ],
+        }
+        mock_dash.__enter__ = Mock(return_value=mock_dash)
+        mock_dash.__exit__ = Mock(return_value=False)
+
+        with patch(
+            "src.services.core.telegram_lifecycle.DashboardService",
+            return_value=mock_dash,
+        ):
+            await handler.send_startup_notification()
+
+        handler.service.bot.send_message.assert_called_once()
+        text = handler.service.bot.send_message.call_args[1]["text"]
+        assert "TL Enterprises" in text
+        assert "3/day" in text
+        assert "50 media" in text
+        assert "Started" in text
+
+    @patch("src.services.core.telegram_lifecycle.settings")
+    async def test_no_instances(self, mock_settings, handler):
+        mock_settings.SEND_LIFECYCLE_NOTIFICATIONS = True
+
+        mock_dash = Mock()
+        mock_dash.get_user_instances.return_value = {"instances": []}
+        mock_dash.__enter__ = Mock(return_value=mock_dash)
+        mock_dash.__exit__ = Mock(return_value=False)
+
+        with patch(
+            "src.services.core.telegram_lifecycle.DashboardService",
+            return_value=mock_dash,
+        ):
+            await handler.send_startup_notification()
+
+        text = handler.service.bot.send_message.call_args[1]["text"]
+        assert "No instances configured" in text
+
+    @patch("src.services.core.telegram_lifecycle.settings")
+    async def test_multiple_instances(self, mock_settings, handler):
+        mock_settings.SEND_LIFECYCLE_NOTIFICATIONS = True
+
+        mock_dash = Mock()
+        mock_dash.get_user_instances.return_value = {
+            "instances": [
+                {
+                    "display_name": "Brand A",
+                    "telegram_chat_id": -100,
+                    "media_count": 10,
+                    "posts_per_day": 2,
+                    "is_paused": False,
+                    "last_post_at": "2026-04-20T12:00:00+00:00",
+                    "chat_settings_id": "cs-1",
+                },
+                {
+                    "display_name": "Brand B",
+                    "telegram_chat_id": -200,
+                    "media_count": 5,
+                    "posts_per_day": 1,
+                    "is_paused": True,
+                    "last_post_at": None,
+                    "chat_settings_id": "cs-2",
+                },
+            ],
+        }
+        mock_dash.__enter__ = Mock(return_value=mock_dash)
+        mock_dash.__exit__ = Mock(return_value=False)
+
+        with patch(
+            "src.services.core.telegram_lifecycle.DashboardService",
+            return_value=mock_dash,
+        ):
+            await handler.send_startup_notification()
+
+        text = handler.service.bot.send_message.call_args[1]["text"]
+        assert "Brand A" in text
+        assert "Brand B" in text
+        assert "paused" in text
+
+
+# ──────────────────────────────────────────────────────────────
+# format_last_post
+# ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.unit
+class TestFormatLastPost:
+    def test_none_returns_never(self):
+        assert format_last_post(None) == "never"
+
+    def test_recent_post(self):
+        from datetime import datetime, timezone
+
+        now = datetime.now(timezone.utc)
+        result = format_last_post(now.isoformat())
+        assert result == "< 1h ago"
+
+    def test_old_post_shows_days(self):
+        from datetime import datetime, timedelta, timezone
+
+        old = datetime.now(timezone.utc) - timedelta(days=3)
+        result = format_last_post(old.isoformat())
+        assert result == "3d ago"


### PR DESCRIPTION
## Summary
- **DM /status** now shows user-level instance list with manage buttons + "New Instance" (matches /start returning-user flow), instead of single-instance status dump
- **Startup notification** uses `DashboardService.get_user_instances()` to show all instances with stats instead of global queue/config dump
- **Group /status** unchanged — still shows instance-scoped status for that chat's tenant
- **PROJECT_MISSION.md** gets a Core Mental Model section documenting User → Instance → Resources hierarchy
- Consolidated `escape_markdownv2` and `format_last_post` into `telegram_utils.py` as shared helpers (were private cross-module imports)

## Changes
| File | What |
|------|------|
| `telegram_lifecycle.py` | Startup notification → multi-instance view via DashboardService |
| `telegram_commands.py` | /status routes DM → `_handle_dm_status` (instance list), group → `_handle_group_status` (unchanged) |
| `telegram_utils.py` | Added `escape_markdownv2()` and `format_last_post()` shared helpers |
| `start_command_router.py` | Uses shared `escape_markdownv2` from utils (removed local `_escape_md2`) |
| `PROJECT_MISSION.md` | Added Core Mental Model section |
| `test_telegram_lifecycle.py` | New — tests startup notification multi-instance view |
| `test_telegram_commands_status.py` | New — tests /status DM vs group routing |
| Existing tests | Updated for moved helpers and corrected patch paths |

## Test plan
- [x] All 1740 tests pass (0 failures, 16 skipped)
- [x] `/simplify` run — consolidated shared helpers, fixed MarkdownV2 consistency
- [ ] Manual: send /status in DM → should show instance list with manage buttons
- [ ] Manual: send /status in group → should show instance-scoped status (unchanged)
- [ ] Manual: restart bot → startup message should show instance list

🤖 Generated with [Claude Code](https://claude.com/claude-code)