### PR TITLE
chore: rebrand Storyline AI → Storydump (Tiers 1-3)

### DIFF
--- a/.claude/PROJECT_CONTEXT.md
+++ b/.claude/PROJECT_CONTEXT.md
@@ -1,4 +1,4 @@
-# Storyline AI - Project Context
+# Storydump - Project Context
 
 **Copy this into Claude web/phone sessions for context.**
 
@@ -6,7 +6,7 @@
 
 ## What This Project Does
 
-Storyline AI is a self-hosted Instagram Story scheduling system with Telegram-based workflow:
+Storydump is a self-hosted Instagram Story scheduling system with Telegram-based workflow:
 1. Media files are indexed from Google Drive (or local filesystem)
 2. A JIT scheduler checks if a posting slot is due each tick
 3. At each slot, the bot either:
@@ -96,12 +96,12 @@ Storyline AI is a self-hosted Instagram Story scheduling system with Telegram-ba
 ## Safety Rules
 
 **NEVER suggest running:**
-- `storyline-cli process-queue` (posts to Instagram)
-- `storyline-cli create-schedule` (modifies queue)
+- `storydump-cli process-queue` (posts to Instagram)
+- `storydump-cli create-schedule` (modifies queue)
 - `python -m src.main` (starts the bot)
 
 **SAFE to suggest:**
-- `storyline-cli list-queue` / `list-media` / `check-health`
+- `storydump-cli list-queue` / `list-media` / `check-health`
 - `pytest tests/`
 - Database SELECT queries
 

--- a/.claude/QUICK_REFERENCE.md
+++ b/.claude/QUICK_REFERENCE.md
@@ -1,16 +1,16 @@
-# Storyline AI - Quick Reference for Claude
+# Storydump - Quick Reference for Claude
 
 ## ⚠️ CRITICAL SAFETY RULES
 
 **NEVER run these commands** (they post to Instagram or modify production):
-- `storyline-cli process-queue`
-- `storyline-cli create-schedule`
-- `storyline-cli reset-queue`
+- `storydump-cli process-queue`
+- `storydump-cli create-schedule`
+- `storydump-cli reset-queue`
 - `python -m src.main`
 
 **SAFE commands** (read-only):
-- `storyline-cli list-queue` / `list-media` / `list-categories` / `list-users`
-- `storyline-cli check-health` / `instagram-status`
+- `storydump-cli list-queue` / `list-media` / `list-categories` / `list-users`
+- `storydump-cli check-health` / `instagram-status`
 - `pytest` (all tests)
 
 ---

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,12 +10,12 @@
       "Bash(pip*)",
       "Bash(pytest*)",
       "Bash(ruff*)",
-      "Bash(storyline-cli index-media*)",
-      "Bash(storyline-cli list-*)",
-      "Bash(storyline-cli check-health*)",
-      "Bash(storyline-cli validate-image*)",
-      "Bash(storyline-cli category-mix-history*)",
-      "Bash(storyline-cli instagram-status*)",
+      "Bash(storydump-cli index-media*)",
+      "Bash(storydump-cli list-*)",
+      "Bash(storydump-cli check-health*)",
+      "Bash(storydump-cli validate-image*)",
+      "Bash(storydump-cli category-mix-history*)",
+      "Bash(storydump-cli instagram-status*)",
       "Bash(source venv*)",
       "Bash(. venv*)",
       "Bash(git status*)",
@@ -51,10 +51,10 @@
       "Edit(documentation/**/*.md)"
     ],
     "deny": [
-      "Bash(storyline-cli process-queue*)",
-      "Bash(storyline-cli create-schedule*)",
-      "Bash(storyline-cli reset-queue*)",
-      "Bash(storyline-cli instagram-auth*)",
+      "Bash(storydump-cli process-queue*)",
+      "Bash(storydump-cli create-schedule*)",
+      "Bash(storydump-cli reset-queue*)",
+      "Bash(storydump-cli instagram-auth*)",
       "Bash(python -m src.main*)",
       "Bash(python src/main.py*)"
     ]

--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
 # ============================================
-# Storyline AI Configuration
+# Storydump Configuration
 # ============================================
 
 # ============================================
@@ -13,13 +13,13 @@ ENABLE_INSTAGRAM_API=false
 # Database Configuration
 # ============================================
 # Option 1: Full connection URL (recommended for cloud — overrides DB_* vars)
-# DATABASE_URL=postgresql://user:pass@ep-xxx.neon.tech/storyline_ai?sslmode=require
+# DATABASE_URL=postgresql://user:pass@ep-xxx.neon.tech/storydump?sslmode=require
 
 # Option 2: Individual components (for local development)
 DB_HOST=localhost
 DB_PORT=5432
-DB_NAME=storyline_ai
-DB_USER=storyline_user
+DB_NAME=storydump
+DB_USER=storydump_user
 # DB_PASSWORD is optional for local PostgreSQL (leave blank if not needed)
 DB_PASSWORD=
 
@@ -31,7 +31,7 @@ DB_PASSWORD=
 # DB_MAX_OVERFLOW=20
 
 # Test database (optional)
-TEST_DB_NAME=storyline_ai_test
+TEST_DB_NAME=storydump_test
 
 # ============================================
 # Telegram Configuration (REQUIRED)
@@ -65,7 +65,7 @@ REPOST_TTL_DAYS=30
 # Path to media directory (absolute path required)
 # Auto-created at startup if it doesn't exist
 # Examples:
-#   macOS/Linux development: /Users/yourname/Projects/storyline-ai/media/stories
+#   macOS/Linux development: /Users/yourname/Projects/storydump/media/stories
 #   Cloud (Railway): /tmp/media
 MEDIA_DIR=/tmp/media
 
@@ -82,7 +82,7 @@ MEDIA_DIR=/tmp/media
 # ============================================
 # Backup Configuration
 # ============================================
-BACKUP_DIR=/backup/storyline-ai
+BACKUP_DIR=/backup/storydump
 BACKUP_RETENTION_DAYS=30
 
 # ============================================
@@ -99,7 +99,7 @@ FACEBOOK_APP_SECRET=
 
 # Instagram deep link redirect URL (GitHub Pages — opens story camera on mobile)
 # Default: https://www.instagram.com/ (opens feed, no deep link)
-# INSTAGRAM_DEEPLINK_URL=https://your-username.github.io/storyline-ai/
+# INSTAGRAM_DEEPLINK_URL=https://your-username.github.io/storydump/
 
 # Rate limit for Instagram API (Meta allows ~25/hour for Stories)
 INSTAGRAM_POSTS_PER_HOUR=25

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         env:
           POSTGRES_USER: test_user
           POSTGRES_PASSWORD: test_password
-          POSTGRES_DB: storyline_test
+          POSTGRES_DB: storydump_test
         ports:
           - 5432:5432
         options: >-
@@ -82,8 +82,8 @@ jobs:
           DB_PORT: 5432
           DB_USER: test_user
           DB_PASSWORD: test_password
-          DB_NAME: storyline_ai
-          TEST_DB_NAME: storyline_test
+          DB_NAME: storydump
+          TEST_DB_NAME: storydump_test
           # Required Telegram settings
           TELEGRAM_BOT_TOKEN: test_token
           TELEGRAM_CHANNEL_ID: -1001234567890

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         env:
           POSTGRES_USER: test_user
           POSTGRES_PASSWORD: test_password
-          POSTGRES_DB: storydump_test
+          POSTGRES_DB: storyline_test
         ports:
           - 5432:5432
         options: >-
@@ -82,8 +82,8 @@ jobs:
           DB_PORT: 5432
           DB_USER: test_user
           DB_PASSWORD: test_password
-          DB_NAME: storydump
-          TEST_DB_NAME: storydump_test
+          DB_NAME: storyline_ai
+          TEST_DB_NAME: storyline_test
           # Required Telegram settings
           TELEGRAM_BOT_TOKEN: test_token
           TELEGRAM_CHANNEL_ID: -1001234567890

--- a/.vercel/project.json
+++ b/.vercel/project.json
@@ -1,1 +1,1 @@
-{"projectId":"prj_uWkyUXgaU5gW17c6rQtNRgUkWMdd","orgId":"team_SZnRQM2KUUyzvmwyhvl2rdMg","projectName":"storyline-ai"}
+{"projectId":"prj_uWkyUXgaU5gW17c6rQtNRgUkWMdd","orgId":"team_SZnRQM2KUUyzvmwyhvl2rdMg","projectName":"storydump"}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,30 +11,30 @@ Domain-specific rules are in `.claude/rules/` and load automatically when workin
 
 ### NEVER run these commands:
 ```bash
-storyline-cli process-queue          # Posts to Instagram/Telegram
-storyline-cli process-queue --force  # Posts to Instagram/Telegram
+storydump-cli process-queue          # Posts to Instagram/Telegram
+storydump-cli process-queue --force  # Posts to Instagram/Telegram
 python -m src.main                   # Starts posting scheduler
-storyline-cli create-schedule        # Modifies production schedule
-storyline-cli reset-queue            # Modifies production queue
-storyline-cli instagram-auth         # Modifies authentication
+storydump-cli create-schedule        # Modifies production schedule
+storydump-cli reset-queue            # Modifies production queue
+storydump-cli instagram-auth         # Modifies authentication
 ```
 
 ### SAFE commands you CAN run:
 ```bash
-storyline-cli list-queue             # Reading/inspection only
-storyline-cli list-media
-storyline-cli list-categories
-storyline-cli list-users
-storyline-cli check-health
-storyline-cli instagram-status
-storyline-cli validate-image <path>
-storyline-cli category-mix-history
-storyline-cli sync-media
-storyline-cli sync-status
-storyline-cli backfill-instagram --dry-run
-storyline-cli backfill-status
-storyline-cli pool-health
-storyline-cli dedup-media            # Dry-run by default (--apply mutates)
+storydump-cli list-queue             # Reading/inspection only
+storydump-cli list-media
+storydump-cli list-categories
+storydump-cli list-users
+storydump-cli check-health
+storydump-cli instagram-status
+storydump-cli validate-image <path>
+storydump-cli category-mix-history
+storydump-cli sync-media
+storydump-cli sync-status
+storydump-cli backfill-instagram --dry-run
+storydump-cli backfill-status
+storydump-cli pool-health
+storydump-cli dedup-media            # Dry-run by default (--apply mutates)
 pytest                               # Tests - always safe
 ```
 
@@ -61,7 +61,7 @@ pytest                               # Tests - always safe
 
 ## Project Overview
 
-**Storyline AI** is a self-hosted Instagram Story scheduling and automation system with Telegram-based team collaboration.
+**Storydump** is a self-hosted Instagram Story scheduling and automation system with Telegram-based team collaboration.
 
 **Core Philosophy**: Phased deployment — 100% manual posting (Phase 1), optional Instagram API automation (Phase 2), web UI (Phase 3).
 
@@ -85,10 +85,10 @@ python3 -m venv venv && source venv/bin/activate
 pip install -r requirements.txt && pip install -e .
 
 # Common tasks
