### PR TITLE
fix: add /health endpoint for Railway health checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Railway health check killing deployments** — Added `/health` endpoint to the web process (`GET /health` → 200, no auth). Configured `railway.toml` with `healthcheckPath = "/health"` and `healthcheckTimeout = 30` so Railway's health checker hits a real endpoint instead of timing out and tearing down the service. The worker process (Telegram bot + scheduler) runs as a separate Railway service with no HTTP binding — it does not need an HTTP health check. Closes #347, #350.
+
 ### Added
 
 - **`ensure_utc(dt)` datetime helper** (`src/utils/datetime_utils.py`) — single source of truth for "naive datetime → UTC-aware" coercion. Returns `None` unchanged; passes already-aware datetimes through without re-allocating. Replaces 5 copies of the same inline idiom in `setup_state_service.py`, `telegram_commands.py`, `scheduler.py`, `dashboard_history_queries.py`, and `telegram_utils.py`. Also used in `ApiToken.is_expired` and `ApiToken.hours_until_expiry`, which previously compared `expires_at` to a naive `datetime.utcnow()` — that latent bug never surfaced because both sides happened to be naive, but it would have broken the moment either side became aware (e.g., a future column migration to `DateTime(timezone=True)`). Closes #335.

--- a/railway.toml
+++ b/railway.toml
@@ -3,5 +3,7 @@ builder = "NIXPACKS"
 buildCommand = "pip install -r requirements.txt && pip install -e . && mkdir -p /tmp/media"
 
 [deploy]
+healthcheckPath = "/health"
+healthcheckTimeout = 30
 restartPolicyType = "ON_FAILURE"
 restartPolicyMaxRetries = 10

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -1,5 +1,6 @@
 """FastAPI application for Storydump OAuth flows and Mini App."""
 
+import time
 from pathlib import Path
 
 from fastapi import FastAPI
@@ -15,6 +16,8 @@ from src.api.rate_limit import limiter
 from src.api.routes.oauth import router as oauth_router
 from src.api.routes.onboarding import router as onboarding_router
 from src.config.settings import settings
+
+_START_TIME = time.time()
 
 app = FastAPI(
     title="Storydump API",
@@ -52,6 +55,16 @@ if STATIC_DIR.exists():
 # Register routes
 app.include_router(oauth_router, prefix="/auth")
 app.include_router(onboarding_router, prefix="/api/onboarding")
+
+
+@app.get("/health")
+async def health_check():
+    """Health check endpoint for Railway. No auth required."""
+    return {
+        "status": "ok",
+        "version": app.version,
+        "uptime_seconds": int(time.time() - _START_TIME),
+    }
 
 
 @app.get("/webapp/onboarding")


### PR DESCRIPTION
## Summary

- Added `GET /health` endpoint to the web process (FastAPI) — returns `{"status": "ok", "version": "...", "uptime_seconds": N}`, no auth required
- Configured `railway.toml` with `healthcheckPath = "/health"` and `healthcheckTimeout = 30`
- Railway was killing deployments after 6-14 min because no endpoint responded to its health checker

**Architecture note:** The worker process (Telegram bot + scheduler) is a separate Railway service that doesn't bind HTTP. Its health check must be disabled in the Railway dashboard (service settings → Health Check → None). `railway.toml` applies to the web service only.

Closes #347, #350

## Test plan

- [x] All 122 existing API tests pass
- [ ] Deploy to Railway preview — verify health check passes and service stays up
- [ ] Confirm worker service has health check disabled in Railway dashboard
- [ ] Hit `/health` endpoint manually after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)