### PR TITLE
fix: gdrive disconnect alert as state transition, not hourly recurrence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Google Drive disconnect alert now behaves as a state transition, not a recurring hourly event** — `PostingService.send_gdrive_auth_alert` used to suppress duplicates via a class-level monotonic timestamp with a 3600s window. Because the JIT scheduler attempts a posting tick whenever a slot is due (~hourly for typical configs), the cooldown lapsed just before each new attempt and the alert re-fired forever until reconnect (observed: TL Stories chat, 9:04 AM → 8:28 PM, ~62 min cadence). Replaced with a persisted `chat_settings.gdrive_alerted_at` column (migration 031): the alert fires once on the first auth error of a disconnect event, stays silent until the OAuth reconnect callback clears the flag, and is restart-safe + per-chat scoped. Removed the `_last_gdrive_alert_time` class variable entirely.
 - **Scheduler tick poisoning standalone `queue_repo` session** — `_scheduler_tick` calls `queue_repo.discard_abandoned_processing()` before iterating chats. `queue_repo` is instantiated standalone (not owned by a BaseService), so the outer loop's `cleanup_transactions()` doesn't roll it back on error. A single transient DB failure was leaving the session in a broken transaction and every subsequent tick threw `PendingRollbackError` for the lifetime of the worker (observed in production after the token-rotation incident). Wrapped the call in try/except + `queue_repo.rollback()`.
 
 ### Added

--- a/scripts/migrations/031_gdrive_alerted_at.sql
+++ b/scripts/migrations/031_gdrive_alerted_at.sql
@@ -1,0 +1,13 @@
+-- Migration 031: Persist Google Drive disconnect alert state per chat.
+-- Replaces the in-memory PostingService._last_gdrive_alert_time cooldown so
+-- the alert behaves as a state transition (fires once per disconnect,
+-- self-clears on reconnect) instead of a recurring hourly event.
+BEGIN;
+
+ALTER TABLE chat_settings
+ADD COLUMN IF NOT EXISTS gdrive_alerted_at TIMESTAMPTZ;
+
+INSERT INTO schema_version (version, description, applied_at)
+VALUES ('031', 'Per-chat Google Drive disconnect alert state', NOW());
+
+COMMIT;

--- a/src/models/chat_settings.py
+++ b/src/models/chat_settings.py
@@ -64,6 +64,12 @@ class ChatSettings(Base):
     # NULL = no post sent yet (treat as "slot is due immediately").
     last_post_sent_at = Column(DateTime(timezone=True), nullable=True)
 
+    # When we last sent a "Google Drive Disconnected" alert for this chat.
+    # NULL = eligible to alert on the next auth error. Set on send, cleared
+    # by the OAuth reconnect callback so the alert behaves as a state
+    # transition rather than a recurring event.
+    gdrive_alerted_at = Column(DateTime(timezone=True), nullable=True)
+
     # Notification settings
     show_verbose_notifications = Column(Boolean, default=True)
 

--- a/src/services/core/posting.py
+++ b/src/services/core/posting.py
@@ -1,6 +1,6 @@
 """Posting service - Google Drive auth alerts and posting utilities."""
 
-import time
+from datetime import datetime, timezone
 from typing import Optional
 
 from src.services.base_service import BaseService
@@ -15,12 +15,9 @@ class PostingService(BaseService):
 
     The main scheduling and sending logic has moved to SchedulerService
     (JIT model). PostingService retains the Google Drive auth alert
-    (rate-limited proactive notification) used by the scheduler loop
-    when a GoogleDriveAuthError is encountered.
+    (state-transition notification) used by the scheduler loop when a
+    GoogleDriveAuthError is encountered.
     """
-
-    # Rate-limit auth alerts to 1 per hour (class-level shared across instances)
-    _last_gdrive_alert_time: float = 0.0
 
     def __init__(self):
         super().__init__()
@@ -30,22 +27,28 @@ class PostingService(BaseService):
     async def send_gdrive_auth_alert(
         self, telegram_chat_id: Optional[int] = None
     ) -> None:
-        """Send a proactive Google Drive reconnect alert to Telegram.
+        """Send a Google Drive reconnect alert to Telegram.
 
-        Rate-limited to at most once per hour to avoid spamming the channel.
+        Gated on chat_settings.gdrive_alerted_at: fires once per disconnect
+        event and stays silent until the OAuth reconnect callback clears
+        the flag. State lives in Postgres so it survives worker restarts
+        and is correctly scoped per chat.
         """
