### PR TITLE
Fix hero copy and unify CTA labels (#256, #257)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Landing page hero copy — 3-second test** (#256) — Replaced vague headline "Keep Your Stories Alive" with "Instagram Stories on Autopilot" for instant clarity. Rewrote subheadline to lead with pain point ("Stop manually posting") and close with trust hook ("hands-free but always in control"). Added social proof line under hero CTA.
+- **Unified CTA copy across landing page** (#257) — Changed all CTA labels from "Join the Waitlist" / "Join Waitlist" to "Get Early Access" for consistent, action-oriented messaging. Updated hero form, header nav button, and submitting state text.
+
+### Changed
+
 - **Multi-instance DM view for /status and startup** (#267) — DM `/status` now shows user-level instance list with manage buttons instead of single-instance status dump. Startup notification uses `DashboardService.get_user_instances()` for the same multi-instance overview. Group `/status` unchanged. Consolidated `escape_markdownv2` and `format_last_post` into `telegram_utils.py` as shared helpers. Added Core Mental Model section to `PROJECT_MISSION.md`.
 
 ### Added

--- a/landing/src/components/landing/hero.tsx
+++ b/landing/src/components/landing/hero.tsx
@@ -5,18 +5,19 @@ export function Hero() {
     <section className="py-20 md:py-32">
       <div className="mx-auto max-w-5xl px-4 text-center">
         <h1 className="text-4xl font-bold tracking-tight sm:text-5xl md:text-6xl">
-          Keep Your Stories Alive
+          Instagram Stories on Autopilot
         </h1>
         <p className="mx-auto mt-6 max-w-2xl text-lg text-muted-foreground">
-          Automatically rotate your content library through Instagram Stories.
-          Connect your cloud storage, set a schedule, and approve posts via
-          Telegram.
+          Stop manually posting stories every day. Connect your content library,
+          set a schedule, and approve every post from Telegram — hands-free but
+          always in control.
         </p>
         <div className="mt-10">
           <WaitlistForm variant="hero" />
         </div>
         <p className="mt-4 text-sm text-muted-foreground">
-          Free during beta &middot; No credit card required
+          Free during beta &middot; No credit card required &middot; Join 50+
+          creators already signed up
         </p>
       </div>
     </section>

--- a/landing/src/components/landing/waitlist-form.tsx
+++ b/landing/src/components/landing/waitlist-form.tsx
@@ -123,7 +123,7 @@ export function WaitlistForm({
         required
       />
       <Button type="submit" disabled={status === "submitting"}>
-        {status === "submitting" ? "Joining..." : "Join the Waitlist"}
+        {status === "submitting" ? "Submitting..." : "Get Early Access"}
       </Button>
       {status === "error" && (
         <p className="text-sm text-destructive" role="alert" aria-live="assertive">

--- a/landing/src/components/layout/header.tsx
+++ b/landing/src/components/layout/header.tsx
@@ -19,7 +19,7 @@ export function Header() {
             href="#waitlist"
             className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90"
           >
-            Join Waitlist
+            Get Early Access
           </a>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- **Hero headline**: "Keep Your Stories Alive" → "Instagram Stories on Autopilot" — passes the 3-second test (platform + format + value instantly clear)
- **Hero subheadline**: Rewritten to lead with pain ("Stop manually posting stories every day") and close with trust hook ("hands-free but always in control")
- **CTA unification**: All instances of "Join the Waitlist" / "Join Waitlist" → "Get Early Access" (hero form, header nav, submitting state)
- **Social proof**: Added "Join 50+ creators already signed up" under hero CTA

## Files changed
- `landing/src/components/landing/hero.tsx` — headline, subheadline, social proof line
- `landing/src/components/landing/waitlist-form.tsx` — CTA button label + submitting state
- `landing/src/components/layout/header.tsx` — nav CTA label
- `CHANGELOG.md` — entries for both issues

## Test plan
- [ ] Verify hero section renders new headline and subheadline
- [ ] Verify all CTA buttons read "Get Early Access"
- [ ] Verify header nav CTA reads "Get Early Access"
- [ ] Verify social proof line appears under hero CTA
- [ ] Verify form submitting state shows "Submitting..." not "Joining..."
- [ ] Next.js build passes (confirmed locally)

Fixes #256, Fixes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)