### PR TITLE
feat: ensure_utc helper consolidates naive→UTC datetime coercion (#335)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`ensure_utc(dt)` datetime helper** (`src/utils/datetime_utils.py`) — single source of truth for "naive datetime → UTC-aware" coercion. Returns `None` unchanged; passes already-aware datetimes through without re-allocating. Replaces 5 copies of the same inline idiom in `setup_state_service.py`, `telegram_commands.py`, `scheduler.py`, `dashboard_history_queries.py`, and `telegram_utils.py`. Also used in `ApiToken.is_expired` and `ApiToken.hours_until_expiry`, which previously compared `expires_at` to a naive `datetime.utcnow()` — that latent bug never surfaced because both sides happened to be naive, but it would have broken the moment either side became aware (e.g., a future column migration to `DateTime(timezone=True)`). Closes #335.
+
 ### Removed
 
 - **Stale documentation archive** — Deleted `documentation/archive/` directory containing 82 historical planning docs (Jan-Mar 2026) that are no longer relevant to current development. Reduces repo clutter by ~51,000 lines.

--- a/src/models/api_token.py
+++ b/src/models/api_token.py
@@ -1,6 +1,6 @@
 """API token model for OAuth token storage."""
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Optional
 import uuid
 
@@ -9,6 +9,7 @@ from sqlalchemy.dialects.postgresql import UUID, ARRAY, JSONB
 from sqlalchemy.orm import relationship
 
 from src.config.database import Base
+from src.utils.datetime_utils import ensure_utc
 
 
 class ApiToken(Base):
@@ -88,13 +89,15 @@ class ApiToken(Base):
     @property
     def is_expired(self) -> bool:
         """Check if the token has expired."""
-        if self.expires_at is None:
+        expires_at = ensure_utc(self.expires_at)
+        if expires_at is None:
             return False
-        return datetime.utcnow() > self.expires_at
+        return datetime.now(timezone.utc) > expires_at
 
     def hours_until_expiry(self) -> Optional[float]:
         """Get hours until token expires, or None if no expiry."""
-        if self.expires_at is None:
+        expires_at = ensure_utc(self.expires_at)
+        if expires_at is None:
             return None
-        delta = self.expires_at - datetime.utcnow()
+        delta = expires_at - datetime.now(timezone.utc)
         return max(0, delta.total_seconds() / 3600)

--- a/src/services/core/dashboard_history_queries.py
+++ b/src/services/core/dashboard_history_queries.py
@@ -238,6 +238,8 @@ class HistoryDashboardQueries:
         import random
         from datetime import datetime, timedelta, timezone
 
+        from src.utils.datetime_utils import ensure_utc
+
         with self.service.track_execution(
             "get_schedule_preview",
             input_params={"telegram_chat_id": telegram_chat_id, "slots": slots},
@@ -257,9 +259,7 @@ class HistoryDashboardQueries:
             interval_seconds = (window_hours * 3600) / ppd if ppd else 3600
 
             now = datetime.now(timezone.utc)
-            last = chat_settings.last_post_sent_at
-            if last and last.tzinfo is None:
-                last = last.replace(tzinfo=timezone.utc)
+            last = ensure_utc(chat_settings.last_post_sent_at)
             next_time = last + timedelta(seconds=interval_seconds) if last else now
 
             configured = self.service.category_mix_repo.get_current_mix_as_dict(

--- a/src/services/core/scheduler.py
+++ b/src/services/core/scheduler.py
@@ -14,6 +14,7 @@ from src.repositories.history_repository import HistoryRepository
 from src.repositories.lock_repository import LockRepository
 from src.repositories.category_mix_repository import CategoryMixRepository
 from src.config.settings import settings
+from src.utils.datetime_utils import ensure_utc
 from src.utils.logger import logger
 
 
@@ -62,11 +63,7 @@ class SchedulerService(BaseService):
         window_hours = self._posting_window_hours(chat_settings)
         interval_seconds = (window_hours * 3600) / chat_settings.posts_per_day
 
-        last_sent = chat_settings.last_post_sent_at
-        if last_sent:
-            # DB may return naive UTC; normalize to aware
-            if last_sent.tzinfo is None:
-                last_sent = last_sent.replace(tzinfo=timezone.utc)
+        last_sent = ensure_utc(chat_settings.last_post_sent_at)
         if last_sent and (now - last_sent).total_seconds() < interval_seconds:
             return False  # Too soon
 

--- a/src/services/core/setup_state_service.py
+++ b/src/services/core/setup_state_service.py
@@ -9,6 +9,7 @@ from src.repositories.history_repository import HistoryRepository
 from src.repositories.media_repository import MediaRepository
 from src.repositories.queue_repository import QueueRepository
 from src.repositories.token_repository import TokenRepository
+from src.utils.datetime_utils import ensure_utc
 from src.utils.logger import logger
 
 # Token is considered stale if expired more than this many days ago
@@ -261,11 +262,7 @@ def is_token_stale(token) -> bool:
     Shared utility used by SetupStateService and available for import
     elsewhere to avoid duplicating the staleness heuristic.
     """
-    if not token.expires_at:
+    expires_at = ensure_utc(token.expires_at)
+    if not expires_at:
         return False
-    # api_tokens.expires_at is stored as naive DateTime (assumed UTC) — coerce
-    # before comparing to an aware datetime, otherwise Python raises TypeError.
-    expires_at = token.expires_at
-    if expires_at.tzinfo is None:
-        expires_at = expires_at.replace(tzinfo=timezone.utc)
     return expires_at < datetime.now(timezone.utc) - timedelta(days=TOKEN_STALE_DAYS)

--- a/src/services/core/telegram_commands.py
+++ b/src/services/core/telegram_commands.py
@@ -16,6 +16,7 @@ from src.services.core.telegram_utils import (
     escape_markdownv2,
     format_last_post,
 )
+from src.utils.datetime_utils import ensure_utc
 from src.utils.logger import logger
 
 if TYPE_CHECKING:
@@ -204,12 +205,9 @@ class TelegramCommandHandlers:
 
             interval_seconds = (window_hours * 3600) / chat_settings.posts_per_day
 
-            last_sent = chat_settings.last_post_sent_at
+            last_sent = ensure_utc(chat_settings.last_post_sent_at)
             if not last_sent:
                 return "Due now"
-
-            if last_sent.tzinfo is None:
-                last_sent = last_sent.replace(tzinfo=timezone.utc)
 
             next_due = last_sent + timedelta(seconds=interval_seconds)
             now = datetime.now(timezone.utc)

--- a/src/services/core/telegram_utils.py
+++ b/src/services/core/telegram_utils.py
@@ -42,9 +42,9 @@ def format_last_post(last_post_at: str | None) -> str:
         return "never"
     from datetime import datetime, timezone
 
-    posted = datetime.fromisoformat(last_post_at)
-    if posted.tzinfo is None:
-        posted = posted.replace(tzinfo=timezone.utc)
+    from src.utils.datetime_utils import ensure_utc
+
+    posted = ensure_utc(datetime.fromisoformat(last_post_at))
     diff = datetime.now(timezone.utc) - posted
     days = diff.days
     if days > 0:

--- a/src/utils/datetime_utils.py
+++ b/src/utils/datetime_utils.py
@@ -5,7 +5,7 @@ from typing import Optional
 
 
 def ensure_utc(dt: Optional[datetime]) -> Optional[datetime]:
-    """Return ``dt`` as a UTC-aware datetime.
+    """Return ``dt`` as a timezone-aware datetime, assuming UTC if naive.
 
     Several DB columns (notably ``api_tokens.expires_at`` and
     ``chat_settings.last_post_sent_at``) are declared as naive ``DateTime``
@@ -14,7 +14,10 @@ def ensure_utc(dt: Optional[datetime]) -> Optional[datetime]:
     consolidates the coercion.
 
     Returns ``None`` unchanged. Already-aware datetimes pass through
-    untouched (no unnecessary allocation).
+    untouched (no unnecessary allocation) — including non-UTC offsets, which
+    are **not** converted to UTC. This is intentional: the helper makes a
+    naive value aware; it does not normalize offsets. If you need an offset
+    conversion, call ``.astimezone(timezone.utc)`` after this.
     """
     if dt is None:
         return None

--- a/src/utils/datetime_utils.py
+++ b/src/utils/datetime_utils.py
@@ -1,0 +1,23 @@
+"""Datetime helpers — keep timezone handling consistent across the codebase."""
+
+from datetime import datetime, timezone
+from typing import Optional
+
+
+def ensure_utc(dt: Optional[datetime]) -> Optional[datetime]:
+    """Return ``dt`` as a UTC-aware datetime.
+
+    Several DB columns (notably ``api_tokens.expires_at`` and
+    ``chat_settings.last_post_sent_at``) are declared as naive ``DateTime``
+    but written with the convention "values are UTC". Comparing those to
+    ``datetime.now(timezone.utc)`` raises ``TypeError``; this helper
+    consolidates the coercion.
+
+    Returns ``None`` unchanged. Already-aware datetimes pass through
+    untouched (no unnecessary allocation).
+    """
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    return dt

--- a/tests/src/utils/test_datetime_utils.py
+++ b/tests/src/utils/test_datetime_utils.py
@@ -1,0 +1,36 @@
+"""Tests for src/utils/datetime_utils.py."""
+
+from datetime import datetime, timezone, timedelta
+
+from src.utils.datetime_utils import ensure_utc
+
+
+def test_ensure_utc_returns_none_for_none():
+    assert ensure_utc(None) is None
+
+
+def test_ensure_utc_coerces_naive_to_utc():
+    naive = datetime(2026, 5, 16, 12, 30, 0)
+    coerced = ensure_utc(naive)
+    assert coerced is not None
+    assert coerced.tzinfo == timezone.utc
+    assert coerced.replace(tzinfo=None) == naive  # wall-clock preserved
+
+
+def test_ensure_utc_passes_through_aware_unchanged():
+    aware = datetime(2026, 5, 16, 12, 30, 0, tzinfo=timezone.utc)
+    assert ensure_utc(aware) is aware  # same object, no allocation
+
+
+def test_ensure_utc_preserves_non_utc_aware_datetime():
+    # Should NOT silently re-anchor: a +05:00 datetime stays +05:00.
+    plus5 = timezone(timedelta(hours=5))
+    aware = datetime(2026, 5, 16, 12, 30, 0, tzinfo=plus5)
+    assert ensure_utc(aware) is aware
+
+
+def test_ensure_utc_preserves_microseconds():
+    naive = datetime(2026, 5, 16, 12, 30, 0, 123456)
+    coerced = ensure_utc(naive)
+    assert coerced is not None
+    assert coerced.microsecond == 123456


### PR DESCRIPTION
## Summary

- Added `src/utils/datetime_utils.py::ensure_utc(dt)` — single source of truth for "naive datetime → UTC-aware" coercion. None passes through; already-aware datetimes pass through with the same object (no allocation).
- Migrated 5 inline copies of the same idiom in `setup_state_service.py`, `telegram_commands.py`, `scheduler.py`, `dashboard_history_queries.py`, `telegram_utils.py`.
- Fixed latent same-bug in `ApiToken.is_expired` and `ApiToken.hours_until_expiry`: previously compared `expires_at` against the deprecated naive `datetime.utcnow()`. The comparisons "worked" only because both sides happened to be naive; would have broken on any column migration to `DateTime(timezone=True)`.

Closes #335.

## Test plan

- [x] New unit tests for `ensure_utc` — None, naive coerced, aware passthrough, non-UTC aware preserved, microsecond preservation (100% coverage on the helper)
- [x] Targeted tests for callsites: `pytest -k "setup_state or token_stale or gdrive or api_token or scheduler or telegram_commands or telegram_utils or dashboard_history"` → **284 passed**
- [x] Full suite: **1737 passed, 16 skipped**
- [x] `ruff check src/` clean, `ruff format src/ --check` clean

## Out of scope (follow-ups)

- Migrating `api_tokens.expires_at` column to `DateTime(timezone=True)` (would touch `token_repository.py` read sites; requires a coordinated deploy).
- Converting remaining `datetime.utcnow()` callsites in `token_repository.py` and `onboarding_repository.py` — those go through SQLAlchemy column expressions, not Python comparisons, so they're safe today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)