-        now = time.monotonic()
-        if (
-            PostingService._last_gdrive_alert_time > 0
-            and now - PostingService._last_gdrive_alert_time < 3600
-        ):
-            logger.debug("Skipping Google Drive auth alert (rate-limited)")
-            return
-
-        PostingService._last_gdrive_alert_time = now
-
         chat_id = telegram_chat_id or settings.ADMIN_TELEGRAM_CHAT_ID
         if not chat_id:
+            return
+
+        chat_settings = self.settings_service.get_settings_if_exists(chat_id)
+        if chat_settings is None:
+            logger.debug(
+                f"Skipping Google Drive auth alert: no chat_settings for {chat_id}"
+            )
+            return
+        if chat_settings.gdrive_alerted_at is not None:
+            logger.debug(
+                f"Skipping Google Drive auth alert for {chat_id}: "
+                "already alerted, awaiting reconnect"
+            )
             return
 
         try:
@@ -84,7 +87,10 @@ class PostingService(BaseService):
                 parse_mode="Markdown",
                 reply_markup=reply_markup,
             )
-            logger.info("Sent Google Drive auth alert to Telegram")
+            logger.info(f"Sent Google Drive auth alert to chat {chat_id}")
 
         except Exception as e:  # noqa: BLE001 — best-effort alert
             logger.error(f"Failed to send Google Drive auth alert: {e}")
+            return
+
+        self.settings_service.set_gdrive_alerted_at(chat_id, datetime.now(timezone.utc))

--- a/src/services/core/settings_service.py
+++ b/src/services/core/settings_service.py
@@ -315,6 +315,18 @@ class SettingsService(BaseService):
         """
         return self.settings_repo.update(telegram_chat_id, last_post_sent_at=sent_at)
 
+    def set_gdrive_alerted_at(
+        self, telegram_chat_id: int, alerted_at: Optional[datetime]
+    ) -> "ChatSettings":
+        """Set or clear the Google Drive disconnect alert timestamp.
+
+        Pass a datetime to record that we have already alerted (suppresses
+        future alerts until the value is cleared). Pass None to clear,
+        which the OAuth reconnect callback does so the next disconnect
+        is allowed to alert again.
+        """
+        return self.settings_repo.update(telegram_chat_id, gdrive_alerted_at=alerted_at)
+
     def get_all_active_chats(self) -> List[ChatSettings]:
         """Get all eligible active chat settings.
 

--- a/src/services/integrations/google_drive_oauth.py
+++ b/src/services/integrations/google_drive_oauth.py
@@ -195,6 +195,10 @@ class GoogleDriveOAuthService(BaseService):
                     metadata={"email": email},
                 )
 
