### PR TITLE
Refactor: break up 5 oversized functions (Fixes #272)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Break up oversized functions** (#272) — Refactored 5 functions exceeding 90 lines into smaller, focused methods: `refresh_instagram_token()` (128→65 lines), `handle_settings_edit_message()` (130→20 lines), `onboarding_upload_media()` (131→40 lines), `sync()` (132→60 lines), and `_process_provider_file()` (7 params→2 via `SyncContext` dataclass).
+
 - **Extract background loops from main.py** (#271) — Moved 5 background loops (scheduler, lock cleanup, cloud cleanup, transaction cleanup, media sync), heartbeat tracking, crash guard, and lifecycle helpers into dedicated modules under `src/services/core/loops/`. Reduced main.py from 851 lines to ~170 lines of pure service wiring.
 
 - **Landing page hero copy — 3-second test** (#256) — Replaced vague headline "Keep Your Stories Alive" with "Instagram Stories on Autopilot" for instant clarity. Rewrote subheadline to lead with pain point ("Stop manually posting") and close with trust hook ("hands-free but always in control"). Added social proof line under hero CTA.

--- a/src/api/routes/onboarding/dashboard.py
+++ b/src/api/routes/onboarding/dashboard.py
@@ -313,33 +313,23 @@ def _detect_mime_from_magic(content: bytes) -> str | None:
     return None
 
 
-@router.post("/upload-media")
-async def onboarding_upload_media(
-    request: Request,
-    init_data: str = Query(...),
-    chat_id: int = Query(...),
-    file: UploadFile = File(...),
-    category: str | None = Form(default=None),
-) -> dict:
-    """Upload a media file and create a media_item record.
+async def _validate_upload_content(
+    request: Request, file: UploadFile
+) -> tuple[bytes, str]:
+    """Read and validate uploaded file content, size, and MIME type.
 
-    Files are stored locally and indexed for posting.
+    Returns (content_bytes, claimed_mime).
     """
-    _validate_request(init_data, chat_id)
-
-    # Fast-fail on Content-Length before buffering the file
     content_length = int(request.headers.get("content-length", 0))
     if content_length > MAX_UPLOAD_SIZE:
         raise HTTPException(status_code=413, detail="File exceeds 50 MB limit")
 
-    # Read file content
     content = await file.read()
     if len(content) > MAX_UPLOAD_SIZE:
         raise HTTPException(status_code=413, detail="File exceeds 50 MB limit")
     if len(content) == 0:
         raise HTTPException(status_code=400, detail="Empty file")
 
-    # Validate MIME type from header/extension, then verify with magic bytes
     claimed_mime = (
         file.content_type
         or mimetypes.guess_type(file.filename or "")[0]
@@ -359,55 +349,36 @@ async def onboarding_upload_media(
             detail=f"File content ({actual_mime}) does not match declared type ({claimed_mime})",
         )
 
-    file_hash = hashlib.sha256(content).hexdigest()
+    return content, claimed_mime
 
-    # Sanitize filename — strip path components to prevent directory traversal
-    safe_name = Path(file.filename or "upload").name
-    if not safe_name or safe_name.startswith("."):
-        safe_name = "upload"
 
-    # Resolve tenant
-    with SettingsService() as settings_service:
-        chat_settings = settings_service.get_settings(chat_id)
-        chat_settings_id = str(chat_settings.id)
+def _resolve_upload_category(category: str | None, chat_settings_id: str) -> str | None:
+    """Validate and sanitize the upload category against known categories."""
+    if not category:
+        return None
 
-    # Validate category against known categories from DB
-    valid_category = None
-    if category:
-        with MediaRepository() as media_repo:
-            known_categories = media_repo.get_categories(
-                chat_settings_id=chat_settings_id
-            )
-        if category in known_categories:
-            valid_category = category
-        else:
-            # Sanitize: strip path separators as defense-in-depth
-            sanitized = Path(category).name
-            if sanitized and not sanitized.startswith(".") and "/" not in category:
-                valid_category = sanitized
-            else:
-                raise HTTPException(
-                    status_code=400, detail=f"Invalid category: {category}"
-                )
-
-    # Check for duplicate content
     with MediaRepository() as media_repo:
-        existing = media_repo.get_active_by_hash(
-            file_hash, chat_settings_id=chat_settings_id
-        )
-        if existing:
-            raise HTTPException(
-                status_code=409,
-                detail=f"Duplicate content — matches existing file: {existing.file_name}",
-            )
+        known_categories = media_repo.get_categories(chat_settings_id=chat_settings_id)
+    if category in known_categories:
+        return category
 
-    # Save to disk
-    folder = valid_category or "uncategorized"
+    sanitized = Path(category).name
+    if sanitized and not sanitized.startswith(".") and "/" not in category:
+        return sanitized
+
+    raise HTTPException(status_code=400, detail=f"Invalid category: {category}")
+
+
+def _prepare_save_path(
+    chat_settings_id: str, category: str | None, filename: str
+) -> Path:
+    """Create directory structure and resolve a unique save path."""
+    folder = category or "uncategorized"
     save_dir = Path(UPLOAD_DIR) / chat_settings_id / folder
     save_dir.mkdir(parents=True, exist_ok=True)
-    save_path = save_dir / safe_name
+    save_path = save_dir / filename
 
-    # Belt-and-suspenders: verify resolved path is within UPLOAD_DIR
+    # Verify resolved path is within UPLOAD_DIR (path traversal defense)
     resolved = save_path.resolve()
     if not str(resolved).startswith(str(Path(UPLOAD_DIR).resolve())):
         raise HTTPException(status_code=400, detail="Invalid file path")
@@ -421,9 +392,50 @@ async def onboarding_upload_media(
             save_path = save_dir / f"{stem}_{counter}{suffix}"
             counter += 1
 
+    return save_path
+
+
+@router.post("/upload-media")
+async def onboarding_upload_media(
+    request: Request,
+    init_data: str = Query(...),
+    chat_id: int = Query(...),
+    file: UploadFile = File(...),
+    category: str | None = Form(default=None),
+) -> dict:
+    """Upload a media file and create a media_item record.
+
+    Files are stored locally and indexed for posting.
+    """
+    _validate_request(init_data, chat_id)
+
+    content, claimed_mime = await _validate_upload_content(request, file)
+    file_hash = hashlib.sha256(content).hexdigest()
+
+    safe_name = Path(file.filename or "upload").name
+    if not safe_name or safe_name.startswith("."):
+        safe_name = "upload"
+
+    with SettingsService() as settings_service:
+        chat_settings = settings_service.get_settings(chat_id)
+        chat_settings_id = str(chat_settings.id)
+
+    valid_category = _resolve_upload_category(category, chat_settings_id)
+
+    # Check for duplicate content
+    with MediaRepository() as media_repo:
+        existing = media_repo.get_active_by_hash(
+            file_hash, chat_settings_id=chat_settings_id
+        )
+        if existing:
+            raise HTTPException(
+                status_code=409,
+                detail=f"Duplicate content — matches existing file: {existing.file_name}",
+            )
+
+    save_path = _prepare_save_path(chat_settings_id, valid_category, safe_name)
     save_path.write_bytes(content)
 
-    # Create media_item record
     with MediaRepository() as media_repo:
         media_item = media_repo.create(
             file_path=str(save_path),

--- a/src/services/core/media_sync.py
+++ b/src/services/core/media_sync.py
@@ -8,7 +8,9 @@ from sqlalchemy.exc import SQLAlchemyError
 from src.config.settings import settings
 from src.repositories.media_repository import MediaRepository
 from src.services.base_service import BaseService
-from src.services.media_sources.base_provider import MediaFileInfo
+from src.services.media_sources.base_provider import (
+    MediaFileInfo,
+)
 from src.services.media_sources.factory import MediaSourceFactory
 from src.utils.logger import logger
 
@@ -61,6 +63,18 @@ class SyncResult:
         )
 
 
+@dataclass
+class SyncContext:
+    """Encapsulates shared sync processing state to reduce parameter count."""
+
+    source_type: str
+    provider: object
+    db_by_identifier: dict
+    db_by_hash: dict[str, list]
+    seen_identifiers: set[str]
+    result: SyncResult
+
+
 class MediaSyncService(BaseService):
     """Scheduled reconciliation of media source providers with the database.
 
@@ -79,6 +93,66 @@ class MediaSyncService(BaseService):
     def __init__(self):
         super().__init__()
         self.media_repo = MediaRepository()
+
+    def _resolve_source_config(
+        self,
+        source_type: Optional[str],
+        source_root: Optional[str],
+        telegram_chat_id: Optional[int],
+    ) -> tuple[str, str]:
+        """Resolve source type and root with fallback chain.
+
+        Resolution order: explicit params > per-chat DB config > global env vars.
+        """
+        if not source_type and not source_root and telegram_chat_id:
+            from src.services.core.settings_service import SettingsService
+
+            settings_service = SettingsService()
+            try:
+                source_type, source_root = settings_service.get_media_source_config(
+                    telegram_chat_id
+                )
+            finally:
+                settings_service.close()
+
+        resolved_type = source_type or settings.MEDIA_SOURCE_TYPE
+        resolved_root = source_root or settings.MEDIA_SOURCE_ROOT
+
+        if resolved_type == "local" and not resolved_root:
+            resolved_root = settings.MEDIA_DIR
+
+        return resolved_type, resolved_root
+
+    def _build_db_lookups(self, source_type: str) -> tuple[list, dict, dict]:
+        """Fetch DB records and build O(1) lookup dicts.
+
+        Returns (db_items, db_by_identifier, db_by_hash).
+        """
+        db_items = self.media_repo.get_active_by_source_type(source_type)
+        db_by_identifier = {
+            item.source_identifier: item for item in db_items if item.source_identifier
+        }
+        db_by_hash: dict[str, list] = {}
+        for item in db_items:
+            db_by_hash.setdefault(item.file_hash, []).append(item)
+        return db_items, db_by_identifier, db_by_hash
+
+    def _deactivate_missing_items(self, ctx: SyncContext) -> None:
+        """Deactivate DB items whose identifiers were not seen in the provider."""
+        for identifier, item in ctx.db_by_identifier.items():
+            if identifier not in ctx.seen_identifiers:
+                try:
+                    self.media_repo.deactivate(str(item.id))
+                    ctx.result.deactivated += 1
+                    logger.info(
+                        f"[MediaSyncService] Deactivated: {item.file_name} "
+                        f"(no longer in provider)"
+                    )
+                except SQLAlchemyError as e:
+                    ctx.result.errors += 1
+                    error_msg = f"Error deactivating {item.file_name}: {e}"
+                    ctx.result.error_details.append(error_msg)
+                    logger.error(f"[MediaSyncService] {error_msg}")
 
     def sync(
         self,
@@ -101,210 +175,184 @@ class MediaSyncService(BaseService):
         Raises:
             ValueError: If provider is not configured or source_type is invalid
         """
-        # Resolution order: explicit params > per-chat DB config > global env vars
-        if not source_type and not source_root and telegram_chat_id:
-            from src.services.core.settings_service import SettingsService
-
-            settings_service = SettingsService()
-            try:
-                source_type, source_root = settings_service.get_media_source_config(
-                    telegram_chat_id
-                )
-            finally:
-                settings_service.close()
-
-        resolved_source_type = source_type or settings.MEDIA_SOURCE_TYPE
-        resolved_source_root = source_root or settings.MEDIA_SOURCE_ROOT
-
-        # For local provider, fall back to MEDIA_DIR if no root specified
-        if resolved_source_type == "local" and not resolved_source_root:
-            resolved_source_root = settings.MEDIA_DIR
+        resolved_type, resolved_root = self._resolve_source_config(
+            source_type, source_root, telegram_chat_id
+        )
 
         with self.track_execution(
             method_name="sync",
             triggered_by=triggered_by,
             input_params={
-                "source_type": resolved_source_type,
-                "source_root": resolved_source_root,
+                "source_type": resolved_type,
+                "source_root": resolved_root,
             },
         ) as run_id:
-            result = SyncResult()
-
-            # Create provider
             provider = self._create_provider(
-                resolved_source_type, resolved_source_root, telegram_chat_id
+                resolved_type, resolved_root, telegram_chat_id
             )
-
             if not provider.is_configured():
                 raise ValueError(
-                    f"Media source provider '{resolved_source_type}' is not configured. "
+                    f"Media source provider '{resolved_type}' is not configured. "
                     f"Check your settings or run the appropriate setup command."
                 )
 
-            # Phase 1: Get provider file listing
             logger.info(
-                f"[MediaSyncService] Starting sync for {resolved_source_type} "
-                f"(root: {resolved_source_root})"
+                f"[MediaSyncService] Starting sync for {resolved_type} "
+                f"(root: {resolved_root})"
             )
             provider_files = provider.list_files()
             logger.info(
                 f"[MediaSyncService] Provider reports {len(provider_files)} files"
             )
 
-            # Phase 2: Get DB records for this source type
-            db_items = self.media_repo.get_active_by_source_type(resolved_source_type)
+            db_items, db_by_identifier, db_by_hash = self._build_db_lookups(
+                resolved_type
+            )
             logger.info(f"[MediaSyncService] Database has {len(db_items)} active items")
 
-            # Build lookup dicts for O(1) matching
-            db_by_identifier = {
-                item.source_identifier: item
-                for item in db_items
-                if item.source_identifier
-            }
-            db_by_hash: dict[str, list] = {}
-            for item in db_items:
-                db_by_hash.setdefault(item.file_hash, []).append(item)
+            ctx = SyncContext(
+                source_type=resolved_type,
+                provider=provider,
+                db_by_identifier=db_by_identifier,
+                db_by_hash=db_by_hash,
+                seen_identifiers=set(),
+                result=SyncResult(),
+            )
 
-            # Track which DB identifiers were seen in the provider
-            seen_identifiers: set[str] = set()
-
-            # Phase 3: Process provider files
             for file_info in provider_files:
                 try:
-                    self._process_provider_file(
-                        file_info=file_info,
-                        source_type=resolved_source_type,
-                        provider=provider,
-                        db_by_identifier=db_by_identifier,
-                        db_by_hash=db_by_hash,
-                        seen_identifiers=seen_identifiers,
-                        result=result,
-                    )
+                    self._process_provider_file(file_info, ctx)
                 except Exception as e:  # noqa: BLE001 — per-file error must not halt sync
                     self.media_repo.rollback()
-                    result.errors += 1
+                    ctx.result.errors += 1
                     error_msg = f"Error processing {file_info.name}: {e}"
-                    result.error_details.append(error_msg)
+                    ctx.result.error_details.append(error_msg)
                     logger.error(f"[MediaSyncService] {error_msg}")
 
-            # Phase 4: Deactivate DB items not seen in provider
-            for identifier, item in db_by_identifier.items():
-                if identifier not in seen_identifiers:
-                    try:
-                        self.media_repo.deactivate(str(item.id))
-                        result.deactivated += 1
-                        logger.info(
-                            f"[MediaSyncService] Deactivated: {item.file_name} "
-                            f"(no longer in provider)"
-                        )
-                    except SQLAlchemyError as e:
-                        result.errors += 1
-                        error_msg = f"Error deactivating {item.file_name}: {e}"
-                        result.error_details.append(error_msg)
-                        logger.error(f"[MediaSyncService] {error_msg}")
+            self._deactivate_missing_items(ctx)
 
             logger.info(
                 f"[MediaSyncService] Sync complete: "
-                f"{result.new} new, {result.updated} updated, "
-                f"{result.deactivated} deactivated, {result.reactivated} reactivated, "
-                f"{result.unchanged} unchanged, {result.errors} errors"
+                f"{ctx.result.new} new, {ctx.result.updated} updated, "
+                f"{ctx.result.deactivated} deactivated, "
+                f"{ctx.result.reactivated} reactivated, "
+                f"{ctx.result.unchanged} unchanged, {ctx.result.errors} errors"
             )
 
-            self.set_result_summary(run_id, result.to_dict())
-            return result
+            self.set_result_summary(run_id, ctx.result.to_dict())
+            return ctx.result
 
     def _process_provider_file(
-        self,
-        file_info: MediaFileInfo,
-        source_type: str,
-        provider,
-        db_by_identifier: dict,
-        db_by_hash: dict,
-        seen_identifiers: set,
-        result: SyncResult,
+        self, file_info: MediaFileInfo, ctx: SyncContext
     ) -> None:
         """Process a single file from the provider listing.
 
         Decision tree:
         1. Identifier matches DB record -> unchanged (or update name if changed)
-        2. Identifier not in DB, but hash matches existing record -> rename/move
-        3. Identifier not in DB, check for inactive record -> reactivate
-        4. Identifier not in DB, no hash match -> new file, index it
+        2. Hash matches existing record -> rename/move
+        3. Inactive record with same identifier -> reactivate
+        4. No match -> new file, index it
         """
         identifier = file_info.identifier
-        seen_identifiers.add(identifier)
+        ctx.seen_identifiers.add(identifier)
 
-        # Case 1: Exact identifier match in DB
-        if identifier in db_by_identifier:
-            existing = db_by_identifier[identifier]
-
-            if existing.file_name != file_info.name:
-                file_path = self._build_file_path(source_type, file_info)
-                self.media_repo.update_source_info(
-                    media_id=str(existing.id),
-                    file_name=file_info.name,
-                    file_path=file_path,
-                )
-                result.updated += 1
-                logger.info(
-                    f"[MediaSyncService] Updated name: "
-                    f"{existing.file_name} -> {file_info.name}"
-                )
-            else:
-                result.unchanged += 1
+        if self._handle_identifier_match(file_info, ctx):
             return
 
-        # Need hash for further matching
-        file_hash = self._get_file_hash(file_info, provider)
+        file_hash = self._get_file_hash(file_info, ctx.provider)
 
-        # Case 2: Hash matches an existing active record (rename/move)
-        if file_hash in db_by_hash:
-            existing_items = db_by_hash[file_hash]
-            existing = existing_items[0]
+        if self._handle_hash_match(file_info, file_hash, ctx):
+            return
 
-            file_path = self._build_file_path(source_type, file_info)
+        if self._handle_reactivation(file_info, ctx):
+            return
 
-            # Skip if another item already holds this file_path (e.g. inactive
-            # duplicate with same Drive ID).  Updating would hit the unique
-            # constraint and poison the session.
-            if self.media_repo.get_by_path(file_path):
-                result.unchanged += 1
-                return
+        self._index_new_file(file_info, file_hash, ctx)
 
+    def _handle_identifier_match(
+        self, file_info: MediaFileInfo, ctx: SyncContext
+    ) -> bool:
+        """Case 1: Exact identifier match — update name if changed."""
+        existing = ctx.db_by_identifier.get(file_info.identifier)
+        if not existing:
+            return False
+
+        if existing.file_name != file_info.name:
+            file_path = self._build_file_path(ctx.source_type, file_info)
             self.media_repo.update_source_info(
                 media_id=str(existing.id),
                 file_name=file_info.name,
                 file_path=file_path,
-                source_identifier=identifier,
             )
-            result.updated += 1
+            ctx.result.updated += 1
             logger.info(
-                f"[MediaSyncService] Rename detected: "
-                f"{existing.file_name} -> {file_info.name} "
-                f"(hash: {file_hash[:8]}...)"
+                f"[MediaSyncService] Updated name: "
+                f"{existing.file_name} -> {file_info.name}"
             )
-            return
+        else:
+            ctx.result.unchanged += 1
+        return True
 
-        # Case 3: Check for inactive record with same identifier (reactivation)
-        inactive = self.media_repo.get_inactive_by_source_identifier(
-            source_type, identifier
+    def _handle_hash_match(
+        self, file_info: MediaFileInfo, file_hash: str, ctx: SyncContext
+    ) -> bool:
+        """Case 2: Hash matches an existing active record (rename/move)."""
+        if file_hash not in ctx.db_by_hash:
+            return False
+
+        existing = ctx.db_by_hash[file_hash][0]
+        file_path = self._build_file_path(ctx.source_type, file_info)
+
+        # Skip if another item already holds this file_path to avoid
+        # unique constraint violation.
+        if self.media_repo.get_by_path(file_path):
+            ctx.result.unchanged += 1
+            return True
+
+        self.media_repo.update_source_info(
+            media_id=str(existing.id),
+            file_name=file_info.name,
+            file_path=file_path,
+            source_identifier=file_info.identifier,
         )
-        if inactive:
-            self.media_repo.reactivate(str(inactive.id))
-            result.reactivated += 1
-            logger.info(f"[MediaSyncService] Reactivated: {inactive.file_name}")
-            return
+        ctx.result.updated += 1
+        logger.info(
+            f"[MediaSyncService] Rename detected: "
+            f"{existing.file_name} -> {file_info.name} "
+            f"(hash: {file_hash[:8]}...)"
+        )
+        return True
 
-        # Case 4: Truly new file -- check for hash duplicate before indexing
-        if file_hash and self.media_repo.get_active_by_hash(file_hash):
-            result.unchanged += 1
+    def _handle_reactivation(self, file_info: MediaFileInfo, ctx: SyncContext) -> bool:
+        """Case 3: Inactive record with same identifier — reactivate."""
+        inactive = self.media_repo.get_inactive_by_source_identifier(
+            ctx.source_type, file_info.identifier
+        )
+        if not inactive:
+            return False
+
+        self.media_repo.reactivate(str(inactive.id))
+        ctx.result.reactivated += 1
+        logger.info(f"[MediaSyncService] Reactivated: {inactive.file_name}")
+        return True
+
+    def _index_new_file(
+        self, file_info: MediaFileInfo, file_hash: str, ctx: SyncContext
+    ) -> None:
+        """Case 4: Truly new file — check for hash duplicate, then index."""
+        # Use in-memory lookup first; this covers same-source-type duplicates.
+        # The DB query catches cross-source-type duplicates not in ctx.db_by_hash.
+        if file_hash and (
+            file_hash in ctx.db_by_hash or self.media_repo.get_active_by_hash(file_hash)
+        ):
+            ctx.result.unchanged += 1
             logger.info(
                 f"[MediaSyncService] Skipped duplicate: {file_info.name} "
                 f"(hash {file_hash[:8]}... already exists)"
             )
             return
 
-        file_path = self._build_file_path(source_type, file_info)
+        file_path = self._build_file_path(ctx.source_type, file_info)
         self.media_repo.create(
             file_path=file_path,
             file_name=file_info.name,
@@ -312,10 +360,10 @@ class MediaSyncService(BaseService):
             file_size_bytes=file_info.size_bytes,
             mime_type=file_info.mime_type,
             category=file_info.folder,
-            source_type=source_type,
-            source_identifier=identifier,
+            source_type=ctx.source_type,
+            source_identifier=file_info.identifier,
         )
-        result.new += 1
+        ctx.result.new += 1
         logger.info(
             f"[MediaSyncService] Indexed new: {file_info.name}"
             + (f" [{file_info.folder}]" if file_info.folder else "")

--- a/src/services/core/telegram_settings.py
+++ b/src/services/core/telegram_settings.py
@@ -253,8 +253,110 @@ class TelegramSettingsHandlers:
                 reply_markup=CANCEL_KEYBOARD,
             )
 
+    @staticmethod
+    def _parse_int_in_range(text: str, min_val: int, max_val: int) -> int:
+        """Parse text as int and validate it's within [min_val, max_val].
+
+        Raises ValueError if parsing fails or value is out of range.
+        """
+        value = int(text)
+        if not min_val <= value <= max_val:
+            raise ValueError("Out of range")
+        return value
+
+    async def _show_edit_error(self, chat_id, context, error_text: str):
+        """Edit the inline settings message to show a validation error."""
+        await context.bot.edit_message_text(
+            chat_id=chat_id,
+            message_id=context.user_data.get("settings_edit_message_id"),
+            text=error_text,
+            parse_mode="Markdown",
+            reply_markup=CANCEL_KEYBOARD,
+        )
+
+    async def _handle_posts_per_day_input(self, message_text, chat_id, user, context):
+        """Process user input for posts_per_day setting."""
+        try:
+            value = self._parse_int_in_range(
+                message_text, MIN_POSTS_PER_DAY, MAX_POSTS_PER_DAY
+            )
+            self.service.settings_service.update_setting(
+                chat_id, "posts_per_day", value, user
+            )
+            clear_settings_edit_state(context)
+            await self.send_settings_message_by_chat_id(chat_id, context)
+            logger.info(
+                f"User {self.service._get_display_name(user)} updated posts_per_day to {value}"
+            )
+        except ValueError:
+            await self._show_edit_error(
+                chat_id,
+                context,
+                f"\U0001f4ca *Edit Posts Per Day*\n\n"
+                f"\u274c Invalid input. Please enter a number between "
+                f"{MIN_POSTS_PER_DAY} and {MAX_POSTS_PER_DAY}:",
+            )
+
+    async def _handle_hours_start_input(self, message_text, chat_id, context):
+        """Process user input for posting hours start."""
+        try:
+            value = self._parse_int_in_range(
+                message_text, MIN_POSTING_HOUR, MAX_POSTING_HOUR
+            )
+            context.user_data["settings_edit_hours_start"] = value
+            context.user_data["settings_edit_state"] = "awaiting_hours_end"
+            await context.bot.edit_message_text(
+                chat_id=chat_id,
+                message_id=context.user_data.get("settings_edit_message_id"),
+                text=(
+                    f"\U0001f550 *Edit Posting Hours*\n\n"
+                    f"Start hour: *{value}:00 UTC*\n\n"
+                    f"Enter the *end hour* ({MIN_POSTING_HOUR}-{MAX_POSTING_HOUR} UTC):"
+                ),
+                parse_mode="Markdown",
+                reply_markup=CANCEL_KEYBOARD,
+            )
+        except ValueError:
+            await self._show_edit_error(
+                chat_id,
+                context,
+                f"\U0001f550 *Edit Posting Hours*\n\n"
+                f"\u274c Invalid input. Please enter a number between "
+                f"{MIN_POSTING_HOUR} and {MAX_POSTING_HOUR}:",
+            )
+
+    async def _handle_hours_end_input(self, message_text, chat_id, user, context):
+        """Process user input for posting hours end."""
+        try:
+            value = self._parse_int_in_range(
+                message_text, MIN_POSTING_HOUR, MAX_POSTING_HOUR
+            )
+            start_hour = context.user_data.get("settings_edit_hours_start")
+            self.service.settings_service.update_setting(
+                chat_id, "posting_hours_start", start_hour, user
+            )
+            self.service.settings_service.update_setting(
+                chat_id, "posting_hours_end", value, user
+            )
+            clear_settings_edit_state(context)
+            await self.send_settings_message_by_chat_id(chat_id, context)
+            logger.info(
+                f"User {self.service._get_display_name(user)} updated posting hours "
+                f"to {start_hour}:00-{value}:00 UTC"
+            )
+        except ValueError:
+            start = context.user_data.get("settings_edit_hours_start")
+            await self._show_edit_error(
+                chat_id,
+                context,
+                f"\U0001f550 *Edit Posting Hours*\n\n"
+                f"Start hour: *{start}:00 UTC*\n\n"
+                f"\u274c Invalid input. Please enter a number between "
+                f"{MIN_POSTING_HOUR} and {MAX_POSTING_HOUR}:",
+            )
+
     async def handle_settings_edit_message(self, update, context):
-        """Handle user input for editing settings."""
+        """Handle user input for editing settings — dispatches to per-state handlers."""
         if "settings_edit_state" not in context.user_data:
             return False
 
@@ -270,116 +372,13 @@ class TelegramSettingsHandlers:
             logger.debug(f"Could not delete user settings input message: {e}")
 
         if state == "awaiting_posts_per_day":
-            try:
-                value = int(message_text)
-                if not MIN_POSTS_PER_DAY <= value <= MAX_POSTS_PER_DAY:
-                    raise ValueError("Out of range")
-
-                # Update the setting
-                self.service.settings_service.update_setting(
-                    chat_id, "posts_per_day", value, user
-                )
-
-                # Clear state and refresh settings
-                clear_settings_edit_state(context)
-
-                # Rebuild settings message
-                await self.send_settings_message_by_chat_id(chat_id, context)
-
-                logger.info(
-                    f"User {self.service._get_display_name(user)} updated posts_per_day to {value}"
-                )
-
-            except ValueError:
-                # Show error, keep waiting for valid input
-                await context.bot.edit_message_text(
-                    chat_id=chat_id,
-                    message_id=context.user_data.get("settings_edit_message_id"),
-                    text=(
-                        "📊 *Edit Posts Per Day*\n\n"
-                        f"❌ Invalid input. Please enter a number between {MIN_POSTS_PER_DAY} and {MAX_POSTS_PER_DAY}:"
-                    ),
-                    parse_mode="Markdown",
-                    reply_markup=CANCEL_KEYBOARD,
-                )
-
+            await self._handle_posts_per_day_input(message_text, chat_id, user, context)
             return True
-
         elif state == "awaiting_hours_start":
-            try:
-                value = int(message_text)
-                if not MIN_POSTING_HOUR <= value <= MAX_POSTING_HOUR:
-                    raise ValueError("Out of range")
-
-                # Store start hour, ask for end hour
-                context.user_data["settings_edit_hours_start"] = value
-                context.user_data["settings_edit_state"] = "awaiting_hours_end"
-
-                await context.bot.edit_message_text(
-                    chat_id=chat_id,
-                    message_id=context.user_data.get("settings_edit_message_id"),
-                    text=(
-                        f"🕐 *Edit Posting Hours*\n\n"
-                        f"Start hour: *{value}:00 UTC*\n\n"
-                        f"Enter the *end hour* ({MIN_POSTING_HOUR}-{MAX_POSTING_HOUR} UTC):"
-                    ),
-                    parse_mode="Markdown",
-                    reply_markup=CANCEL_KEYBOARD,
-                )
-
-            except ValueError:
-                await context.bot.edit_message_text(
-                    chat_id=chat_id,
-                    message_id=context.user_data.get("settings_edit_message_id"),
-                    text=(
-                        "🕐 *Edit Posting Hours*\n\n"
-                        f"❌ Invalid input. Please enter a number between {MIN_POSTING_HOUR} and {MAX_POSTING_HOUR}:"
-                    ),
-                    parse_mode="Markdown",
-                    reply_markup=CANCEL_KEYBOARD,
-                )
-
+            await self._handle_hours_start_input(message_text, chat_id, context)
             return True
-
         elif state == "awaiting_hours_end":
-            try:
-                value = int(message_text)
-                if not MIN_POSTING_HOUR <= value <= MAX_POSTING_HOUR:
-                    raise ValueError("Out of range")
-
-                start_hour = context.user_data.get("settings_edit_hours_start")
-
-                # Update both settings
-                self.service.settings_service.update_setting(
-                    chat_id, "posting_hours_start", start_hour, user
-                )
-                self.service.settings_service.update_setting(
-                    chat_id, "posting_hours_end", value, user
-                )
-
-                # Clear state
-                clear_settings_edit_state(context)
-
-                # Rebuild settings message
-                await self.send_settings_message_by_chat_id(chat_id, context)
-
-                logger.info(
-                    f"User {self.service._get_display_name(user)} updated posting hours to {start_hour}:00-{value}:00 UTC"
-                )
-
-            except ValueError:
-                await context.bot.edit_message_text(
-                    chat_id=chat_id,
-                    message_id=context.user_data.get("settings_edit_message_id"),
-                    text=(
-                        f"🕐 *Edit Posting Hours*\n\n"
-                        f"Start hour: *{context.user_data.get('settings_edit_hours_start')}:00 UTC*\n\n"
-                        f"❌ Invalid input. Please enter a number between {MIN_POSTING_HOUR} and {MAX_POSTING_HOUR}:"
-                    ),
-                    parse_mode="Markdown",
-                    reply_markup=CANCEL_KEYBOARD,
-                )
-
+            await self._handle_hours_end_input(message_text, chat_id, user, context)
             return True
 
         return False

--- a/src/services/integrations/token_refresh.py
+++ b/src/services/integrations/token_refresh.py
@@ -177,6 +177,63 @@ class TokenRefreshService(BaseService):
 
         return f"{settings.meta_graph_base}/oauth/access_token"
 
+    def _get_current_token(self, instagram_account_id: Optional[str] = None):
+        """Retrieve the current token from the database.
+
+        Returns:
+            The token DB record, or None if not found.
+        """
+        if instagram_account_id:
+            return self.token_repo.get_token_for_account(
+                instagram_account_id, token_type="access_token"
+            )
+        return self.token_repo.get_token("instagram", "access_token")
+
+    async def _call_meta_refresh(
+        self, current_token: str, instagram_account_id: Optional[str]
+    ) -> httpx.Response:
+        """Call Meta's token refresh endpoint.
+
+        Returns:
+            The HTTP response from Meta's API.
+        """
+        refresh_url = self._get_refresh_endpoint(instagram_account_id)
+        async with httpx.AsyncClient() as client:
+            return await client.get(
+                refresh_url,
+                params={
+                    "grant_type": "ig_refresh_token",
+                    "access_token": current_token,
+                },
+                timeout=30.0,
+            )
+
+    def _store_refreshed_token(
+        self, new_token: str, expires_in: int, instagram_account_id: Optional[str]
+    ) -> datetime:
+        """Encrypt and persist a refreshed token to the database.
+
+        Returns:
+            The new expiry datetime.
+        """
+        issued_at = datetime.now(timezone.utc)
+        expires_at = issued_at + timedelta(seconds=expires_in)
+        encrypted = self.encryption.encrypt(new_token)
+
+        self.token_repo.create_or_update(
+            service_name="instagram",
+            token_type="access_token",
+            token_value=encrypted,
+            issued_at=issued_at,
+            expires_at=expires_at,
+            metadata={
+                "refreshed_at": issued_at.isoformat(),
+                "expires_in_seconds": expires_in,
+            },
+            instagram_account_id=instagram_account_id,
+        )
+        return expires_at
+
     async def refresh_instagram_token(
         self, instagram_account_id: Optional[str] = None
     ) -> bool:
@@ -205,14 +262,7 @@ class TokenRefreshService(BaseService):
             method_name="refresh_instagram_token",
             input_params={"account_id": account_label},
         ) as run_id:
-            # Get current token
-            if instagram_account_id:
-                db_token = self.token_repo.get_token_for_account(
-                    instagram_account_id, token_type="access_token"
-                )
-            else:
-                db_token = self.token_repo.get_token("instagram", "access_token")
-
+            db_token = self._get_current_token(instagram_account_id)
             if not db_token:
                 logger.error(f"No Instagram token found to refresh for {account_label}")
                 self.set_result_summary(
@@ -223,81 +273,57 @@ class TokenRefreshService(BaseService):
             current_token = self.encryption.decrypt(db_token.token_value)
 
             try:
-                async with httpx.AsyncClient() as client:
-                    refresh_url = self._get_refresh_endpoint(instagram_account_id)
-                    response = await client.get(
-                        refresh_url,
-                        params={
-                            "grant_type": "ig_refresh_token",
-                            "access_token": current_token,
-                        },
-                        timeout=30.0,
+                response = await self._call_meta_refresh(
+                    current_token, instagram_account_id
+                )
+
+                if response.status_code != 200:
+                    error_data = response.json()
+                    logger.error(
+                        f"Instagram token refresh failed for {account_label}: {error_data}"
                     )
-
-                    if response.status_code != 200:
-                        error_data = response.json()
-                        logger.error(
-                            f"Instagram token refresh failed for {account_label}: {error_data}"
-                        )
-                        self.set_result_summary(
-                            run_id,
-                            {
-                                "success": False,
-                                "status_code": response.status_code,
-                                "error": error_data,
-                            },
-                        )
-                        return False
-
-                    data = response.json()
-                    new_token = data.get("access_token")
-                    expires_in = data.get(
-                        "expires_in", 5184000
-                    )  # Default 60 days in seconds
-
-                    if not new_token:
-                        logger.error(
-                            f"No access_token in refresh response for {account_label}"
-                        )
-                        self.set_result_summary(
-                            run_id, {"success": False, "reason": "no_token_in_response"}
-                        )
-                        return False
-
-                    # Store the new token
-                    issued_at = datetime.now(timezone.utc)
-                    expires_at = issued_at + timedelta(seconds=expires_in)
-
-                    encrypted = self.encryption.encrypt(new_token)
-
-                    self.token_repo.create_or_update(
-                        service_name="instagram",
-                        token_type="access_token",
-                        token_value=encrypted,
-                        issued_at=issued_at,
-                        expires_at=expires_at,
-                        metadata={
-                            "refreshed_at": issued_at.isoformat(),
-                            "expires_in_seconds": expires_in,
-                        },
-                        instagram_account_id=instagram_account_id,
-                    )
-
-                    logger.info(
-                        f"Instagram token refreshed successfully for {account_label}. "
-                        f"New expiry: {expires_at.isoformat()}"
-                    )
-
                     self.set_result_summary(
                         run_id,
                         {
-                            "success": True,
-                            "account": account_label,
-                            "expires_at": expires_at.isoformat(),
-                            "expires_in_days": expires_in // 86400,
+                            "success": False,
+                            "status_code": response.status_code,
+                            "error": error_data,
                         },
                     )
-                    return True
+                    return False
+
+                data = response.json()
+                new_token = data.get("access_token")
+                expires_in = data.get("expires_in", 5184000)  # Default 60 days
+
+                if not new_token:
+                    logger.error(
+                        f"No access_token in refresh response for {account_label}"
+                    )
+                    self.set_result_summary(
+                        run_id, {"success": False, "reason": "no_token_in_response"}
+                    )
+                    return False
+
+                expires_at = self._store_refreshed_token(
+                    new_token, expires_in, instagram_account_id
+                )
+
+                logger.info(
+                    f"Instagram token refreshed successfully for {account_label}. "
+                    f"New expiry: {expires_at.isoformat()}"
+                )
+
+                self.set_result_summary(
+                    run_id,
+                    {
+                        "success": True,
+                        "account": account_label,
+                        "expires_at": expires_at.isoformat(),
+                        "expires_in_days": expires_in // 86400,
+                    },
+                )
+                return True
 
             except httpx.RequestError as e:
                 logger.error(


### PR DESCRIPTION
## Summary

- **`refresh_instagram_token()`** (128→65 lines) — Extracted `_get_current_token()`, `_call_meta_refresh()`, `_store_refreshed_token()`
- **`handle_settings_edit_message()`** (130→20 lines) — Extracted per-state handlers (`_handle_posts_per_day_input`, `_handle_hours_start_input`, `_handle_hours_end_input`) with shared `_parse_int_in_range()` and `_show_edit_error()` helpers
- **`onboarding_upload_media()`** (131→40 lines) — Extracted `_validate_upload_content()`, `_resolve_upload_category()`, `_prepare_save_path()`
- **`sync()`** (132→60 lines) — Extracted `_resolve_source_config()`, `_build_db_lookups()`, `_deactivate_missing_items()`
- **`_process_provider_file()`** (7 params→2) — Introduced `SyncContext` dataclass, extracted `_handle_identifier_match()`, `_handle_hash_match()`, `_handle_reactivation()`, `_index_new_file()`

Bonus from /simplify: added in-memory `ctx.db_by_hash` short-circuit in `_index_new_file()` to avoid redundant DB query.

Fixes #272

## Test plan
- [x] All 1740 tests pass
- [x] `ruff check` and `ruff format --check` clean
- [x] `/simplify` review completed — no reuse duplicates, one efficiency fix applied
- [x] No public API signatures changed
- [x] No behavior changes — pure internal refactoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)