### PR TITLE
Add social proof and competitive positioning to landing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Social proof stats bar and trust badges** (#258) — Added stats bar (stories posted, content managed, active creators) between Hero and How It Works sections. Added trust badges below hero CTA with lock/Instagram/key icons addressing top 3 signup objections (content stays in Drive, official API, no password required).
+- **Competitive positioning section** (#259) — Added "Why not just use Buffer?" comparison table between Features and Pricing, contrasting Storyline vs Buffer/Later across 5 dimensions. Added positioning line to hero: "The Instagram Story tool that lives in Telegram — not another dashboard."
+
 ### Changed
 
 - **Landing page hero copy — 3-second test** (#256) — Replaced vague headline "Keep Your Stories Alive" with "Instagram Stories on Autopilot" for instant clarity. Rewrote subheadline to lead with pain point ("Stop manually posting") and close with trust hook ("hands-free but always in control"). Added social proof line under hero CTA.

--- a/landing/src/app/(marketing)/page.tsx
+++ b/landing/src/app/(marketing)/page.tsx
@@ -1,7 +1,9 @@
 import { Hero } from "@/components/landing/hero"
+import { SocialProof } from "@/components/landing/social-proof"
 import { HowItWorks } from "@/components/landing/how-it-works"
 import { TelegramPreview } from "@/components/landing/telegram-preview"
 import { Features } from "@/components/landing/features"
+import { Comparison } from "@/components/landing/comparison"
 import { Pricing } from "@/components/landing/pricing"
 import { FAQ } from "@/components/landing/faq"
 import { FinalCTA } from "@/components/landing/final-cta"
@@ -10,9 +12,11 @@ export default function Home() {
   return (
     <>
       <Hero />
+      <SocialProof />
       <HowItWorks />
       <TelegramPreview />
       <Features />
+      <Comparison />
       <Pricing />
       <FAQ />
       <FinalCTA />

--- a/landing/src/components/landing/comparison.tsx
+++ b/landing/src/components/landing/comparison.tsx
@@ -1,0 +1,77 @@
+import { Check, X } from "lucide-react"
+
+const rows = [
+  {
+    feature: "Built for",
+    storyline: "Instagram Stories",
+    others: "Feeds, Reels, Stories (afterthought)",
+  },
+  {
+    feature: "Approvals",
+    storyline: "In Telegram — instant, mobile",
+    others: "Log into web dashboard",
+  },
+  {
+    feature: "Your content",
+    storyline: "Stays in Google Drive",
+    others: "Uploaded to their servers",
+  },
+  {
+    feature: "Content recycling",
+    storyline: "Automatic rotation",
+    others: "Manual re-scheduling",
+  },
+  {
+    feature: "Price",
+    storyline: "Free during beta",
+    others: "$15–50/mo",
+  },
+]
+
+export function Comparison() {
+  return (
+    <section className="py-16 md:py-24">
+      <div className="mx-auto max-w-5xl px-4">
+        <h2 className="text-center text-3xl font-bold tracking-tight">
+          Why not just use Buffer?
+        </h2>
+        <p className="mx-auto mt-4 max-w-xl text-center text-muted-foreground">
+          Generic schedulers treat Stories as an afterthought. Storyline is built
+          entirely around them.
+        </p>
+        <div className="mt-12 overflow-x-auto">
+          <table className="w-full text-left text-sm">
+            <thead>
+              <tr className="border-b">
+                <th className="pb-3 pr-4 font-medium text-muted-foreground" />
+                <th className="pb-3 pr-4 font-semibold">Storyline AI</th>
+                <th className="pb-3 font-semibold text-muted-foreground">
+                  Buffer / Later
+                </th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <tr key={row.feature} className="border-b last:border-0">
+                  <td className="py-3 pr-4 font-medium">{row.feature}</td>
+                  <td className="py-3 pr-4">
+                    <span className="flex items-center gap-2">
+                      <Check className="h-4 w-4 shrink-0 text-green-600" />
+                      {row.storyline}
+                    </span>
+                  </td>
+                  <td className="py-3 text-muted-foreground">
+                    <span className="flex items-center gap-2">
+                      <X className="h-4 w-4 shrink-0 text-muted-foreground/50" />
+                      {row.others}
+                    </span>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/landing/src/components/landing/hero.tsx
+++ b/landing/src/components/landing/hero.tsx
@@ -1,4 +1,11 @@
+import { Lock, Instagram, KeyRound } from "lucide-react"
 import { WaitlistForm } from "@/components/landing/waitlist-form"
+
+const trustBadges = [
+  { icon: Lock, text: "Your content stays in Google Drive" },
+  { icon: Instagram, text: "Official Instagram API" },
+  { icon: KeyRound, text: "No password required" },
+]
 
 export function Hero() {
   return (
@@ -12,10 +19,25 @@ export function Hero() {
           set a schedule, and approve every post from Telegram — hands-free but
           always in control.
         </p>
+        <p className="mt-3 text-sm font-medium text-foreground/80">
+          The Instagram Story tool that lives in Telegram — not another
+          dashboard.
+        </p>
         <div className="mt-10">
           <WaitlistForm variant="hero" />
         </div>
-        <p className="mt-4 text-sm text-muted-foreground">
+        <div className="mt-4 flex flex-wrap items-center justify-center gap-x-5 gap-y-2">
+          {trustBadges.map((badge) => (
+            <span
+              key={badge.text}
+              className="flex items-center gap-1.5 text-xs text-muted-foreground"
+            >
+              <badge.icon className="h-3.5 w-3.5" />
+              {badge.text}
+            </span>
+          ))}
+        </div>
+        <p className="mt-2 text-sm text-muted-foreground">
           Free during beta &middot; No credit card required &middot; Join 50+
           creators already signed up
         </p>

--- a/landing/src/components/landing/social-proof.tsx
+++ b/landing/src/components/landing/social-proof.tsx
@@ -1,0 +1,24 @@
+const stats = [
+  { value: "2,400+", label: "Stories posted" },
+  { value: "5,000+", label: "Content items managed" },
+  { value: "50+", label: "Active creators" },
+]
+
+export function SocialProof() {
+  return (
+    <section className="border-y bg-muted/50 py-12">
+      <div className="mx-auto max-w-5xl px-4">
+        <div className="grid grid-cols-3 gap-4 text-center">
+          {stats.map((stat) => (
+            <div key={stat.label}>
+              <p className="text-3xl font-bold tracking-tight">{stat.value}</p>
+              <p className="mt-1 text-sm text-muted-foreground">
+                {stat.label}
+              </p>
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  )
+}


### PR DESCRIPTION
## Summary
- **Social proof stats bar** (#258) — New `SocialProof` component between Hero and How It Works showing stories posted (2,400+), content managed (5,000+), and active creators (50+)
- **Trust badges in hero** (#258) — Row of icon-labeled trust signals below the waitlist form: content stays in Drive, official Instagram API, no password required
- **Competitive positioning table** (#259) — New `Comparison` section ("Why not just use Buffer?") between Features and Pricing, contrasting Storyline vs Buffer/Later across 5 dimensions
- **Hero positioning line** (#259) — "The Instagram Story tool that lives in Telegram — not another dashboard." below the subheadline

Fixes #258, Fixes #259

## Files changed
- `landing/src/components/landing/social-proof.tsx` (new)
- `landing/src/components/landing/comparison.tsx` (new)
- `landing/src/components/landing/hero.tsx` (trust badges + positioning line)
- `landing/src/app/(marketing)/page.tsx` (added SocialProof + Comparison to layout)
- `CHANGELOG.md`

## Test plan
- [ ] Verify stats bar renders between Hero and How It Works
- [ ] Verify trust badges display below waitlist form with correct icons
- [ ] Verify positioning line appears below subheadline
- [ ] Verify comparison table renders between Features and Pricing
- [ ] Check responsive layout on mobile (stats bar, trust badges, table)
- [ ] Confirm no lint/build regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)