+            # Rearm the disconnect-alert state machine: a new auth error
+            # after reconnect is a new disconnect event and should alert.
+            self.settings_repo.update(telegram_chat_id, gdrive_alerted_at=None)
+
             logger.info(
                 f"Google Drive OAuth: stored tokens for {email} "
                 f"(chat {telegram_chat_id})"

--- a/tests/src/services/test_google_drive_oauth.py
+++ b/tests/src/services/test_google_drive_oauth.py
@@ -216,6 +216,10 @@ class TestGDriveExchangeAndStore:
         assert result["email"] == "user@gmail.com"
         # Should store both access and refresh tokens
         assert service.token_repo.create_or_update_for_chat.call_count == 2
+        # Rearms the disconnect-alert state machine for this chat
+        service.settings_repo.update.assert_called_once_with(
+            -100123, gdrive_alerted_at=None
+        )
 
     @pytest.mark.asyncio
     async def test_exchange_without_refresh_token(self, service):

--- a/tests/src/services/test_posting.py
+++ b/tests/src/services/test_posting.py
@@ -1,10 +1,12 @@
-"""Tests for PostingService (JIT model).
+"""Tests for PostingService.
 
-PostingService has been simplified to only handle Google Drive auth alerts.
-The main scheduling and sending logic now lives in SchedulerService.
+PostingService is now only responsible for the Google Drive disconnect
+alert. The alert is gated on chat_settings.gdrive_alerted_at — fires once
+per disconnect event and stays silent until the OAuth reconnect callback
+clears the flag.
 """
 
-import time
+from datetime import datetime, timezone
 
 import pytest
 from unittest.mock import AsyncMock, Mock, patch
@@ -24,40 +26,29 @@ def posting_service():
         return service
 
 
+def _chat_settings(alerted_at=None):
+    """Build a mock ChatSettings with the given gdrive_alerted_at."""
+    cs = Mock()
+    cs.gdrive_alerted_at = alerted_at
+    return cs
+
+
 @pytest.mark.unit
 class TestSendGdriveAuthAlert:
-    """Tests for PostingService.send_gdrive_auth_alert()."""
+    """send_gdrive_auth_alert behaves as a state-transition notification."""
 
     @pytest.mark.asyncio
     @patch("src.services.core.posting.settings")
-    async def test_rate_limited_skips_send(self, mock_settings, posting_service):
-        """send_gdrive_auth_alert is rate-limited to once per hour."""
+    async def test_sends_and_persists_timestamp_when_flag_null(
+        self, mock_settings, posting_service
+    ):
+        """First auth error in a disconnect event sends the alert and persists."""
         mock_settings.ADMIN_TELEGRAM_CHAT_ID = -100123
         mock_settings.OAUTH_REDIRECT_BASE_URL = "https://example.com"
         posting_service.telegram_service.bot_token = "test-token"
-
-        # Set last alert time to now (simulate recent alert)
-        PostingService._last_gdrive_alert_time = time.monotonic()
-
-        with patch("telegram.Bot") as MockBot:
-            await posting_service.send_gdrive_auth_alert(-100123)
-
-        # Should NOT have sent because rate-limited
-        MockBot.assert_not_called()
-
-        # Reset for other tests
-        PostingService._last_gdrive_alert_time = 0.0
-
-    @pytest.mark.asyncio
-    @patch("src.services.core.posting.settings")
-    async def test_sends_when_not_rate_limited(self, mock_settings, posting_service):
-        """send_gdrive_auth_alert sends when not recently sent."""
-        mock_settings.ADMIN_TELEGRAM_CHAT_ID = -100123
-        mock_settings.OAUTH_REDIRECT_BASE_URL = "https://example.com"
-        posting_service.telegram_service.bot_token = "test-token"
-
-        # Ensure not rate-limited
-        PostingService._last_gdrive_alert_time = 0.0
+        posting_service.settings_service.get_settings_if_exists.return_value = (
+            _chat_settings(alerted_at=None)
+        )
 
         mock_bot_instance = AsyncMock()
         with patch("telegram.Bot", return_value=mock_bot_instance):
@@ -68,8 +59,46 @@ class TestSendGdriveAuthAlert:
         assert "Disconnected" in call_kwargs["text"]
         assert call_kwargs["reply_markup"] is not None
 
-        # Reset for other tests
-        PostingService._last_gdrive_alert_time = 0.0
+        posting_service.settings_service.set_gdrive_alerted_at.assert_called_once()
+        args, _ = posting_service.settings_service.set_gdrive_alerted_at.call_args
+        assert args[0] == -100123
+        assert isinstance(args[1], datetime)
+
+    @pytest.mark.asyncio
+    @patch("src.services.core.posting.settings")
+    async def test_skips_send_when_flag_already_set(
+        self, mock_settings, posting_service
+    ):
+        """Second auth error within the same disconnect event is suppressed."""
+        mock_settings.ADMIN_TELEGRAM_CHAT_ID = -100123
+        mock_settings.OAUTH_REDIRECT_BASE_URL = "https://example.com"
+        posting_service.telegram_service.bot_token = "test-token"
+        posting_service.settings_service.get_settings_if_exists.return_value = (
+            _chat_settings(alerted_at=datetime(2026, 5, 14, tzinfo=timezone.utc))
+        )
+
+        with patch("telegram.Bot") as MockBot:
+            await posting_service.send_gdrive_auth_alert(-100123)
+
+        MockBot.assert_not_called()
+        posting_service.settings_service.set_gdrive_alerted_at.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("src.services.core.posting.settings")
+    async def test_skips_send_when_no_chat_settings(
+        self, mock_settings, posting_service
+    ):
+        """Unknown chat (no chat_settings row) is silently skipped."""
+        mock_settings.ADMIN_TELEGRAM_CHAT_ID = -100123
+        mock_settings.OAUTH_REDIRECT_BASE_URL = "https://example.com"
+        posting_service.telegram_service.bot_token = "test-token"
+        posting_service.settings_service.get_settings_if_exists.return_value = None
+
+        with patch("telegram.Bot") as MockBot:
+            await posting_service.send_gdrive_auth_alert(-100123)
+
+        MockBot.assert_not_called()
+        posting_service.settings_service.set_gdrive_alerted_at.assert_not_called()
 
     @pytest.mark.asyncio
     @patch("src.services.core.posting.settings")
@@ -78,8 +107,9 @@ class TestSendGdriveAuthAlert:
         mock_settings.ADMIN_TELEGRAM_CHAT_ID = -100999
         mock_settings.OAUTH_REDIRECT_BASE_URL = "https://example.com"
         posting_service.telegram_service.bot_token = "test-token"
-
-        PostingService._last_gdrive_alert_time = 0.0
+        posting_service.settings_service.get_settings_if_exists.return_value = (
+            _chat_settings(alerted_at=None)
+        )
 
         mock_bot_instance = AsyncMock()
         with patch("telegram.Bot", return_value=mock_bot_instance):
@@ -87,8 +117,9 @@ class TestSendGdriveAuthAlert:
 
         call_kwargs = mock_bot_instance.send_message.call_args.kwargs
         assert call_kwargs["chat_id"] == -100999
-
-        PostingService._last_gdrive_alert_time = 0.0
+        posting_service.settings_service.get_settings_if_exists.assert_called_once_with(
+            -100999
+        )
 
     @pytest.mark.asyncio
     @patch("src.services.core.posting.settings")
@@ -99,8 +130,9 @@ class TestSendGdriveAuthAlert:
         mock_settings.ADMIN_TELEGRAM_CHAT_ID = -100123
         mock_settings.OAUTH_REDIRECT_BASE_URL = None
         posting_service.telegram_service.bot_token = "test-token"
-
-        PostingService._last_gdrive_alert_time = 0.0
+        posting_service.settings_service.get_settings_if_exists.return_value = (
+            _chat_settings(alerted_at=None)
+        )
 
         mock_bot_instance = AsyncMock()
         with patch("telegram.Bot", return_value=mock_bot_instance):
@@ -108,8 +140,6 @@ class TestSendGdriveAuthAlert:
 
         call_kwargs = mock_bot_instance.send_message.call_args.kwargs
         assert call_kwargs["reply_markup"] is None
-
-        PostingService._last_gdrive_alert_time = 0.0
 
     @pytest.mark.asyncio
     @patch("src.services.core.posting.settings")
@@ -120,29 +150,28 @@ class TestSendGdriveAuthAlert:
         mock_settings.ADMIN_TELEGRAM_CHAT_ID = None
         posting_service.telegram_service.bot_token = "test-token"
 
-        PostingService._last_gdrive_alert_time = 0.0
-
         with patch("telegram.Bot") as MockBot:
             await posting_service.send_gdrive_auth_alert()
 
         MockBot.assert_not_called()
-
-        PostingService._last_gdrive_alert_time = 0.0
+        posting_service.settings_service.get_settings_if_exists.assert_not_called()
 
     @pytest.mark.asyncio
     @patch("src.services.core.posting.settings")
-    async def test_send_failure_caught(self, mock_settings, posting_service):
-        """Exceptions during send are caught (not re-raised)."""
+    async def test_send_failure_does_not_persist_flag(
+        self, mock_settings, posting_service
+    ):
+        """If the Telegram send fails, the flag is NOT set — allow retry next tick."""
         mock_settings.ADMIN_TELEGRAM_CHAT_ID = -100123
         mock_settings.OAUTH_REDIRECT_BASE_URL = "https://example.com"
         posting_service.telegram_service.bot_token = "test-token"
-
-        PostingService._last_gdrive_alert_time = 0.0
+        posting_service.settings_service.get_settings_if_exists.return_value = (
+            _chat_settings(alerted_at=None)
+        )
 
         mock_bot_instance = AsyncMock()
         mock_bot_instance.send_message.side_effect = RuntimeError("Network error")
         with patch("telegram.Bot", return_value=mock_bot_instance):
-            # Should not raise
             await posting_service.send_gdrive_auth_alert(-100123)
 
-        PostingService._last_gdrive_alert_time = 0.0
+        posting_service.settings_service.set_gdrive_alerted_at.assert_not_called()


### PR DESCRIPTION
## Summary

- Investigated repeated "Google Drive Disconnected" Telegram alerts in the **TL Stories** chat firing on a ~62 min cadence (observed 9:04 AM → 8:28 PM in the screenshots from the user).
- Root cause: `PostingService.send_gdrive_auth_alert` was gated on a class-level monotonic timestamp (`_last_gdrive_alert_time`, 3600s window). The JIT scheduler attempts a posting tick whenever a slot is due (~1/hour for typical configs), so the cooldown lapsed just before each new attempt and the alert re-fired forever until reconnect.
- Fix: replace the in-memory cooldown with a persisted `chat_settings.gdrive_alerted_at` column (migration 031). The alert fires once on the first auth error of a disconnect event, stays silent until the OAuth reconnect callback clears the flag, then rearms naturally for the next disconnect.

## Why this design

From first principles, a disconnect alert exists to notify a human of a state transition (healthy → unhealthy), not to chant on a timer. Anything time-windowed is a proxy for state we declined to model. One nullable timestamp on `chat_settings`:

- `NULL` → eligible to alert on next auth error
- non-NULL → already alerted, suppress

State lives in Postgres, so it's restart-safe, multi-instance-safe, and per-chat-scoped by construction.

## Changes

- `src/models/chat_settings.py` — add nullable `gdrive_alerted_at` column
- `scripts/migrations/031_gdrive_alerted_at.sql` — schema migration
- `src/services/core/posting.py` — rewrite `send_gdrive_auth_alert` to read/write the persisted flag; drop the `_last_gdrive_alert_time` class variable entirely
- `src/services/core/settings_service.py` — add `set_gdrive_alerted_at` setter (avoids the service→repo layer leak)
- `src/services/integrations/google_drive_oauth.py` — `exchange_and_store` clears the flag after persisting fresh tokens
- `tests/src/services/test_posting.py` — fully rewritten for the new state machine
- `tests/src/services/test_google_drive_oauth.py` — assertion that reconnect clears the flag
- `CHANGELOG.md` — entry under `### Fixed`

## Test plan

- [x] `pytest tests/src/services/test_posting.py tests/src/services/test_google_drive_oauth.py` — 29 passed
- [x] `pytest tests/src/services/ tests/src/repositories/ -m unit` — 1207 passed, 8 skipped, 0 failures
- [x] `ruff check` + `ruff format --check` clean on changed files
- [ ] Apply migration 031 in staging/prod: `psql "\$DATABASE_URL" -f scripts/migrations/031_gdrive_alerted_at.sql`
- [ ] After deploy, observe a chat with a broken token receives exactly one alert and no follow-ups until reconnect
- [ ] After deploy, force a reconnect and confirm a subsequent auth error produces a single fresh alert (state machine rearms)

## Notes for reviewers

**Separate signal worth flagging** — the user also reported an alert firing 5 min after a successful reconnect (9:24 PM connect → 9:29 PM alert). Under this fix that would produce exactly one alert per re-disconnect, which is the honest behavior. The deeper question — why the freshly issued token starts failing within minutes of `exchange_and_store` succeeding — is a separate underlying bug. The OAuth URL is correct (`access_type=offline`, `prompt=consent`), credentials are read fresh from DB every tick (no caching), and the worker/API share Neon. Candidates: Google omitting a new `refresh_token` on re-consent and the stale one persisting, Drive folder permission issue on `list_files`. Not addressed here.

**Out of scope (deliberately):**
- Pausing `process_slot` while disconnected — the scheduler still attempts and still logs `GoogleDriveAuthError`; it just doesn't spam Telegram. Log churn is a separate concern.
- Reworking the hourly `_token_health_tick` (`scheduler_loop.py:183-220`) — its 24h cooldown is correct for its different purpose (proactive expiry warning) and was not the source of the spam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)