### PR TITLE
Improve post-signup experience with enriched confirmation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Post-signup experience** (#260) — Replaced dead-end "We'll be in touch" confirmation with enriched post-signup block: sets timeline expectations (within a week), gives a micro-task (prepare Google Drive folder), and adds Telegram community link to move signups from "registered" to "engaged."
 - **Social proof stats bar and trust badges** (#258) — Added stats bar (stories posted, content managed, active creators) between Hero and How It Works sections. Added trust badges below hero CTA with lock/Instagram/key icons addressing top 3 signup objections (content stays in Drive, official API, no password required).
 - **Competitive positioning section** (#259) — Added "Why not just use Buffer?" comparison table between Features and Pricing, contrasting Storyline vs Buffer/Later across 5 dimensions. Added positioning line to hero: "The Instagram Story tool that lives in Telegram — not another dashboard."
 

--- a/landing/src/components/landing/waitlist-form.tsx
+++ b/landing/src/components/landing/waitlist-form.tsx
@@ -84,12 +84,29 @@ export function WaitlistForm({
         role="status"
         aria-live="polite"
       >
-        <p className="text-lg font-medium">{message}</p>
-        {status === "success" && (
-          <p className="text-sm text-muted-foreground mt-1">
-            We&apos;ll be in touch.
-          </p>
-        )}
+        <div className="space-y-3">
+          <p className="text-lg font-medium">{message}</p>
+          {status === "success" && (
+            <>
+              <p className="text-sm text-muted-foreground">
+                We&apos;re onboarding beta users in small batches. You&apos;ll
+                hear from us within a week with setup instructions.
+              </p>
+              <p className="text-sm text-muted-foreground">
+                While you wait — get your Google Drive folder ready with your
+                story content. That&apos;s all you&apos;ll need to get started.
+              </p>
+            </>
+          )}
+          <a
+            href="https://t.me/storyline_ai"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-block text-sm text-muted-foreground underline underline-offset-4 hover:text-foreground transition-colors"
+          >
+            Join the Telegram community
+          </a>
+        </div>
       </div>
     )
   }


### PR DESCRIPTION
## Summary
- Replaced dead-end "We'll be in touch" confirmation with enriched post-signup block
- Sets timeline expectations ("within a week"), gives a micro-task ("get your Google Drive folder ready"), and adds Telegram community link
- Moves waitlist signups from "registered" to "engaged" — warmer leads at onboarding time

Fixes #260

## Test plan
- [ ] Submit waitlist form and verify enriched confirmation appears (timeline + micro-task + Telegram link)
- [ ] Verify returning visitors (duplicate state) see the message + Telegram link but not the success-specific copy
- [ ] Verify Telegram community link opens in new tab
- [ ] Check mobile responsiveness of confirmation block

🤖 Generated with [Claude Code](https://claude.com/claude-code)