### PR TITLE
security: audit Drive OAuth scope, document narrowing path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Pin all dependency versions** — Replaced `>=` version specifiers with exact `==` pins for all unpinned dependencies (cloudinary, google-api-python-client, google-auth, google-auth-oauthlib, fastapi, uvicorn, python-multipart, cryptography, anthropic). Prevents supply chain attacks via silent upgrades and ensures reproducible builds. (#325)
 - **Add rate limiting to API endpoints** — Added SlowAPI middleware with a global default of 30 req/min per IP. Mutation-heavy endpoints (`toggle-setting`, `update-setting`, `update-string-setting`) limited to 10/min; `sync-media` limited to 5/min to prevent Google Drive API abuse. Returns 429 with `Retry-After` header when exceeded. (#324)
+- **Google Drive OAuth scope audit** — Evaluated narrowing `drive.readonly` to `drive.file` or `drive.metadata.readonly`. `drive.readonly` is the minimum viable scope: `drive.file` breaks folder browsing (user media predates the app), `drive.metadata.readonly` blocks file downloads. Documented the tradeoff and the Picker API narrowing path in `google_drive_oauth.py` and `google_drive_provider.py`. (#327)
 
 ### Removed
 

--- a/src/services/integrations/google_drive_oauth.py
+++ b/src/services/integrations/google_drive_oauth.py
@@ -39,6 +39,21 @@ class GoogleDriveOAuthService(BaseService):
     TOKEN_TYPE_ACCESS = "oauth_access"
     TOKEN_TYPE_REFRESH = "oauth_refresh"
 
+    # Scope: drive.readonly is the narrowest scope that supports the current
+    # media sync UX, where users select a pre-existing Drive folder and the app
+    # lists + downloads files from it. Narrower alternatives were evaluated:
+    #
+    #   - drive.file: only sees files created/opened by the app — breaks folder
+    #     browsing since user media predates the app.
+    #   - drive.metadata.readonly: allows listing but not downloading
+    #     (files().get_media() requires read access).
+    #   - drive.metadata.readonly + per-file read: no such composite scope
+    #     exists without the Google Picker API.
+    #
+    # To narrow further: implement Google Picker API for folder selection,
+    # which grants per-file access under drive.file scope. That changes the
+    # onboarding UX from "paste folder ID" to a Picker widget.
+    # Tracked in: https://github.com/chrisrogers37/storydump/issues/327
     REQUIRED_SCOPES = [
         "https://www.googleapis.com/auth/drive.readonly",
         "https://www.googleapis.com/auth/userinfo.email",

--- a/src/services/media_sources/google_drive_provider.py
+++ b/src/services/media_sources/google_drive_provider.py
@@ -39,6 +39,8 @@ class GoogleDriveProvider(MediaSourceProvider):
         oauth_credentials: google.oauth2.credentials.Credentials instance.
     """
 
+    # drive.readonly is the narrowest viable scope — see google_drive_oauth.py
+    # REQUIRED_SCOPES comment for the full analysis and narrowing path.
     SCOPES = ["https://www.googleapis.com/auth/drive.readonly"]
 
     SUPPORTED_MIME_TYPES = {


### PR DESCRIPTION
## Summary

- Evaluated narrowing `drive.readonly` to `drive.file` or `drive.metadata.readonly`
- `drive.readonly` is the minimum viable scope: `drive.file` breaks folder browsing (user media predates the app), `drive.metadata.readonly` blocks file downloads (`files().get_media()`)
- Documented the tradeoff and Picker API narrowing path in `google_drive_oauth.py` (REQUIRED_SCOPES) and `google_drive_provider.py` (SCOPES)
- CHANGELOG entry under Security

**No functional code changes** — this is documentation of the scope analysis. The scope itself stays at `drive.readonly` because narrower scopes break the current media sync flow (10 API calls across list/get/download all require it).

Closes #327

## Test plan

- [x] `ruff check` and `ruff format --check` pass on changed files
- [x] `git diff origin/main..HEAD --stat` shows only 3 intended files
- [ ] CI tests pass (comment-only change, no functional impact)

🤖 Generated with [Claude Code](https://claude.com/claude-code)