### PR TITLE
feat: add Plausible analytics and conversion tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Analytics and conversion tracking** (#279) — Integrated Plausible Analytics for privacy-friendly page views, referrer tracking, and custom events. Tracks waitlist signups, form errors, FAQ expansions, and comparison table views. Captures UTM parameters (source, medium, campaign) with waitlist submissions for attribution. Controlled via `NEXT_PUBLIC_PLAUSIBLE_DOMAIN` env var — omit to disable.
+
 - **Post-signup experience** (#260) — Replaced dead-end "We'll be in touch" confirmation with enriched post-signup block: sets timeline expectations (within a week), gives a micro-task (prepare Google Drive folder), and adds Telegram community link to move signups from "registered" to "engaged."
 - **Social proof stats bar and trust badges** (#258) — Added stats bar (stories posted, content managed, active creators) between Hero and How It Works sections. Added trust badges below hero CTA with lock/Instagram/key icons addressing top 3 signup objections (content stays in Drive, official API, no password required).
 - **Competitive positioning section** (#259) — Added "Why not just use Buffer?" comparison table between Features and Pricing, contrasting Storyline vs Buffer/Later across 5 dimensions. Added positioning line to hero: "The Instagram Story tool that lives in Telegram — not another dashboard."

--- a/landing/.env.local.example
+++ b/landing/.env.local.example
@@ -8,6 +8,9 @@ ADMIN_TELEGRAM_CHAT_ID=
 # Site URL
 NEXT_PUBLIC_SITE_URL=https://storyline.ai
 
+# Analytics — Plausible domain (omit to disable analytics)
+NEXT_PUBLIC_PLAUSIBLE_DOMAIN=
+
 # Dashboard auth
 JWT_SECRET=          # Random 32+ char string for signing session tokens
 NEXT_PUBLIC_TELEGRAM_BOT_NAME=   # Bot username (without @) for Telegram Login Widget

--- a/landing/src/app/api/waitlist/route.ts
+++ b/landing/src/app/api/waitlist/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server"
 import { getDb } from "@/lib/db"
 import { waitlistSignups } from "@/lib/schema"
 import { notifyAdmin } from "@/lib/telegram"
+import { UTM_KEYS } from "@/lib/analytics"
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 
@@ -17,8 +18,17 @@ export async function POST(req: NextRequest) {
       )
     }
 
+    // Capture UTM params
+    const utm: Record<string, string> = {}
+    for (const key of UTM_KEYS) {
+      if (typeof body[key] === "string" && body[key].trim()) {
+        utm[key] = body[key].trim()
+      }
+    }
+    const notes = Object.keys(utm).length > 0 ? JSON.stringify(utm) : null
+
     try {
-      await getDb().insert(waitlistSignups).values({ email })
+      await getDb().insert(waitlistSignups).values({ email, notes })
     } catch (err: unknown) {
       // Unique constraint violation = already registered
       if (

--- a/landing/src/app/layout.tsx
+++ b/landing/src/app/layout.tsx
@@ -1,7 +1,10 @@
 import type { Metadata } from "next"
+import Script from "next/script"
 import { Geist, Geist_Mono } from "next/font/google"
 import { siteConfig } from "@/config/site"
 import "./globals.css"
+
+const plausibleDomain = process.env.NEXT_PUBLIC_PLAUSIBLE_DOMAIN
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -41,6 +44,14 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         {children}
+        {plausibleDomain && (
+          <Script
+            defer
+            data-domain={plausibleDomain}
+            src="https://plausible.io/js/script.js"
+            strategy="afterInteractive"
+          />
+        )}
       </body>
     </html>
   )

--- a/landing/src/components/landing/comparison.tsx
+++ b/landing/src/components/landing/comparison.tsx
@@ -1,4 +1,8 @@
+"use client"
+
+import { useEffect, useRef } from "react"
 import { Check, X } from "lucide-react"
+import { trackEvent } from "@/lib/analytics"
 
 const rows = [
   {
@@ -29,8 +33,26 @@ const rows = [
 ]
 
 export function Comparison() {
+  const sectionRef = useRef<HTMLElement>(null)
+
+  useEffect(() => {
+    const el = sectionRef.current
+    if (!el) return
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          trackEvent("Comparison Viewed")
+          observer.disconnect()
+        }
+      },
+      { threshold: 0.5 }
+    )
+    observer.observe(el)
+    return () => observer.disconnect()
+  }, [])
+
   return (
-    <section className="py-16 md:py-24">
+    <section ref={sectionRef} className="py-16 md:py-24">
       <div className="mx-auto max-w-5xl px-4">
         <h2 className="text-center text-3xl font-bold tracking-tight">
           Why not just use Buffer?

--- a/landing/src/components/landing/faq.tsx
+++ b/landing/src/components/landing/faq.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import { siteConfig } from "@/config/site"
 import {
   Accordion,
@@ -5,6 +7,7 @@ import {
   AccordionTrigger,
   AccordionContent,
 } from "@/components/ui/accordion"
+import { trackEvent } from "@/lib/analytics"
 
 const faqs = [
   {
@@ -55,7 +58,18 @@ export function FAQ() {
         <h2 className="text-center text-3xl font-bold tracking-tight">
           Frequently Asked Questions
         </h2>
-        <Accordion type="single" collapsible className="mt-12">
+        <Accordion
+          type="single"
+          collapsible
+          className="mt-12"
+          onValueChange={(value) => {
+            if (value) {
+              const idx = parseInt(value.replace("faq-", ""), 10)
+              const faq = faqs[idx]
+              if (faq) trackEvent("FAQ Expanded", { question: faq.question })
+            }
+          }}
+        >
           {faqs.map((faq, i) => (
             <AccordionItem key={i} value={`faq-${i}`}>
               <AccordionTrigger>{faq.question}</AccordionTrigger>

--- a/landing/src/components/landing/waitlist-form.tsx
+++ b/landing/src/components/landing/waitlist-form.tsx
@@ -4,6 +4,7 @@ import { useState } from "react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { cn } from "@/lib/utils"
+import { trackEvent, UTM_KEYS } from "@/lib/analytics"
 
 interface WaitlistFormProps {
   variant?: "hero" | "footer"
@@ -14,6 +15,17 @@ const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
 const STORAGE_KEY = "storyline-waitlist-registered"
 
 type FormStatus = "idle" | "submitting" | "success" | "error" | "duplicate"
+
+function getUtmParams(): Record<string, string> {
+  if (typeof window === "undefined") return {}
+  const params = new URLSearchParams(window.location.search)
+  const utm: Record<string, string> = {}
+  for (const key of UTM_KEYS) {
+    const val = params.get(key)
+    if (val) utm[key] = val
+  }
+  return utm
+}
 
 function getInitialStatus(): FormStatus {
   if (typeof window !== "undefined" && localStorage.getItem(STORAGE_KEY)) {
@@ -43,16 +55,18 @@ export function WaitlistForm({
     if (!email || !EMAIL_REGEX.test(email)) {
       setStatus("error")
       setMessage("Please enter a valid email address.")
+      trackEvent("Waitlist Error", { reason: "invalid_email", variant })
       return
     }
 
     setStatus("submitting")
+    const utm = getUtmParams()
 
     try {
       const res = await fetch("/api/waitlist", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ email }),
+        body: JSON.stringify({ email, ...utm }),
       })
 
       const data = await res.json()
@@ -64,15 +78,18 @@ export function WaitlistForm({
         } else {
           setStatus("success")
           setMessage(data.message)
+          trackEvent("Waitlist Signup", { variant, ...utm })
         }
         localStorage.setItem(STORAGE_KEY, "true")
       } else {
         setStatus("error")
         setMessage(data.message || "Something went wrong. Please try again.")
+        trackEvent("Waitlist Error", { reason: "server_error", variant })
       }
     } catch {
       setStatus("error")
       setMessage("Something went wrong. Please try again.")
+      trackEvent("Waitlist Error", { reason: "network_error", variant })
     }
   }
 

--- a/landing/src/lib/analytics.ts
+++ b/landing/src/lib/analytics.ts
@@ -1,0 +1,18 @@
+type EventProps = Record<string, string | number | boolean>
+
+export const UTM_KEYS = ["utm_source", "utm_medium", "utm_campaign"] as const
+
+export function trackEvent(name: string, props?: EventProps) {
+  if (typeof window !== "undefined" && window.plausible) {
+    window.plausible(name, props ? { props } : undefined)
+  }
+}
+
+declare global {
+  interface Window {
+    plausible?: (
+      event: string,
+      options?: { props?: EventProps }
+    ) => void
+  }
+}


### PR DESCRIPTION
## Summary

Closes #279

- Integrate Plausible Analytics (privacy-friendly, no cookie banner) controlled via `NEXT_PUBLIC_PLAUSIBLE_DOMAIN` env var
- Track custom events: Waitlist Signup, Waitlist Error, FAQ Expanded, Comparison Viewed
- Capture UTM parameters (source, medium, campaign) from URL and store with waitlist submissions for attribution
- Shared `UTM_KEYS` constant between client and server to prevent drift

## Changes

| File | What |
|------|------|
| `landing/src/lib/analytics.ts` | New — `trackEvent()` wrapper + `UTM_KEYS` constant |
| `landing/src/app/layout.tsx` | Plausible script tag (conditional on env var) |
| `landing/src/components/landing/waitlist-form.tsx` | UTM capture + signup/error event tracking |
| `landing/src/app/api/waitlist/route.ts` | Accept UTM params, store as JSON in notes field |
| `landing/src/components/landing/faq.tsx` | Track FAQ accordion expansions |
| `landing/src/components/landing/comparison.tsx` | Track comparison table visibility via IntersectionObserver |
| `landing/.env.local.example` | Document new env var |
| `CHANGELOG.md` | Entry under Unreleased |

## Setup

Set `NEXT_PUBLIC_PLAUSIBLE_DOMAIN=storydump.app` in Vercel env vars after creating a Plausible Cloud account (free tier).

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] Landing page loads without analytics env var (no errors, no script)
- [ ] With env var set, Plausible script loads and pageviews register
- [ ] Waitlist form submit sends UTM params from URL
- [ ] FAQ expand triggers "FAQ Expanded" event
- [ ] Scrolling to comparison table triggers "Comparison Viewed" event

🤖 Generated with [Claude Code](https://claude.com/claude-code)