### PR TITLE
Security: pin deps + add API rate limiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`ensure_utc(dt)` datetime helper** (`src/utils/datetime_utils.py`) — single source of truth for "naive datetime → UTC-aware" coercion. Returns `None` unchanged; passes already-aware datetimes through without re-allocating. Replaces 5 copies of the same inline idiom in `setup_state_service.py`, `telegram_commands.py`, `scheduler.py`, `dashboard_history_queries.py`, and `telegram_utils.py`. Also used in `ApiToken.is_expired` and `ApiToken.hours_until_expiry`, which previously compared `expires_at` to a naive `datetime.utcnow()` — that latent bug never surfaced because both sides happened to be naive, but it would have broken the moment either side became aware (e.g., a future column migration to `DateTime(timezone=True)`). Closes #335.
 
+### Security
+
+- **Pin all dependency versions** — Replaced `>=` version specifiers with exact `==` pins for all unpinned dependencies (cloudinary, google-api-python-client, google-auth, google-auth-oauthlib, fastapi, uvicorn, python-multipart, cryptography, anthropic). Prevents supply chain attacks via silent upgrades and ensures reproducible builds. (#325)
+- **Add rate limiting to API endpoints** — Added SlowAPI middleware with a global default of 30 req/min per IP. Mutation-heavy endpoints (`toggle-setting`, `update-setting`, `update-string-setting`) limited to 10/min; `sync-media` limited to 5/min to prevent Google Drive API abuse. Returns 429 with `Retry-After` header when exceeded. (#324)
+
 ### Removed
 
 - **Stale documentation archive** — Deleted `documentation/archive/` directory containing 82 historical planning docs (Jan-Mar 2026) that are no longer relevant to current development. Reduces repo clutter by ~51,000 lines.

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,23 +23,24 @@ rich==15.0.0
 python-dateutil==2.9.0.post0
 
 # Cloud Storage (Phase 2)
-cloudinary>=1.44.0
+cloudinary==1.44.2
 
 # Google Drive (Cloud Media Phase 02)
-google-api-python-client>=2.190.0
-google-auth>=2.49.0
-google-auth-oauthlib>=1.3.0
+google-api-python-client==2.196.0
+google-auth==2.53.0
+google-auth-oauthlib==1.4.0
 
 # API Server (Phase 04 OAuth)
-fastapi>=0.136.0
-uvicorn>=0.46.0
-python-multipart>=0.0.20
+fastapi==0.136.1
+uvicorn==0.47.0
+python-multipart==0.0.28
+slowapi==0.1.9
 
 # Security (Phase 2)
-cryptography>=46.0.0
+cryptography==48.0.0
 
 # AI Caption Generation
-anthropic>=0.97.0,<2
+anthropic==0.102.0
 
 # Testing
 pytest==9.0.3

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -6,7 +6,11 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
+from slowapi import _rate_limit_exceeded_handler
+from slowapi.errors import RateLimitExceeded
+from slowapi.middleware import SlowAPIMiddleware
 
+from src.api.rate_limit import limiter
 from src.api.routes.oauth import router as oauth_router
 from src.api.routes.onboarding import router as onboarding_router
 from src.config.settings import settings
@@ -16,6 +20,11 @@ app = FastAPI(
     description="OAuth and API endpoints for Storydump",
     version="0.1.0",
 )
+
+# Rate limiting — 30 req/min per IP global default (see src/api/rate_limit.py)
+app.state.limiter = limiter
+app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
+app.add_middleware(SlowAPIMiddleware)
 
 # CORS middleware — restrict to our own domain in production
 _cors_origins = (

--- a/src/api/rate_limit.py
+++ b/src/api/rate_limit.py
@@ -1,0 +1,10 @@
+"""Rate limiting configuration for the Storydump API."""
+
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+
+limiter = Limiter(
+    key_func=get_remote_address,
+    default_limits=["30/minute"],
+    storage_uri="memory://",
+)

--- a/src/api/routes/onboarding/settings.py
+++ b/src/api/routes/onboarding/settings.py
@@ -1,9 +1,10 @@
 """Settings and schedule action endpoints for onboarding Mini App."""
 
 import httpx
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
 from sqlalchemy.exc import OperationalError
 
+from src.api.rate_limit import limiter
 from src.config.settings import settings
 
 from src.models.instagram_account import AUTH_METHOD_MANUAL
@@ -33,9 +34,12 @@ router = APIRouter(tags=["onboarding"])
 
 
 @router.post("/toggle-setting")
-async def onboarding_toggle_setting(request: ToggleSettingRequest) -> dict:
+@limiter.limit("10/minute")
+async def onboarding_toggle_setting(
+    request: Request, body: ToggleSettingRequest
+) -> dict:
     """Toggle a boolean setting (is_paused, dry_run_mode) from dashboard."""
-    _validate_request(request.init_data, request.chat_id)
+    _validate_request(body.init_data, body.chat_id)
 
     allowed_settings = {
         "is_paused",
@@ -46,27 +50,28 @@ async def onboarding_toggle_setting(request: ToggleSettingRequest) -> dict:
         "enable_ai_captions",
         "send_lifecycle_notifications",
     }
-    if request.setting_name not in allowed_settings:
+    if body.setting_name not in allowed_settings:
         raise HTTPException(
             status_code=400,
-            detail=f"Setting '{request.setting_name}' cannot be toggled from dashboard. "
+            detail=f"Setting '{body.setting_name}' cannot be toggled from dashboard. "
             f"Allowed: {', '.join(sorted(allowed_settings))}",
         )
 
     with SettingsService() as settings_service, service_error_handler():
-        new_value = settings_service.toggle_setting(
-            request.chat_id, request.setting_name
-        )
+        new_value = settings_service.toggle_setting(body.chat_id, body.setting_name)
         return {
-            "setting_name": request.setting_name,
+            "setting_name": body.setting_name,
             "new_value": new_value,
         }
 
 
 @router.post("/update-setting")
-async def onboarding_update_setting(request: UpdateSettingRequest) -> dict:
+@limiter.limit("10/minute")
+async def onboarding_update_setting(
+    request: Request, body: UpdateSettingRequest
+) -> dict:
     """Update a numeric setting (posts_per_day, posting hours) from dashboard."""
-    _validate_request(request.init_data, request.chat_id)
+    _validate_request(body.init_data, body.chat_id)
 
     allowed_settings = {
         "posts_per_day",
@@ -75,26 +80,25 @@ async def onboarding_update_setting(request: UpdateSettingRequest) -> dict:
         "repost_ttl_days",
         "skip_ttl_days",
     }
-    if request.setting_name not in allowed_settings:
+    if body.setting_name not in allowed_settings:
         raise HTTPException(
             status_code=400,
-            detail=f"Setting '{request.setting_name}' cannot be updated from dashboard. "
+            detail=f"Setting '{body.setting_name}' cannot be updated from dashboard. "
             f"Allowed: {', '.join(sorted(allowed_settings))}",
         )
 
     with SettingsService() as settings_service, service_error_handler():
-        settings_service.update_setting(
-            request.chat_id, request.setting_name, request.value
-        )
+        settings_service.update_setting(body.chat_id, body.setting_name, body.value)
         return {
-            "setting_name": request.setting_name,
-            "new_value": request.value,
+            "setting_name": body.setting_name,
+            "new_value": body.value,
         }
 
 
 @router.post("/update-string-setting")
+@limiter.limit("10/minute")
 async def onboarding_update_string_setting(
-    request: UpdateStringSettingRequest,
+    request: Request, body: UpdateStringSettingRequest
 ) -> dict:
     """Update a string-typed per-chat setting (e.g. caption_style).
 
@@ -102,34 +106,32 @@ async def onboarding_update_string_setting(
     has to dispatch on the value type. Each setting has its own allowed
     value list to keep input validation tight at the API boundary.
     """
-    _validate_request(request.init_data, request.chat_id)
+    _validate_request(body.init_data, body.chat_id)
 
     allowed_values = {
         "caption_style": {"enhanced", "simple"},
     }
-    if request.setting_name not in allowed_values:
+    if body.setting_name not in allowed_values:
         raise HTTPException(
             status_code=400,
-            detail=f"Setting '{request.setting_name}' cannot be updated from dashboard. "
+            detail=f"Setting '{body.setting_name}' cannot be updated from dashboard. "
             f"Allowed: {', '.join(sorted(allowed_values))}",
         )
-    if request.value not in allowed_values[request.setting_name]:
+    if body.value not in allowed_values[body.setting_name]:
         raise HTTPException(
             status_code=400,
             detail=(
-                f"Invalid value for {request.setting_name}: "
-                f"{request.value!r}. Allowed: "
-                f"{', '.join(sorted(allowed_values[request.setting_name]))}"
+                f"Invalid value for {body.setting_name}: "
+                f"{body.value!r}. Allowed: "
+                f"{', '.join(sorted(allowed_values[body.setting_name]))}"
             ),
         )
 
     with SettingsService() as settings_service, service_error_handler():
-        settings_service.update_setting(
-            request.chat_id, request.setting_name, request.value
-        )
+        settings_service.update_setting(body.chat_id, body.setting_name, body.value)
         return {
-            "setting_name": request.setting_name,
-            "new_value": request.value,
+            "setting_name": body.setting_name,
+            "new_value": body.value,
         }
 
 
@@ -181,17 +183,18 @@ async def onboarding_disconnect_gdrive(request: InitRequest) -> dict:
 
 
 @router.post("/sync-media")
-async def onboarding_sync_media(request: InitRequest) -> dict:
+@limiter.limit("5/minute")
+async def onboarding_sync_media(request: Request, body: InitRequest) -> dict:
     """Trigger media sync from the dashboard.
 
     Calls MediaSyncService.sync() with the chat's per-tenant config.
     Returns sync result counts (new, updated, deactivated, etc).
     """
-    _validate_request(request.init_data, request.chat_id)
+    _validate_request(body.init_data, body.chat_id)
 
     with SettingsService() as settings_service:
         source_type, source_root = settings_service.get_media_source_config(
-            request.chat_id
+            body.chat_id
         )
 
     if not source_root:
@@ -206,7 +209,7 @@ async def onboarding_sync_media(request: InitRequest) -> dict:
                 source_type=source_type,
                 source_root=source_root,
                 triggered_by="dashboard",
-                telegram_chat_id=request.chat_id,
+                telegram_chat_id=body.chat_id,
             )
         except ValueError as e:
             raise HTTPException(status_code=400, detail=str(e))


### PR DESCRIPTION
## Summary

- Pin all 9 unpinned dependencies to exact versions (`==`) — prevents supply chain attacks via silent upgrades and ensures reproducible builds
- Add SlowAPI rate limiting middleware: 30 req/min global default per IP, 10/min for settings mutations (`toggle-setting`, `update-setting`, `update-string-setting`), 5/min for `sync-media` (protects against Google Drive API abuse)
- Returns proper 429 status with `Retry-After` header when limits are exceeded

Fixes #325
Fixes #324

## Test plan

- [x] All 1732 existing tests pass
- [x] `ruff check` + `ruff format --check` clean
- [ ] Verify 429 response when exceeding rate limit (manual: `for i in $(seq 35); do curl -s -o /dev/null -w "%{http_code}\n" <endpoint>; done`)
- [ ] Confirm `X-RateLimit-Remaining` and `Retry-After` headers present in responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)