-storyline-cli check-health
-storyline-cli queue-preview
-storyline-cli list-categories
-storyline-cli update-category-mix
+storydump-cli check-health
+storydump-cli queue-preview
+storydump-cli list-categories
+storydump-cli update-category-mix
 
 # Testing
 pytest                          # All tests

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ ENV_FILE ?= .env
 # Database connection variables
 DB_HOST ?= localhost
 DB_PORT ?= 5432
-DB_NAME ?= storyline_ai
+DB_NAME ?= storydump
 DB_USER ?= $(USER)
 DB_PASSWORD ?=
 
@@ -29,7 +29,7 @@ RED    := \033[0;31m
 NC     := \033[0m # No Color
 
 help: ## Show this help message
-	@echo "$(GREEN)Storyline AI - Makefile Commands$(NC)"
+	@echo "$(GREEN)Storydump - Makefile Commands$(NC)"
 	@echo ""
 	@echo "$(YELLOW)Usage:$(NC)"
 	@echo "  make <target>"
@@ -128,7 +128,7 @@ check-db: ## Check if database exists and is accessible
 
 check-health: ## Run application health checks
 	@echo "$(GREEN)Running health checks...$(NC)"
-	storyline-cli check-health
+	storydump-cli check-health
 
 index-media: ## Index media files from MEDIA_DIR
 	@echo "$(GREEN)Indexing media files...$(NC)"
@@ -136,23 +136,23 @@ index-media: ## Index media files from MEDIA_DIR
 		echo "$(YELLOW)Usage: make index-media DIR=path/to/media$(NC)"; \
 		exit 1; \
 	fi
-	storyline-cli index-media $(DIR)
+	storydump-cli index-media $(DIR)
 
 create-schedule: ## Create posting schedule (default: 7 days)
 	@echo "$(GREEN)Creating posting schedule...$(NC)"
-	storyline-cli create-schedule --days $(or $(DAYS),7)
+	storydump-cli create-schedule --days $(or $(DAYS),7)
 
 list-queue: ## List pending queue items
-	storyline-cli list-queue
+	storydump-cli list-queue
 
 list-media: ## List indexed media items
-	storyline-cli list-media --limit $(or $(LIMIT),50)
+	storydump-cli list-media --limit $(or $(LIMIT),50)
 
 list-users: ## List all users
-	storyline-cli list-users
+	storydump-cli list-users
 
 run: ## Run the main application
-	@echo "$(GREEN)Starting Storyline AI...$(NC)"
+	@echo "$(GREEN)Starting Storydump...$(NC)"
 	python -m src.main
 
 dev: ## Run in development mode with environment validation
@@ -167,7 +167,7 @@ dev: ## Run in development mode with environment validation
 
 logs: ## View application logs (tail -f)
 	@echo "$(GREEN)Tailing logs...$(NC)"
-	tail -f logs/storyline.log
+	tail -f logs/app.log
 
 db-shell: ## Open PostgreSQL shell for application database
 	@echo "$(GREEN)Opening database shell...$(NC)"

--- a/PROJECT_MISSION.md
+++ b/PROJECT_MISSION.md
@@ -1,4 +1,4 @@
-# Project Mission — Storyline AI
+# Project Mission — Storydump
 
 ## What this project is
 A social media automation platform that manages the full content lifecycle — from sourcing and scheduling to posting and performance analysis. Currently a Telegram bot for Instagram Stories with Google Drive as the content hub. Supports multi-account management for small teams.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Storyline AI - Instagram Story Automation System
+# Storydump - Instagram Story Automation System
 
 A self-hosted Instagram Story scheduling system with Telegram-based team collaboration.
 
@@ -22,7 +22,7 @@ A self-hosted Instagram Story scheduling system with Telegram-based team collabo
 ```bash
 # Clone repository
 git clone <your-repo-url>
-cd storyline-ai
+cd storydump
 
 # Create virtual environment
 python3 -m venv venv
@@ -54,10 +54,10 @@ Required configuration:
 
 ```bash
 # Create database
-createdb storyline_ai
+createdb storydump
 
 # Run schema setup
-psql -U postgres -d storyline_ai -f scripts/setup_database.sql
+psql -U postgres -d storydump -f scripts/setup_database.sql
 
 # Or use Python script
 python scripts/init_db.py
@@ -67,20 +67,20 @@ python scripts/init_db.py
 
 ```bash
 # Index media files
-storyline-cli index-media /path/to/media/stories
+storydump-cli index-media /path/to/media/stories
 
 # List indexed media
-storyline-cli list-media --limit 20
+storydump-cli list-media --limit 20
 ```
 
 ### 5. Create Schedule
 
 ```bash
 # Create 7-day posting schedule
-storyline-cli create-schedule --days 7
+storydump-cli create-schedule --days 7
 
 # View queue
-storyline-cli list-queue
+storydump-cli list-queue
 ```
 
 ### 6. Run the Application
@@ -98,62 +98,62 @@ python -m src.main
 
 ```bash
 # Index media from directory
-storyline-cli index-media /path/to/media
+storydump-cli index-media /path/to/media
 
 # List all media items
-storyline-cli list-media --limit 50 --active-only
+storydump-cli list-media --limit 50 --active-only
 
 # Validate image
-storyline-cli validate-image /path/to/image.jpg
+storydump-cli validate-image /path/to/image.jpg
 ```
 
 ### Queue Management
 
 ```bash
 # Create posting schedule (uses category ratios)
-storyline-cli create-schedule --days 7
+storydump-cli create-schedule --days 7
 
 # Process pending posts
-storyline-cli process-queue
+storydump-cli process-queue
 
 # Force process next post (development testing)
-storyline-cli process-queue --force
+storydump-cli process-queue --force
 
 # View queue
-storyline-cli list-queue
+storydump-cli list-queue
 
 # Reset queue (clear all pending posts)
-storyline-cli reset-queue
+storydump-cli reset-queue
 ```
 
 ### Category Management
 
 ```bash
 # List categories and their posting ratios
-storyline-cli list-categories
+storydump-cli list-categories
 
 # Update category posting ratios (interactive prompts)
-storyline-cli update-category-mix
+storydump-cli update-category-mix
 
 # View ratio history (Type 2 SCD)
-storyline-cli category-mix-history --limit 10
+storydump-cli category-mix-history --limit 10
 ```
 
 ### User Management
 
 ```bash
 # List users
-storyline-cli list-users
+storydump-cli list-users
 
 # Promote user to admin
-storyline-cli promote-user <telegram_user_id> --role admin
+storydump-cli promote-user <telegram_user_id> --role admin
 ```
 
 ### Health Check
 
 ```bash
 # Check system health
-storyline-cli check-health
+storydump-cli check-health
 ```
 
 ## Telegram Bot Commands
@@ -242,13 +242,13 @@ pytest -m unit
 pytest -m integration
 
 # Force process next post (development testing)
-storyline-cli process-queue --force
+storydump-cli process-queue --force
 ```
 
 ### Project Structure
 
 ```
-storyline-ai/
+storydump/
 ├── src/                    # Main application code
 │   ├── config/            # Configuration management
 │   ├── models/            # Database models

--- a/cli/commands/backfill.py
+++ b/cli/commands/backfill.py
@@ -61,15 +61,15 @@ def backfill_instagram(
 
     Examples:
 
-        storyline-cli backfill-instagram
+        storydump-cli backfill-instagram
 
-        storyline-cli backfill-instagram --limit 50
+        storydump-cli backfill-instagram --limit 50
 
-        storyline-cli backfill-instagram --dry-run
+        storydump-cli backfill-instagram --dry-run
 
-        storyline-cli backfill-instagram --since 2025-01-01
+        storydump-cli backfill-instagram --since 2025-01-01
 
-        storyline-cli backfill-instagram --account-id abc123...
+        storydump-cli backfill-instagram --account-id abc123...
     """
     from src.services.integrations.instagram_backfill import (
         InstagramBackfillService,
@@ -83,7 +83,7 @@ def backfill_instagram(
             f"Limit: {limit or 'all'}\n"
             f"Since: {since.strftime('%Y-%m-%d') if since else 'all time'}\n"
             f"Account: {account_id or 'active account'}",
-            title="Storyline AI",
+            title="Storydump",
         )
     )
 
@@ -162,7 +162,7 @@ def backfill_status():
     if not last_run:
         console.print("\n[yellow]No backfill runs recorded yet.[/yellow]")
         console.print(
-            "[dim]Run 'storyline-cli backfill-instagram --dry-run' to preview.[/dim]"
+            "[dim]Run 'storydump-cli backfill-instagram --dry-run' to preview.[/dim]"
         )
         return
 

--- a/cli/commands/google_drive.py
+++ b/cli/commands/google_drive.py
@@ -32,7 +32,7 @@ def connect_google_drive(credentials_file, folder_id):
             "[bold blue]Connecting Google Drive[/bold blue]\n\n"
             f"Credentials: {credentials_file}\n"
             f"Folder ID: {folder_id}",
-            title="Storyline AI",
+            title="Storydump",
         )
     )
 
@@ -113,7 +113,7 @@ def google_drive_status():
         table.add_row("Error", status.get("error", "Unknown"))
         console.print(table)
         console.print(
-            "\n[dim]Connect with: storyline-cli connect-google-drive "
+            "\n[dim]Connect with: storydump-cli connect-google-drive "
             "--credentials-file <path> --folder-id <id>[/dim]"
         )
 

--- a/cli/commands/instagram.py
+++ b/cli/commands/instagram.py
@@ -39,7 +39,7 @@ def instagram_auth(manual: bool):
         Panel.fit(
             "[bold blue]Instagram API Authentication Setup[/bold blue]\n\n"
             "This wizard will help you obtain a long-lived Instagram access token.",
-            title="Storyline AI",
+            title="Storydump",
         )
     )
 
@@ -91,7 +91,7 @@ def _show_manual_instructions():
     console.print("   - pages_read_engagement\n")
 
     console.print("4. Copy the short-lived token and run:")
-    console.print("   [cyan]storyline-cli instagram-auth[/cyan]")
+    console.print("   [cyan]storydump-cli instagram-auth[/cyan]")
     console.print("   Then paste the token when prompted.\n")
 
     console.print("5. The token will be exchanged for a long-lived token (60 days)")
@@ -176,7 +176,7 @@ def _run_auth_wizard():
     console.print("1. Set ENABLE_INSTAGRAM_API=true in .env")
     if account_info:
         console.print(f"2. Set INSTAGRAM_ACCOUNT_ID={account_info.get('id')} in .env")
-    console.print("3. Run: storyline-cli check-health")
+    console.print("3. Run: storydump-cli check-health")
 
 
 async def _exchange_for_long_lived_token(short_token: str) -> tuple:
@@ -423,7 +423,7 @@ def add_instagram_account(
     Use /settings in Telegram to switch between accounts.
 
     Example:
-        storyline-cli add-instagram-account \\
+        storydump-cli add-instagram-account \\
             --display-name "Main Brand" \\
             --account-id "17841234567890" \\
             --username "brand_main" \\
@@ -438,7 +438,7 @@ def add_instagram_account(
             f"Display Name: {display_name}\n"
             f"Account ID: {account_id}\n"
             f"Username: @{username.lstrip('@')}",
-            title="Storyline AI",
+            title="Storydump",
         )
     )
 
@@ -515,7 +515,7 @@ def list_instagram_accounts(include_inactive):
     if not accounts:
         console.print("[yellow]No Instagram accounts configured.[/yellow]")
         console.print("\nAdd an account with:")
-        console.print("  storyline-cli add-instagram-account --help")
+        console.print("  storydump-cli add-instagram-account --help")
         return
 
     table = Table(title="Instagram Accounts")

--- a/cli/commands/sync.py
+++ b/cli/commands/sync.py
@@ -103,7 +103,7 @@ def sync_status():
         if not enabled:
             console.print(
                 "[dim]Enable with MEDIA_SYNC_ENABLED=true in .env, "
-                "or run 'storyline-cli sync-media' manually.[/dim]"
+                "or run 'storydump-cli sync-media' manually.[/dim]"
             )
         return
 

--- a/cli/main.py
+++ b/cli/main.py
@@ -39,7 +39,7 @@ console = Console()
 @click.group()
 @click.version_option(version=__version__)
 def cli():
-    """Storyline AI - Instagram Story Automation System"""
+    """Storydump - Instagram Story Automation System"""
     pass
 
 

--- a/landing/.env.local.example
+++ b/landing/.env.local.example
@@ -6,7 +6,7 @@ TELEGRAM_BOT_TOKEN=
 ADMIN_TELEGRAM_CHAT_ID=
 
 # Site URL
-NEXT_PUBLIC_SITE_URL=https://storyline.ai
+NEXT_PUBLIC_SITE_URL=https://storydump.app
 
 # Analytics — Plausible domain (omit to disable analytics)
 NEXT_PUBLIC_PLAUSIBLE_DOMAIN=

--- a/landing/package-lock.json
+++ b/landing/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "storyline-ai-landing",
+  "name": "storydump-landing",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "storyline-ai-landing",
+      "name": "storydump-landing",
       "version": "0.1.0",
       "dependencies": {
         "@neondatabase/serverless": "^1.0.2",

--- a/landing/package.json
+++ b/landing/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "storyline-ai-landing",
+  "name": "storydump-landing",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/landing/src/app/(dashboard)/dashboard/analytics/page.tsx
+++ b/landing/src/app/(dashboard)/dashboard/analytics/page.tsx
@@ -1,7 +1,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 export const metadata = {
-  title: "Analytics — Storyline AI",
+  title: "Analytics — Storydump",
 };
 
 export default function AnalyticsPage() {

--- a/landing/src/app/(dashboard)/dashboard/setup/page.tsx
+++ b/landing/src/app/(dashboard)/dashboard/setup/page.tsx
@@ -4,7 +4,7 @@ import { backendPost } from "@/lib/backend";
 import { SetupWizard } from "@/components/dashboard/setup-wizard";
 
 export const metadata = {
-  title: "Setup — Storyline AI",
+  title: "Setup — Storydump",
 };
 
 export default async function SetupPage() {

--- a/landing/src/app/(dashboard)/layout.tsx
+++ b/landing/src/app/(dashboard)/layout.tsx
@@ -4,7 +4,7 @@ import { Sidebar } from "@/components/dashboard/sidebar";
 import { DashboardHeader } from "@/components/dashboard/header";
 
 export const metadata = {
-  title: "Dashboard — Storyline AI",
+  title: "Dashboard — Storydump",
 };
 
 export default async function DashboardLayout({

--- a/landing/src/app/(marketing)/setup/connect/page.tsx
+++ b/landing/src/app/(marketing)/setup/connect/page.tsx
@@ -6,7 +6,7 @@ import { Callout } from "@/components/setup/callout"
 import { siteConfig } from "@/config/site"
 
 export const metadata: Metadata = {
-  title: "Connect to Telegram — Storyline AI",
+  title: "Connect to Telegram — Storydump",
   robots: { index: false, follow: false },
 }
 
@@ -17,7 +17,7 @@ export default function ConnectTelegram() {
         Connect to Telegram
       </h1>
       <p className="mt-4 text-lg text-muted-foreground">
-        The final step — link your account to the Storyline Telegram bot and
+        The final step — link your account to the Storydump Telegram bot and
         start automating your Stories.
       </p>
 
@@ -106,7 +106,7 @@ export default function ConnectTelegram() {
               <span className="font-medium text-foreground">
                 Select your media folder
               </span>{" "}
-              — point Storyline to the Drive folder you organized
+              — point Storydump to the Drive folder you organized
             </li>
             <li>
               <span className="font-medium text-foreground">
@@ -118,7 +118,7 @@ export default function ConnectTelegram() {
         </StepCard>
 
         <StepCard number={4} title="What happens next">
-          <p>Once setup is complete, Storyline will:</p>
+          <p>Once setup is complete, Storydump will:</p>
           <ul className="mt-2 space-y-2">
             <li className="flex items-start gap-3">
               <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-primary" />

--- a/landing/src/app/(marketing)/setup/google-drive/page.tsx
+++ b/landing/src/app/(marketing)/setup/google-drive/page.tsx
@@ -7,7 +7,7 @@ import { Screenshot } from "@/components/setup/screenshot"
 import { CopyButton } from "@/components/setup/copy-button"
 
 export const metadata: Metadata = {
-  title: "Google Drive Setup — Storyline AI",
+  title: "Google Drive Setup — Storydump",
   robots: { index: false, follow: false },
 }
 
@@ -19,7 +19,7 @@ export default function GoogleDriveSetup() {
       </h1>
       <p className="mt-4 text-lg text-muted-foreground">
         Create a Google Cloud project with the Drive API enabled and OAuth
-        credentials so Storyline can read your media files.
+        credentials so Storydump can read your media files.
       </p>
 
       <div className="mt-10 space-y-10">
@@ -35,7 +35,7 @@ export default function GoogleDriveSetup() {
               </span>
             </li>
             <li>
-              Name it something recognizable (e.g., &quot;Storyline AI&quot;)
+              Name it something recognizable (e.g., &quot;Storydump&quot;)
             </li>
             <li>Click Create</li>
           </ol>
@@ -139,7 +139,7 @@ export default function GoogleDriveSetup() {
 
         <StepCard number={5} title="Verify it's working">
           <p>
-            You should now have two values ready for the Storyline setup wizard:
+            You should now have two values ready for the Storydump setup wizard:
           </p>
           <ul className="mt-2 list-inside list-disc space-y-1">
             <li>

--- a/landing/src/app/(marketing)/setup/instagram/page.tsx
+++ b/landing/src/app/(marketing)/setup/instagram/page.tsx
@@ -6,7 +6,7 @@ import { Callout } from "@/components/setup/callout"
 import { Screenshot } from "@/components/setup/screenshot"
 
 export const metadata: Metadata = {
-  title: "Instagram Account Setup — Storyline AI",
+  title: "Instagram Account Setup — Storydump",
   robots: { index: false, follow: false },
 }
 

--- a/landing/src/app/(marketing)/setup/media-organize/page.tsx
+++ b/landing/src/app/(marketing)/setup/media-organize/page.tsx
@@ -5,7 +5,7 @@ import { StepCard } from "@/components/setup/step-card"
 import { Callout } from "@/components/setup/callout"
 
 export const metadata: Metadata = {
-  title: "Organize Your Media — Storyline AI",
+  title: "Organize Your Media — Storydump",
   robots: { index: false, follow: false },
 }
 
@@ -16,14 +16,14 @@ export default function MediaOrganize() {
         Organizing Your Media
       </h1>
       <p className="mt-4 text-lg text-muted-foreground">
-        Storyline reads media from your Google Drive. How you organize your
+        Storydump reads media from your Google Drive. How you organize your
         folders determines your content categories and posting mix.
       </p>
 
       <div className="mt-10 space-y-10">
         <StepCard number={1} title="Folder structure = categories">
           <p>
-            Storyline treats each subfolder in your root media folder as a
+            Storydump treats each subfolder in your root media folder as a
             category. Here&apos;s the recommended structure:
           </p>
           <pre className="mt-3 overflow-x-auto rounded-lg bg-muted p-4 text-sm">
@@ -61,14 +61,14 @@ export default function MediaOrganize() {
             </li>
           </ul>
           <Callout type="tip" className="mt-3">
-            Don&apos;t worry about getting everything perfect. Storyline
+            Don&apos;t worry about getting everything perfect. Storydump
             validates each file and will tell you which ones need attention.
           </Callout>
         </StepCard>
 
         <StepCard number={3} title="Category mixing">
           <p>
-            Storyline distributes posts across your categories based on ratios
+            Storydump distributes posts across your categories based on ratios
             you define. For example:
           </p>
           <ul className="mt-2 list-inside list-disc space-y-1">
@@ -94,7 +94,7 @@ export default function MediaOrganize() {
             </li>
           </ul>
           <p className="mt-2">
-            Storyline tracks what&apos;s been posted and cycles through your
+            Storydump tracks what&apos;s been posted and cycles through your
             library evenly — never-posted content always goes first.
           </p>
         </StepCard>
@@ -106,11 +106,11 @@ export default function MediaOrganize() {
               Telegram
             </li>
             <li>
-              Remove content you&apos;d never want to post — Storyline will try
+              Remove content you&apos;d never want to post — Storydump will try
               to post everything in the folder
             </li>
             <li>
-              You can add or remove files anytime — Storyline syncs
+              You can add or remove files anytime — Storydump syncs
               automatically
             </li>
           </ul>

--- a/landing/src/app/(marketing)/setup/meta-developer/page.tsx
+++ b/landing/src/app/(marketing)/setup/meta-developer/page.tsx
@@ -7,7 +7,7 @@ import { Screenshot } from "@/components/setup/screenshot"
 import { CopyButton } from "@/components/setup/copy-button"
 
 export const metadata: Metadata = {
-  title: "Meta Developer Setup — Storyline AI",
+  title: "Meta Developer Setup — Storydump",
   robots: { index: false, follow: false },
 }
 
@@ -56,7 +56,7 @@ export default function MetaDeveloperSetup() {
               Consumer, not None)
             </li>
             <li>
-              App name: anything you like (e.g., &quot;Storyline AI&quot; or
+              App name: anything you like (e.g., &quot;Storydump&quot; or
               &quot;My Story Bot&quot;)
             </li>
             <li>App contact email: your email address</li>
@@ -103,7 +103,7 @@ export default function MetaDeveloperSetup() {
 
         <StepCard number={5} title="Generate an access token">
           <p>
-            Storyline handles OAuth for you during the Telegram setup wizard, so
+            Storydump handles OAuth for you during the Telegram setup wizard, so
             your app just needs the right permissions configured. The required
             scopes are:
           </p>
@@ -178,7 +178,7 @@ export default function MetaDeveloperSetup() {
             </li>
           </ul>
           <Callout type="tip" className="mt-3">
-            If you only plan to use Storyline for your own account(s),
+            If you only plan to use Storydump for your own account(s),
             Development Mode is sufficient — you don&apos;t strictly need App
             Review. But it&apos;s recommended for stability.
           </Callout>
@@ -216,7 +216,7 @@ export default function MetaDeveloperSetup() {
               <span className="font-medium text-foreground">App Secret</span>
             </li>
             <li>
-              You&apos;ll enter these during Storyline&apos;s Telegram setup
+              You&apos;ll enter these during Storydump&apos;s Telegram setup
             </li>
           </ol>
           <Screenshot caption="App Settings showing App ID and App Secret" />
@@ -262,7 +262,7 @@ export default function MetaDeveloperSetup() {
                 &quot;Token expires after 60 days&quot;
               </p>
               <p>
-                Storyline handles token auto-refresh automatically. You
+                Storydump handles token auto-refresh automatically. You
                 don&apos;t need to manually renew tokens.
               </p>
             </div>

--- a/landing/src/app/(marketing)/setup/page.tsx
+++ b/landing/src/app/(marketing)/setup/page.tsx
@@ -4,7 +4,7 @@ import { ArrowRight, Clock } from "lucide-react"
 import { Checklist } from "@/components/setup/checklist"
 
 export const metadata: Metadata = {
-  title: "Getting Started — Storyline AI",
+  title: "Getting Started — Storydump",
   robots: { index: false, follow: false },
 }
 
@@ -21,7 +21,7 @@ export default function SetupOverview() {
   return (
     <div>
       <h1 className="text-3xl font-bold tracking-tight">
-        Getting Started with Storyline AI
+        Getting Started with Storydump
       </h1>
       <p className="mt-4 text-lg text-muted-foreground">
         Before connecting to the Telegram bot, you&apos;ll need to set up a few

--- a/landing/src/app/instances/page.tsx
+++ b/landing/src/app/instances/page.tsx
@@ -91,12 +91,12 @@ export default function InstancePickerPage() {
               Set up your first instance
             </h1>
             <p className="text-muted-foreground">
-              Start a conversation with the Storyline AI bot in Telegram to
+              Start a conversation with the Storydump bot in Telegram to
               create your first posting instance.
             </p>
           </div>
           <a
-            href="https://t.me/storyline_ai_bot"
+            href="https://t.me/storydump_bot"
             target="_blank"
             rel="noopener noreferrer"
             className="inline-flex items-center gap-2 rounded-md bg-primary px-6 py-3 text-sm font-medium text-primary-foreground hover:bg-primary/90 transition-colors"

--- a/landing/src/app/login/page.tsx
+++ b/landing/src/app/login/page.tsx
@@ -31,7 +31,7 @@ export default function LoginPage() {
         </div>
 
         <p className="text-center text-xs text-muted-foreground">
-          Only users with an active Storyline AI bot can access the dashboard.
+          Only users with an active Storydump bot can access the dashboard.
         </p>
       </div>
     </div>

--- a/landing/src/components/landing/comparison.tsx
+++ b/landing/src/components/landing/comparison.tsx
@@ -7,27 +7,27 @@ import { trackEvent } from "@/lib/analytics"
 const rows = [
   {
     feature: "Built for",
-    storyline: "Instagram Stories",
+    storydump: "Instagram Stories",
     others: "Feeds, Reels, Stories (afterthought)",
   },
   {
     feature: "Approvals",
-    storyline: "In Telegram — instant, mobile",
+    storydump: "In Telegram — instant, mobile",
     others: "Log into web dashboard",
   },
   {
     feature: "Your content",
-    storyline: "Stays in Google Drive",
+    storydump: "Stays in Google Drive",
     others: "Uploaded to their servers",
   },
   {
     feature: "Content recycling",
-    storyline: "Automatic rotation",
+    storydump: "Automatic rotation",
     others: "Manual re-scheduling",
   },
   {
     feature: "Price",
-    storyline: "Free during beta",
+    storydump: "Free during beta",
     others: "$15–50/mo",
   },
 ]
@@ -58,7 +58,7 @@ export function Comparison() {
           Why not just use Buffer?
         </h2>
         <p className="mx-auto mt-4 max-w-xl text-center text-muted-foreground">
-          Generic schedulers treat Stories as an afterthought. Storyline is built
+          Generic schedulers treat Stories as an afterthought. Storydump is built
           entirely around them.
         </p>
         <div className="mt-12 overflow-x-auto">
@@ -66,7 +66,7 @@ export function Comparison() {
             <thead>
               <tr className="border-b">
                 <th className="pb-3 pr-4 font-medium text-muted-foreground" />
-                <th className="pb-3 pr-4 font-semibold">Storyline AI</th>
+                <th className="pb-3 pr-4 font-semibold">Storydump</th>
                 <th className="pb-3 font-semibold text-muted-foreground">
                   Buffer / Later
                 </th>
@@ -79,7 +79,7 @@ export function Comparison() {
                   <td className="py-3 pr-4">
                     <span className="flex items-center gap-2">
                       <Check className="h-4 w-4 shrink-0 text-green-600" />
-                      {row.storyline}
+                      {row.storydump}
                     </span>
                   </td>
                   <td className="py-3 text-muted-foreground">

--- a/landing/src/components/landing/faq.tsx
+++ b/landing/src/components/landing/faq.tsx
@@ -11,9 +11,9 @@ import { trackEvent } from "@/lib/analytics"
 
 const faqs = [
   {
-    question: "What is Storyline AI?",
+    question: "What is Storydump?",
     answer:
-      "Storyline AI is an Instagram Story scheduling tool that automatically rotates your content library. Connect your Google Drive, set a posting schedule, and approve each story via Telegram before it goes live.",
+      "Storydump is an Instagram Story scheduling tool that automatically rotates your content library. Connect your Google Drive, set a posting schedule, and approve each story via Telegram before it goes live.",
   },
   {
     question: "Why Telegram instead of a web dashboard?",
@@ -23,12 +23,12 @@ const faqs = [
   {
     question: "Do I need to give you my Instagram password?",
     answer:
-      "No. Storyline uses the official Instagram Graph API with OAuth, so you authenticate directly with Meta. We never see or store your Instagram password.",
+      "No. Storydump uses the official Instagram Graph API with OAuth, so you authenticate directly with Meta. We never see or store your Instagram password.",
   },
   {
     question: "What content types are supported?",
     answer:
-      "Instagram Stories support JPG, PNG, and GIF images. Storyline validates and optimizes each image to meet Instagram's specifications (9:16 aspect ratio, max 100MB) before posting.",
+      "Instagram Stories support JPG, PNG, and GIF images. Storydump validates and optimizes each image to meet Instagram's specifications (9:16 aspect ratio, max 100MB) before posting.",
   },
   {
     question: "Can I manage multiple Instagram accounts?",
@@ -43,7 +43,7 @@ const faqs = [
   {
     question: "Is my content stored on your servers?",
     answer:
-      "No. Your media stays in your Google Drive. Storyline reads from your drive to schedule posts, but your files are never permanently stored on our infrastructure.",
+      "No. Your media stays in your Google Drive. Storydump reads from your drive to schedule posts, but your files are never permanently stored on our infrastructure.",
   },
   {
     question: "Who built this?",
@@ -76,7 +76,7 @@ export function FAQ() {
               <AccordionContent>
                 {faq.answer === "built-by-chris" ? (
                   <p className="text-muted-foreground">
-                    Storyline AI is built by{" "}
+                    Storydump is built by{" "}
                     <a
                       href={siteConfig.contact.portfolio}
                       target="_blank"

--- a/landing/src/components/landing/features.tsx
+++ b/landing/src/components/landing/features.tsx
@@ -41,7 +41,7 @@ const features = [
     icon: Shield,
     title: "Self-Hosted Media",
     description:
-      "Your images stay in your cloud storage. Storyline orchestrates — it never owns your content.",
+      "Your images stay in your cloud storage. Storydump orchestrates — it never owns your content.",
   },
 ]
 

--- a/landing/src/components/landing/how-it-works.tsx
+++ b/landing/src/components/landing/how-it-works.tsx
@@ -5,7 +5,7 @@ const steps = [
     number: 1,
     title: "Connect Your Drive",
     description:
-      "Link your Google Drive folder. Storyline indexes your media and keeps everything in sync automatically.",
+      "Link your Google Drive folder. Storydump indexes your media and keeps everything in sync automatically.",
     icon: Cloud,
   },
   {

--- a/landing/src/components/landing/pricing.tsx
+++ b/landing/src/components/landing/pricing.tsx
@@ -16,7 +16,7 @@ export function Pricing() {
           Free While in Beta
         </h2>
         <p className="mx-auto mt-4 max-w-xl text-muted-foreground">
-          Storyline AI is free for early adopters. Join now and lock in access
+          Storydump is free for early adopters. Join now and lock in access
           before launch pricing kicks in.
         </p>
         <ul className="mx-auto mt-8 inline-flex flex-col items-start gap-3 text-left">

--- a/landing/src/components/landing/telegram-preview.tsx
+++ b/landing/src/components/landing/telegram-preview.tsx
@@ -52,7 +52,7 @@ function TelegramMockup() {
           S
         </div>
         <div>
-          <p className="text-sm font-medium text-white">Storyline AI</p>
+          <p className="text-sm font-medium text-white">Storydump</p>
           <p className="text-xs text-[#6c7883]">bot</p>
         </div>
       </div>

--- a/landing/src/components/landing/waitlist-form.tsx
+++ b/landing/src/components/landing/waitlist-form.tsx
@@ -12,7 +12,7 @@ interface WaitlistFormProps {
 }
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
-const STORAGE_KEY = "storyline-waitlist-registered"
+const STORAGE_KEY = "storydump-waitlist-registered"
 
 type FormStatus = "idle" | "submitting" | "success" | "error" | "duplicate"
 
@@ -116,7 +116,7 @@ export function WaitlistForm({
             </>
           )}
           <a
-            href="https://t.me/storyline_ai"
+            href="https://t.me/storydump_bot"
             target="_blank"
             rel="noopener noreferrer"
             className="inline-block text-sm text-muted-foreground underline underline-offset-4 hover:text-foreground transition-colors"

--- a/landing/src/config/site.ts
+++ b/landing/src/config/site.ts
@@ -1,13 +1,13 @@
 export const siteConfig = {
-  name: "Storyline AI",
+  name: "Storydump",
   description:
     "Keep your Instagram Stories alive. Automatically rotate your content library through Stories — powered by Telegram.",
-  url: "https://storyline.ai",
+  url: "https://storydump.app",
   contact: {
     portfolio: "https://crog.gg",
     email: "christophertrogers37@gmail.com",
   },
   links: {
-    github: "https://github.com/chrisrogers37/storyline-ai",
+    github: "https://github.com/chrisrogers37/storydump",
   },
 }

--- a/landing/src/lib/session.ts
+++ b/landing/src/lib/session.ts
@@ -17,7 +17,7 @@ export interface SessionPayload {
   photoUrl?: string;
 }
 
-export const SESSION_COOKIE = "storyline_session";
+export const SESSION_COOKIE = "storydump_session";
 
 const JWT_EXPIRY = "24h";
 const JWT_MAX_AGE_SECONDS = 86400; // must match JWT_EXPIRY

--- a/planning/multi-account-dashboard.md
+++ b/planning/multi-account-dashboard.md
@@ -123,12 +123,12 @@ URL tokens bake in `chat_id` and are valid for 1 hour. If a user is removed from
 ```
 User sends /start in DM
   ↓
-Bot: "Welcome to Storyline AI! Let's set up your first posting instance."
+Bot: "Welcome to Storydump! Let's set up your first posting instance."
   ↓
 Step 1: "What do you want to call this instance?" → user types "TL Enterprises"
   ↓
 Step 2: "Add me to the group chat where your team will review posts."
-        [Button: "Add to Group Chat" → t.me/StorylineAIBot?startgroup=setup_{session_id}]
+        [Button: "Add to Group Chat" → t.me/storydump_bot?startgroup=setup_{session_id}]
         "Bot already in your group? Run /link in that group."
   ↓
 Bot is added to group → my_chat_member event fires → auto-links pending session

--- a/scripts/migrations/003_add_user_interactions.sql
+++ b/scripts/migrations/003_add_user_interactions.sql
@@ -1,5 +1,5 @@
 -- Migration 003: Add user_interactions table
--- Run on Pi: PGPASSWORD=your_password psql -h localhost -U storyline_user -d storyline_ai -f scripts/migrations/003_add_user_interactions.sql
+-- Run on Pi: PGPASSWORD=your_password psql -h localhost -U storydump_user -d storydump -f scripts/migrations/003_add_user_interactions.sql
 
 -- User interactions table (tracks all bot interactions for analytics)
 CREATE TABLE IF NOT EXISTS user_interactions (

--- a/scripts/migrations/004_instagram_api_phase2.sql
+++ b/scripts/migrations/004_instagram_api_phase2.sql
@@ -3,10 +3,10 @@
 -- Description: Add cloud storage fields, Instagram posting tracking, and API tokens table
 --
 -- Run on local:
---   psql -U storyline_user -d storyline_ai -f scripts/migrations/004_instagram_api_phase2.sql
+--   psql -U storydump_user -d storydump -f scripts/migrations/004_instagram_api_phase2.sql
 --
 -- Run on Pi:
---   PGPASSWORD=your_password psql -h localhost -U storyline_user -d storyline_ai -f scripts/migrations/004_instagram_api_phase2.sql
+--   PGPASSWORD=your_password psql -h localhost -U storydump_user -d storydump -f scripts/migrations/004_instagram_api_phase2.sql
 
 BEGIN;
 

--- a/scripts/setup_database.sql
+++ b/scripts/setup_database.sql
@@ -1,4 +1,4 @@
--- Storyline AI Database Schema
+-- Storydump Database Schema
 -- Phase 1: Core Tables
 
 -- Enable UUID extension

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 from src import __version__
 
 setup(
-    name="storyline-ai",
+    name="storydump",
     version=__version__,
     description="Instagram Story Automation System with Telegram Integration",
     author="Your Name",
@@ -31,7 +31,7 @@ setup(
     ],
     entry_points={
         "console_scripts": [
-            "storyline-cli=cli.main:cli",
+            "storydump-cli=cli.main:cli",
         ],
     },
     python_requires=">=3.10",

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -1,4 +1,4 @@
-"""FastAPI application for Storyline AI OAuth flows and Mini App."""
+"""FastAPI application for Storydump OAuth flows and Mini App."""
 
 from pathlib import Path
 
@@ -12,8 +12,8 @@ from src.api.routes.onboarding import router as onboarding_router
 from src.config.settings import settings
 
 app = FastAPI(
-    title="Storyline AI API",
-    description="OAuth and API endpoints for Storyline AI",
+    title="Storydump API",
+    description="OAuth and API endpoints for Storydump",
     version="0.1.0",
 )
 

--- a/src/api/routes/oauth.py
+++ b/src/api/routes/oauth.py
@@ -276,7 +276,7 @@ def _gdrive_success_html_page(email: str) -> HTMLResponse:
         content=f"""
         <!DOCTYPE html>
         <html>
-        <head><title>Storyline AI - Google Drive Connected!</title>
+        <head><title>Storydump - Google Drive Connected!</title>
         <style>
             body {{ font-family: -apple-system, sans-serif; text-align: center;
                    padding: 60px 20px; background: #f5f5f5; }}
@@ -290,7 +290,7 @@ def _gdrive_success_html_page(email: str) -> HTMLResponse:
         <div class="card">
             <h1>Google Drive Connected!</h1>
             <p>Your Google Drive (<strong>{safe_email}</strong>) has been
-            connected to Storyline AI.</p>
+            connected to Storydump.</p>
             <p>You can close this window and return to Telegram.</p>
         </div>
         </body></html>
@@ -306,7 +306,7 @@ def _success_html_page(username: str) -> HTMLResponse:
         content=f"""
         <!DOCTYPE html>
         <html>
-        <head><title>Storyline AI - Connected!</title>
+        <head><title>Storydump - Connected!</title>
         <style>
             body {{ font-family: -apple-system, sans-serif; text-align: center;
                    padding: 60px 20px; background: #f5f5f5; }}
@@ -320,7 +320,7 @@ def _success_html_page(username: str) -> HTMLResponse:
         <div class="card">
             <h1>Connected!</h1>
             <p>Instagram account <strong>@{safe_username}</strong> has been
-            connected to Storyline AI.</p>
+            connected to Storydump.</p>
             <p>You can close this window and return to Telegram.</p>
         </div>
         </body></html>
@@ -337,7 +337,7 @@ def _error_html_page(title: str, message: str) -> HTMLResponse:
         content=f"""
         <!DOCTYPE html>
         <html>
-        <head><title>Storyline AI - {safe_title}</title>
+        <head><title>Storydump - {safe_title}</title>
         <style>
             body {{ font-family: -apple-system, sans-serif; text-align: center;
                    padding: 60px 20px; background: #f5f5f5; }}

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -21,13 +21,13 @@ class Settings(BaseSettings):
     DATABASE_URL: Optional[str] = None  # Full URL (overrides DB_* components if set)
     DB_HOST: str = "localhost"
     DB_PORT: int = 5432
-    DB_NAME: str = "storyline_ai"
-    DB_USER: str = "storyline_user"
+    DB_NAME: str = "storydump"
+    DB_USER: str = "storydump_user"
     DB_PASSWORD: Optional[str] = ""
     DB_SSLMODE: Optional[str] = None  # e.g., "require" for Neon
     DB_POOL_SIZE: int = 10
     DB_MAX_OVERFLOW: int = 20
-    TEST_DB_NAME: str = "storyline_ai_test"
+    TEST_DB_NAME: str = "storydump_test"
 
     # Telegram Configuration (REQUIRED)
     TELEGRAM_BOT_TOKEN: str
@@ -45,7 +45,7 @@ class Settings(BaseSettings):
     MEDIA_DIR: str = "/tmp/media"
 
     # Backup Configuration
-    BACKUP_DIR: str = "/backup/storyline-ai"
+    BACKUP_DIR: str = "/backup/storydump"
     BACKUP_RETENTION_DAYS: int = 30
 
     # Instagram API Configuration (Phase 2 Only)
@@ -55,7 +55,7 @@ class Settings(BaseSettings):
     FACEBOOK_APP_SECRET: Optional[str] = None  # Facebook Login OAuth (legacy)
     INSTAGRAM_APP_ID: Optional[str] = None  # Instagram Login OAuth (preferred)
     INSTAGRAM_APP_SECRET: Optional[str] = None  # Instagram Login OAuth (preferred)
-    OAUTH_REDIRECT_BASE_URL: Optional[str] = None  # e.g., "https://api.storyline.ai"
+    OAUTH_REDIRECT_BASE_URL: Optional[str] = None  # e.g., "https://api.storydump.app"
     INSTAGRAM_DEEPLINK_URL: str = "https://www.instagram.com/"
 
     # Google Drive OAuth (Phase 05 Multi-Tenant)

--- a/src/exceptions/__init__.py
+++ b/src/exceptions/__init__.py
@@ -1,6 +1,6 @@
-"""Storyline AI exception classes."""
+"""Storydump exception classes."""
 
-from src.exceptions.base import StorylineError
+from src.exceptions.base import StorydumpError
 from src.exceptions.google_drive import (
     GoogleDriveError,
     GoogleDriveAuthError,
@@ -20,7 +20,7 @@ from src.exceptions.backfill import (
 )
 
 __all__ = [
-    "StorylineError",
+    "StorydumpError",
     "GoogleDriveError",
     "GoogleDriveAuthError",
     "GoogleDriveRateLimitError",

--- a/src/exceptions/backfill.py
+++ b/src/exceptions/backfill.py
@@ -2,10 +2,10 @@
 
 from typing import Optional
 
-from src.exceptions.base import StorylineError
+from src.exceptions.base import StorydumpError
 
 
-class BackfillError(StorylineError):
+class BackfillError(StorydumpError):
     """General error during Instagram media backfill."""
 
     def __init__(

--- a/src/exceptions/base.py
+++ b/src/exceptions/base.py
@@ -1,9 +1,9 @@
-"""Base exception classes for Storyline AI."""
+"""Base exception classes for Storydump."""
 
 
-class StorylineError(Exception):
+class StorydumpError(Exception):
     """
-    Base exception for all Storyline errors.
+    Base exception for all Storydump errors.
 
     All custom exceptions in the application should inherit from this class
     to enable consistent error handling and catching.

--- a/src/exceptions/google_drive.py
+++ b/src/exceptions/google_drive.py
@@ -2,10 +2,10 @@
 
 from typing import Optional
 
-from src.exceptions.base import StorylineError
+from src.exceptions.base import StorydumpError
 
 
-class GoogleDriveError(StorylineError):
+class GoogleDriveError(StorydumpError):
     """General Google Drive API error."""
 
     def __init__(

--- a/src/exceptions/instagram.py
+++ b/src/exceptions/instagram.py
@@ -2,10 +2,10 @@
 
 from typing import Optional
 
-from src.exceptions.base import StorylineError
+from src.exceptions.base import StorydumpError
 
 
-class InstagramAPIError(StorylineError):
+class InstagramAPIError(StorydumpError):
     """
     General Instagram API error.
 
@@ -74,7 +74,7 @@ class TokenExpiredError(InstagramAPIError):
         super().__init__(message, **kwargs)
 
 
-class MediaUploadError(StorylineError):
+class MediaUploadError(StorydumpError):
     """
     Cloud storage upload failed.
 

--- a/src/services/core/loops/lifecycle.py
+++ b/src/services/core/loops/lifecycle.py
@@ -26,7 +26,7 @@ def validate_and_log_startup() -> None:
     Exits the process if configuration is invalid.
     """
     logger.info("=" * 60)
-    logger.info("Storyline AI - Instagram Story Automation System")
+    logger.info("Storydump - Instagram Story Automation System")
     logger.info("=" * 60)
 
     is_valid, errors = ConfigValidator.validate_all()

--- a/src/services/core/start_command_router.py
+++ b/src/services/core/start_command_router.py
@@ -143,16 +143,16 @@ class StartCommandRouter:
             )
 
             if onboarding_done:
-                button_text = "Open Storyline"
+                button_text = "Open Storydump"
                 message_text = (
-                    "Welcome back to *Storyline AI*!\n\n"
+                    "Welcome back to *Storydump*!\n\n"
                     "Tap the button below to view your dashboard "
                     "and manage your settings."
                 )
             else:
                 button_text = "Open Setup Wizard"
                 message_text = (
-                    "Welcome to *Storyline AI*!\n\n"
+                    "Welcome to *Storydump*!\n\n"
                     "Let's get you set up. Tap the button below to "
                     "connect your accounts and configure your posting schedule."
                 )
@@ -173,7 +173,7 @@ class StartCommandRouter:
             )
         else:
             await update.message.reply_text(
-                "👋 *Storyline AI Bot*\n\n"
+                "👋 *Storydump Bot*\n\n"
                 "Commands:\n"
                 "/status - System health & overview\n"
                 "/next - Force send next post\n"
@@ -225,7 +225,7 @@ class StartCommandRouter:
             data = dash.get_user_instances(update.effective_user.id)
 
         instances = data["instances"]
-        lines = ["Welcome back to *Storyline AI*\\!\n\nYour instances:"]
+        lines = ["Welcome back to *Storydump*\\!\n\nYour instances:"]
 
         keyboard_rows = []
         for i, inst in enumerate(instances, 1):
@@ -270,7 +270,7 @@ class StartCommandRouter:
         context.user_data["onboarding_session_id"] = str(session.id)
 
         await update.message.reply_text(
-            "Welcome to *Storyline AI*\\! Let's set up your first posting instance\\.\n\n"
+            "Welcome to *Storydump*\\! Let's set up your first posting instance\\.\n\n"
             "What do you want to call this instance?\n"
             '_\\(e\\.g\\. "TL Enterprises", "Personal Brand"\\)_',
             parse_mode="MarkdownV2",

--- a/src/services/core/telegram_commands.py
+++ b/src/services/core/telegram_commands.py
@@ -59,7 +59,7 @@ class TelegramCommandHandlers:
             data = dash.get_user_instances(update.effective_user.id)
 
         instances = data["instances"]
-        lines = ["📊 *Storyline AI Status*\n\nYour instances:"]
+        lines = ["📊 *Storydump Status*\n\nYour instances:"]
 
         keyboard_rows = []
         if instances:
@@ -126,7 +126,7 @@ class TelegramCommandHandlers:
         setup_section = self._get_setup_status(chat_id)
 
         status_msg = (
-            f"📊 *Storyline AI Status*\n\n"
+            f"📊 *Storydump Status*\n\n"
             f"{setup_section}\n\n"
             f"*Instagram API:*\n"
             f"📸 {ig_status}\n\n"
@@ -367,7 +367,7 @@ class TelegramCommandHandlers:
         user = self.service._get_or_create_user(update.effective_user)
 
         help_text = (
-            "📖 *Storyline AI Help*\n\n"
+            "📖 *Storydump Help*\n\n"
             "*Commands:*\n"
             "/start - Open dashboard & settings\n"
             "/status - System health & overview\n"
@@ -552,7 +552,7 @@ class TelegramCommandHandlers:
             "/locks": "Lock count is shown in /status. Full list in the dashboard.",
             "/reset": "The JIT scheduler manages the queue automatically.",
             "/dryrun": "Use /settings to toggle dry-run mode.",
-            "/backfill": "Use the CLI: storyline-cli backfill-instagram",
+            "/backfill": "Use the CLI: storydump-cli backfill-instagram",
             "/connect": "Use /start to open the setup wizard and connect Instagram.",
             "/queue": "View your queue in the dashboard. Use /start to open it.",
             "/pause": "Use Quick Controls in the dashboard. Use /start to open it.",

--- a/src/services/core/telegram_lifecycle.py
+++ b/src/services/core/telegram_lifecycle.py
@@ -30,7 +30,7 @@ class TelegramLifecycleHandler:
                 data = dash.get_user_instances(self.service.admin_chat_id)
 
             instances = data["instances"]
-            lines = ["🟢 *Storyline AI Started*\n"]
+            lines = ["🟢 *Storydump Started*\n"]
 
             if instances:
                 lines.append("Your instances:")
@@ -76,7 +76,7 @@ class TelegramLifecycleHandler:
             uptime_str = f"{hours}h {minutes}m"
 
             message = (
-                f"🔴 *Storyline AI Stopped*\n\n"
+                f"🔴 *Storydump Stopped*\n\n"
                 f"📊 *Session Summary:*\n"
                 f"├─ Uptime: {uptime_str}\n"
                 f"├─ Posts sent: {posts_sent}\n"

--- a/src/services/core/telegram_service.py
+++ b/src/services/core/telegram_service.py
@@ -242,7 +242,7 @@ class TelegramService(BaseService):
 
         # Register commands with Telegram for autocomplete menu
         commands = [
-            BotCommand("start", "Open Storyline (setup & config)"),
+            BotCommand("start", "Open Storydump (setup & config)"),
             BotCommand("status", "System health & media overview"),
             BotCommand("setup", "Quick settings & toggles"),
             BotCommand("next", "Send next post now"),

--- a/src/services/core/telegram_utils.py
+++ b/src/services/core/telegram_utils.py
@@ -466,7 +466,7 @@ def build_webapp_button(
     Group chats use a signed URL token (opens in browser).
 
     Args:
-        text: Button label text (e.g., "Open Storyline", "Open Dashboard")
+        text: Button label text (e.g., "Open Storydump", "Open Dashboard")
         webapp_url: The base webapp URL including query params
         chat_type: Telegram chat type string (from update.effective_chat.type)
         chat_id: Telegram chat ID (for URL token signing)

--- a/src/services/integrations/cloud_storage.py
+++ b/src/services/integrations/cloud_storage.py
@@ -63,7 +63,7 @@ class CloudStorageService(BaseService):
         file_path: Optional[str] = None,
         file_bytes: Optional[bytes] = None,
         filename: Optional[str] = None,
-        folder: str = "storyline",
+        folder: str = "storydump",
         public_id: Optional[str] = None,
     ) -> dict:
         """
@@ -264,7 +264,7 @@ class CloudStorageService(BaseService):
             logger.error(f"Error fetching Cloudinary resource: {e}")
             return None
 
-    def cleanup_expired(self, folder: str = "storyline") -> int:
+    def cleanup_expired(self, folder: str = "storydump") -> int:
         """
         Remove uploads older than retention period.
 

--- a/src/services/integrations/google_drive.py
+++ b/src/services/integrations/google_drive.py
@@ -163,7 +163,7 @@ class GoogleDriveService(BaseService):
         if not db_token:
             raise GoogleDriveAuthError(
                 "No Google Drive credentials found. "
-                "Run 'storyline-cli connect-google-drive' first."
+                "Run 'storydump-cli connect-google-drive' first."
             )
 
         try:

--- a/src/utils/logger.py
+++ b/src/utils/logger.py
@@ -8,7 +8,7 @@ from src.config.settings import settings
 
 
 def setup_logger(
-    name: str = "storyline-ai", level: int = None, log_file: Optional[str] = None
+    name: str = "storydump", level: int = None, log_file: Optional[str] = None
 ) -> logging.Logger:
     """
     Setup and configure a logger.
@@ -71,7 +71,7 @@ def setup_logger(
     return logger_instance
 
 
-def get_logger(name: str = "storyline-ai") -> logging.Logger:
+def get_logger(name: str = "storydump") -> logging.Logger:
     """
     Get an existing logger or create a new one.
 

--- a/tests/src/api/test_onboarding_routes.py
+++ b/tests/src/api/test_onboarding_routes.py
@@ -88,7 +88,7 @@ class TestOnboardingInit:
             mock_validate(),
             _mock_setup_state(
                 instagram_connected=True,
-                instagram_username="storyline_ai",
+                instagram_username="storydump",
             ),
             patch(
                 "src.api.routes.onboarding.setup.SettingsService"
@@ -102,7 +102,7 @@ class TestOnboardingInit:
 
         data = response.json()
         assert data["setup_state"]["instagram_connected"] is True
-        assert data["setup_state"]["instagram_username"] == "storyline_ai"
+        assert data["setup_state"]["instagram_username"] == "storydump"
 
     def test_init_shows_connected_gdrive(self, client):
         """When Google Drive is connected, setup_state reflects it."""

--- a/tests/src/config/test_settings.py
+++ b/tests/src/config/test_settings.py
@@ -19,7 +19,7 @@ class TestSettingsDefaults:
         assert Settings.model_fields["DB_PORT"].default == 5432
 
     def test_db_name_defaults(self):
-        assert Settings.model_fields["DB_NAME"].default == "storyline_ai"
+        assert Settings.model_fields["DB_NAME"].default == "storydump"
 
     def test_posts_per_day_defaults_to_3(self):
         assert Settings.model_fields["POSTS_PER_DAY"].default == 3
@@ -80,9 +80,9 @@ class TestSettingsDatabaseUrl:
             "TELEGRAM_BOT_TOKEN": "test-token-123",
             "TELEGRAM_CHANNEL_ID": -1001234567,
             "ADMIN_TELEGRAM_CHAT_ID": 12345,
-            "DB_USER": "storyline_user",
-            "DB_NAME": "storyline_ai",
-            "TEST_DB_NAME": "storyline_ai_test",
+            "DB_USER": "storydump_user",
+            "DB_NAME": "storydump",
+            "TEST_DB_NAME": "storydump_test",
         }
         defaults.update(overrides)
         return Settings(_env_file=None, **defaults)
@@ -92,19 +92,19 @@ class TestSettingsDatabaseUrl:
         url = s.database_url
         assert "secret123" in url
         assert url.startswith("postgresql://")
-        assert "storyline_user" in url
-        assert "storyline_ai" in url
+        assert "storydump_user" in url
+        assert "storydump" in url
 
     def test_database_url_without_password(self):
         s = self._make_settings(DB_PASSWORD="")
         url = s.database_url
         assert ":@" not in url
-        assert "storyline_user@" in url
+        assert "storydump_user@" in url
 
     def test_test_database_url_uses_test_db_name(self):
         s = self._make_settings(DB_PASSWORD="secret")
         url = s.test_database_url
-        assert "storyline_ai_test" in url
+        assert "storydump_test" in url
         assert url != s.database_url
 
     def test_database_url_includes_host_and_port(self):

--- a/tests/src/exceptions/test_backfill_exceptions.py
+++ b/tests/src/exceptions/test_backfill_exceptions.py
@@ -7,7 +7,7 @@ from src.exceptions.backfill import (
     BackfillMediaExpiredError,
     BackfillMediaNotFoundError,
 )
-from src.exceptions.base import StorylineError
+from src.exceptions.base import StorydumpError
 
 
 @pytest.mark.unit
@@ -26,10 +26,10 @@ class TestBackfillExceptions:
         assert str(error) == "General failure"
         assert error.instagram_media_id is None
 
-    def test_backfill_error_inherits_from_storyline_error(self):
-        """BackfillError is a StorylineError."""
+    def test_backfill_error_inherits_from_storydump_error(self):
+        """BackfillError is a StorydumpError."""
         error = BackfillError("test")
-        assert isinstance(error, StorylineError)
+        assert isinstance(error, StorydumpError)
 
     def test_backfill_media_expired_error(self):
         """BackfillMediaExpiredError inherits from BackfillError."""

--- a/tests/src/exceptions/test_base_exceptions.py
+++ b/tests/src/exceptions/test_base_exceptions.py
@@ -2,34 +2,34 @@
 
 import pytest
 
-from src.exceptions.base import StorylineError
+from src.exceptions.base import StorydumpError
 
 
 @pytest.mark.unit
-class TestStorylineError:
-    """Tests for the StorylineError base exception."""
+class TestStorydumpError:
+    """Tests for the StorydumpError base exception."""
 
     def test_inherits_from_exception(self):
-        """StorylineError inherits from Exception."""
-        assert issubclass(StorylineError, Exception)
+        """StorydumpError inherits from Exception."""
+        assert issubclass(StorydumpError, Exception)
 
     def test_can_be_raised_and_caught(self):
-        """StorylineError can be raised and caught."""
-        with pytest.raises(StorylineError, match="test error"):
-            raise StorylineError("test error")
+        """StorydumpError can be raised and caught."""
+        with pytest.raises(StorydumpError, match="test error"):
+            raise StorydumpError("test error")
 
     def test_caught_by_exception_handler(self):
-        """StorylineError is caught by a generic Exception handler."""
+        """StorydumpError is caught by a generic Exception handler."""
         with pytest.raises(Exception):
-            raise StorylineError("generic catch")
+            raise StorydumpError("generic catch")
 
     def test_message_stored(self):
         """Error message is accessible via args."""
-        err = StorylineError("my message")
+        err = StorydumpError("my message")
         assert str(err) == "my message"
         assert err.args == ("my message",)
 
     def test_empty_message(self):
-        """StorylineError works with empty message."""
-        err = StorylineError()
+        """StorydumpError works with empty message."""
+        err = StorydumpError()
         assert str(err) == ""

--- a/tests/src/exceptions/test_google_drive_exceptions.py
+++ b/tests/src/exceptions/test_google_drive_exceptions.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from src.exceptions.base import StorylineError
+from src.exceptions.base import StorydumpError
 from src.exceptions.google_drive import (
     GoogleDriveError,
     GoogleDriveAuthError,
@@ -15,15 +15,15 @@ from src.exceptions.google_drive import (
 class TestGoogleDriveError:
     """Tests for GoogleDriveError base class."""
 
-    def test_inherits_from_storyline_error(self):
-        assert issubclass(GoogleDriveError, StorylineError)
+    def test_inherits_from_storydump_error(self):
+        assert issubclass(GoogleDriveError, StorydumpError)
 
     def test_can_be_raised(self):
         with pytest.raises(GoogleDriveError, match="drive error"):
             raise GoogleDriveError("drive error")
 
-    def test_caught_by_storyline_error(self):
-        with pytest.raises(StorylineError):
+    def test_caught_by_storydump_error(self):
+        with pytest.raises(StorydumpError):
             raise GoogleDriveError("caught by parent")
 
     def test_status_code_attribute(self):
@@ -54,8 +54,8 @@ class TestGoogleDriveAuthError:
     def test_inherits_from_google_drive_error(self):
         assert issubclass(GoogleDriveAuthError, GoogleDriveError)
 
-    def test_inherits_from_storyline_error(self):
-        assert issubclass(GoogleDriveAuthError, StorylineError)
+    def test_inherits_from_storydump_error(self):
+        assert issubclass(GoogleDriveAuthError, StorydumpError)
 
     def test_can_be_raised(self):
         with pytest.raises(GoogleDriveAuthError, match="auth failed"):

--- a/tests/src/exceptions/test_instagram_exceptions.py
+++ b/tests/src/exceptions/test_instagram_exceptions.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from src.exceptions.base import StorylineError
+from src.exceptions.base import StorydumpError
 from src.exceptions.instagram import (
     InstagramAPIError,
     RateLimitError,
@@ -15,15 +15,15 @@ from src.exceptions.instagram import (
 class TestInstagramAPIError:
     """Tests for InstagramAPIError base class."""
 
-    def test_inherits_from_storyline_error(self):
-        assert issubclass(InstagramAPIError, StorylineError)
+    def test_inherits_from_storydump_error(self):
+        assert issubclass(InstagramAPIError, StorydumpError)
 
     def test_can_be_raised(self):
         with pytest.raises(InstagramAPIError, match="api error"):
             raise InstagramAPIError("api error")
 
-    def test_caught_by_storyline_error(self):
-        with pytest.raises(StorylineError):
+    def test_caught_by_storydump_error(self):
+        with pytest.raises(StorydumpError):
             raise InstagramAPIError("caught by parent")
 
     def test_error_code_attribute(self):
@@ -59,8 +59,8 @@ class TestRateLimitError:
     def test_inherits_from_instagram_api_error(self):
         assert issubclass(RateLimitError, InstagramAPIError)
 
-    def test_inherits_from_storyline_error(self):
-        assert issubclass(RateLimitError, StorylineError)
+    def test_inherits_from_storydump_error(self):
+        assert issubclass(RateLimitError, StorydumpError)
 
     def test_can_be_raised(self):
         with pytest.raises(RateLimitError, match="rate limited"):
@@ -103,8 +103,8 @@ class TestTokenExpiredError:
 class TestMediaUploadError:
     """Tests for MediaUploadError."""
 
-    def test_inherits_from_storyline_error(self):
-        assert issubclass(MediaUploadError, StorylineError)
+    def test_inherits_from_storydump_error(self):
+        assert issubclass(MediaUploadError, StorydumpError)
 
     def test_not_instagram_api_error(self):
         """MediaUploadError is separate from InstagramAPIError hierarchy."""

--- a/tests/src/services/test_cloud_storage.py
+++ b/tests/src/services/test_cloud_storage.py
@@ -130,7 +130,7 @@ class TestCloudStorageService:
         """Test successful media upload."""
         mock_cloudinary.uploader.upload.return_value = {
             "secure_url": "https://res.cloudinary.com/test/image/upload/test_image.jpg",
-            "public_id": "storyline/test_image",
+            "public_id": "storydump/test_image",
             "bytes": 12345,
             "format": "jpg",
             "width": 1080,
@@ -143,7 +143,7 @@ class TestCloudStorageService:
             result["url"]
             == "https://res.cloudinary.com/test/image/upload/test_image.jpg"
         )
-        assert result["public_id"] == "storyline/test_image"
+        assert result["public_id"] == "storydump/test_image"
         assert result["size_bytes"] == 12345
         assert result["format"] == "jpg"
         assert "uploaded_at" in result
@@ -232,7 +232,7 @@ class TestCloudStorageService:
         """Test successful upload using file_bytes instead of file_path."""
         mock_cloudinary.uploader.upload.return_value = {
             "secure_url": "https://res.cloudinary.com/test/image/upload/bytes_image.jpg",
-            "public_id": "storyline/bytes_image",
+            "public_id": "storydump/bytes_image",
             "bytes": 5000,
             "format": "jpg",
             "width": 1080,
@@ -248,7 +248,7 @@ class TestCloudStorageService:
             result["url"]
             == "https://res.cloudinary.com/test/image/upload/bytes_image.jpg"
         )
-        assert result["public_id"] == "storyline/bytes_image"
+        assert result["public_id"] == "storydump/bytes_image"
         assert result["size_bytes"] == 5000
         assert "uploaded_at" in result
         assert "expires_at" in result
@@ -327,10 +327,10 @@ class TestCloudStorageService:
         """Test successful media deletion."""
         mock_cloudinary.uploader.destroy.return_value = {"result": "ok"}
 
-        result = cloud_service.delete_media("storyline/test_image")
+        result = cloud_service.delete_media("storydump/test_image")
 
         assert result is True
-        mock_cloudinary.uploader.destroy.assert_called_once_with("storyline/test_image")
+        mock_cloudinary.uploader.destroy.assert_called_once_with("storydump/test_image")
 
     @patch("src.services.integrations.cloud_storage.cloudinary")
     def test_delete_media_not_found(self, mock_cloudinary, cloud_service):
@@ -406,8 +406,8 @@ class TestCloudStorageService:
 
         mock_cloudinary.api.resources.return_value = {
             "resources": [
-                {"public_id": "storyline/old_image", "created_at": old_date},
-                {"public_id": "storyline/new_image", "created_at": new_date},
+                {"public_id": "storydump/old_image", "created_at": old_date},
+                {"public_id": "storydump/new_image", "created_at": new_date},
             ]
         }
         mock_cloudinary.uploader.destroy.return_value = {"result": "ok"}
@@ -416,7 +416,7 @@ class TestCloudStorageService:
 
         # Only the old resource should be deleted
         assert deleted_count == 1
-        mock_cloudinary.uploader.destroy.assert_called_once_with("storyline/old_image")
+        mock_cloudinary.uploader.destroy.assert_called_once_with("storydump/old_image")
 
     @patch("src.services.integrations.cloud_storage.cloudinary")
     def test_cleanup_expired_no_old_resources(self, mock_cloudinary, cloud_service):
@@ -427,7 +427,7 @@ class TestCloudStorageService:
 
         mock_cloudinary.api.resources.return_value = {
             "resources": [
-                {"public_id": "storyline/recent", "created_at": recent_date},
+                {"public_id": "storydump/recent", "created_at": recent_date},
             ]
         }
 

--- a/tests/src/services/test_settings_service.py
+++ b/tests/src/services/test_settings_service.py
@@ -717,14 +717,14 @@ class TestDeploymentModel:
         """
         DOCUMENTATION TEST: Current deployment model is single-tenant.
 
-        Each deployment of storyline-ai represents:
+        Each deployment of storydump represents:
         - ONE Telegram bot (TELEGRAM_BOT_TOKEN)
         - ONE admin channel (TELEGRAM_CHANNEL_ID / ADMIN_TELEGRAM_CHAT_ID)
         - ONE Instagram account (INSTAGRAM_ACCOUNT_ID)
 
         This is BY DESIGN for Phase 1. Multi-tenancy is Phase 3.
 
-        If another group wants to use storyline-ai, they should:
+        If another group wants to use storydump, they should:
         1. Fork/clone the repository
         2. Deploy their own instance
         3. Configure their own .env with their credentials

--- a/tests/src/services/test_start_command_router.py
+++ b/tests/src/services/test_start_command_router.py
@@ -341,7 +341,7 @@ class TestHandleGroupStart:
     async def test_with_oauth_url_and_onboarding_done(
         self, mock_button, mock_settings, router
     ):
-        """Onboarding complete → 'Open Storyline' button."""
+        """Onboarding complete → 'Open Storydump' button."""
         mock_settings.OAUTH_REDIRECT_BASE_URL = "https://example.com"
         mock_button.return_value = Mock()
 

--- a/tests/src/services/test_telegram_commands.py
+++ b/tests/src/services/test_telegram_commands.py
@@ -559,7 +559,7 @@ class TestStatusCommand:
         call_args = mock_update.message.reply_text.call_args
         message_text = call_args.args[0]
 
-        assert "Storyline AI Status" in message_text
+        assert "Storydump Status" in message_text
         assert "Posted: 2" in message_text
         assert "Never posted: 1" in message_text
         assert "Next:" in message_text
@@ -966,7 +966,7 @@ class TestStatusIncludesSetup:
         assert "Delivery" in message_text
 
         # Existing sections should still be present
-        assert "Storyline AI Status" in message_text
+        assert "Storydump Status" in message_text
 
 
 @pytest.mark.unit
@@ -1312,7 +1312,7 @@ class TestStartCommand:
     async def test_start_returning_user_shows_webapp_button(
         self, mock_command_handlers
     ):
-        """Returning user (onboarding completed) sees 'Open Storyline' button in group."""
+        """Returning user (onboarding completed) sees 'Open Storydump' button in group."""
         handlers = mock_command_handlers
         service = handlers.service
 
@@ -1347,7 +1347,7 @@ class TestStartCommand:
                 await handlers.handle_start(mock_update, mock_context)
 
         call_args = mock_update.message.reply_text.call_args
-        assert "Open Storyline" in str(call_args)
+        assert "Open Storydump" in str(call_args)
         assert "Welcome back" in str(call_args)
 
     async def test_start_no_oauth_url_shows_text_fallback(self, mock_command_handlers):

--- a/tests/src/utils/test_validators.py
+++ b/tests/src/utils/test_validators.py
@@ -23,7 +23,7 @@ class TestConfigValidator:
         mock_settings.TELEGRAM_CHANNEL_ID = -1001234567890
         mock_settings.ADMIN_TELEGRAM_CHAT_ID = 123456789
         mock_settings.ENABLE_INSTAGRAM_API = False
-        mock_settings.DB_NAME = "storyline_ai"
+        mock_settings.DB_NAME = "storydump"
         mock_settings.MEDIA_DIR = "/media/stories"
 
         # Mock path exists
@@ -48,7 +48,7 @@ class TestConfigValidator:
         mock_settings.TELEGRAM_CHANNEL_ID = -1001234567890
         mock_settings.ADMIN_TELEGRAM_CHAT_ID = 123456789
         mock_settings.ENABLE_INSTAGRAM_API = False
-        mock_settings.DB_NAME = "storyline_ai"
+        mock_settings.DB_NAME = "storydump"
         mock_settings.MEDIA_DIR = "/media/stories"
 
         mock_path_instance = MagicMock()
@@ -72,7 +72,7 @@ class TestConfigValidator:
         mock_settings.TELEGRAM_CHANNEL_ID = None  # Missing
         mock_settings.ADMIN_TELEGRAM_CHAT_ID = 123456789
         mock_settings.ENABLE_INSTAGRAM_API = False
-        mock_settings.DB_NAME = "storyline_ai"
+        mock_settings.DB_NAME = "storydump"
         mock_settings.MEDIA_DIR = "/media/stories"
 
         mock_path_instance = MagicMock()
@@ -96,7 +96,7 @@ class TestConfigValidator:
         mock_settings.TELEGRAM_CHANNEL_ID = -1001234567890
         mock_settings.ADMIN_TELEGRAM_CHAT_ID = 123456789
         mock_settings.ENABLE_INSTAGRAM_API = False
-        mock_settings.DB_NAME = "storyline_ai"
+        mock_settings.DB_NAME = "storydump"
         mock_settings.MEDIA_DIR = "/media/stories"
 
         mock_path_instance = MagicMock()
@@ -122,7 +122,7 @@ class TestConfigValidator:
         mock_settings.TELEGRAM_CHANNEL_ID = -1001234567890
         mock_settings.ADMIN_TELEGRAM_CHAT_ID = 123456789
         mock_settings.ENABLE_INSTAGRAM_API = False
-        mock_settings.DB_NAME = "storyline_ai"
+        mock_settings.DB_NAME = "storydump"
         mock_settings.MEDIA_DIR = "/media/stories"
 
         mock_path_instance = MagicMock()
@@ -146,7 +146,7 @@ class TestConfigValidator:
         mock_settings.TELEGRAM_CHANNEL_ID = -1001234567890
         mock_settings.ADMIN_TELEGRAM_CHAT_ID = 123456789
         mock_settings.ENABLE_INSTAGRAM_API = False
-        mock_settings.DB_NAME = "storyline_ai"
+        mock_settings.DB_NAME = "storydump"
         mock_settings.MEDIA_DIR = "/media/stories"
 
         mock_path_instance = MagicMock()
@@ -170,7 +170,7 @@ class TestConfigValidator:
         mock_settings.TELEGRAM_CHANNEL_ID = -1001234567890
         mock_settings.ADMIN_TELEGRAM_CHAT_ID = 123456789
         mock_settings.ENABLE_INSTAGRAM_API = False
-        mock_settings.DB_NAME = "storyline_ai"
+        mock_settings.DB_NAME = "storydump"
         mock_settings.MEDIA_DIR = "/media/stories"
 
         mock_path_instance = MagicMock()
@@ -194,7 +194,7 @@ class TestConfigValidator:
         mock_settings.TELEGRAM_CHANNEL_ID = -1001234567890
         mock_settings.ADMIN_TELEGRAM_CHAT_ID = 123456789
         mock_settings.ENABLE_INSTAGRAM_API = False
-        mock_settings.DB_NAME = "storyline_ai"
+        mock_settings.DB_NAME = "storydump"
         mock_settings.MEDIA_DIR = "/media/stories"
 
         mock_path_instance = MagicMock()
@@ -244,7 +244,7 @@ class TestConfigValidator:
         mock_settings.TELEGRAM_CHANNEL_ID = -1001234567890
         mock_settings.ADMIN_TELEGRAM_CHAT_ID = 123456789
         mock_settings.ENABLE_INSTAGRAM_API = False
-        mock_settings.DB_NAME = "storyline_ai"
+        mock_settings.DB_NAME = "storydump"
         mock_settings.MEDIA_DIR = "/nonexistent/path"
 
         mock_path_instance = MagicMock()
@@ -269,7 +269,7 @@ class TestConfigValidator:
         mock_settings.TELEGRAM_CHANNEL_ID = -1001234567890
         mock_settings.ADMIN_TELEGRAM_CHAT_ID = 123456789
         mock_settings.ENABLE_INSTAGRAM_API = False
-        mock_settings.DB_NAME = "storyline_ai"
+        mock_settings.DB_NAME = "storydump"
         mock_settings.MEDIA_DIR = "/tmp/media"
 
         mock_path_instance = MagicMock()
@@ -298,7 +298,7 @@ class TestConfigValidator:
         mock_settings.ADMIN_TELEGRAM_CHAT_ID = 123456789
         mock_settings.ENABLE_INSTAGRAM_API = True  # Enabled
         mock_settings.CLOUDINARY_CLOUD_NAME = ""  # Missing
-        mock_settings.DB_NAME = "storyline_ai"
+        mock_settings.DB_NAME = "storydump"
         mock_settings.MEDIA_DIR = "/media/stories"
 
         mock_path_instance = MagicMock()
@@ -322,7 +322,7 @@ class TestConfigValidator:
         mock_settings.TELEGRAM_CHANNEL_ID = -1001234567890
         mock_settings.ADMIN_TELEGRAM_CHAT_ID = 123456789
         mock_settings.ENABLE_INSTAGRAM_API = False
-        mock_settings.DB_NAME = "storyline_ai"
+        mock_settings.DB_NAME = "storydump"
         mock_settings.MEDIA_DIR = "/media/stories"
 
         mock_path_instance = MagicMock()


### PR DESCRIPTION
## Summary

Full rebrand from "Storyline AI" to "Storydump" across the codebase. 71 files changed, 294 symmetric insertions/deletions. Closes #290.

**Tier 1 (critical):**
- `setup.py` entry point and package name → `storydump` / `storydump-cli`
- `StorydumpError` exception hierarchy (base + all subclasses + imports)
- DB defaults (`storydump`), logger name, landing site config, session cookie

**Tier 2 (user-facing):**
- FastAPI title/description, OAuth HTML responses
- Telegram bot messages (lifecycle, welcome, help, commands)
- All landing page components (comparison, FAQ, features, pricing, etc.)
- All dashboard page titles and metadata
- Setup flow pages, login page
- CLI help text across all commands
- README.md, PROJECT_MISSION.md, CLAUDE.md

**Tier 3 (operational):**
- `.env.example`, `.env.local.example`
- Makefile (DB name, echo messages, CLI refs, fixed log path bug)
- SQL migration comments, setup script header
- All test files (exception assertions, mock DB names, assertion strings)
- Planning docs, `.claude/` dev config files

**Not in this PR:**
- `documentation/` (Tier 4 — follow-up PR)
- `.github/workflows/ci.yml` (DB name change needs `workflow` OAuth scope — tracked separately)
- Railway callback URL (external service rename is post-merge)
- `CHANGELOG.md` historical entries

**Notes:**
- Session cookie rename (`storydump_session`) will log out existing dashboard users — expected for rebrand
- localStorage key rename will reset waitlist "already registered" state
- Cloudinary folder default now `storydump` — old uploads under `storyline/` remain accessible by `public_id`
- 612 tests passing (1 pre-existing failure unrelated to rebrand)

## Test plan

- [x] Full pytest suite: 612 passed, 6 skipped, 1 pre-existing failure (unrelated `test_cloud_cleanup_loop`)
- [x] Verified zero remaining `storyline` references outside `documentation/`, `CHANGELOG.md`, and the Railway callback URL
- [x] Code review via `/simplify` — all findings addressed
- [ ] Rebuild landing page on Vercel after merge
- [ ] Verify Telegram bot messages show "Storydump" branding
- [ ] After external renames (Railway, Vercel, Neon): update callback URL and CI workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)