### PR TITLE
fix: scheduler catch-up after restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **Railway health check killing deployments** — Added `/health` endpoint to the web process (`GET /health` → 200, no auth). Configured `railway.toml` with `healthcheckPath = "/health"` and `healthcheckTimeout = 30` so Railway's health checker hits a real endpoint instead of timing out and tearing down the service. The worker process (Telegram bot + scheduler) runs as a separate Railway service with no HTTP binding — it does not need an HTTP health check. Closes #347, #350.
+- **Scheduler catch-up after restart** — When the worker restarts after missing posting slots, the scheduler now gradually catches up instead of skipping missed posts. Detects when `last_post_sent_at` is behind by >= 2 intervals and advances it by one interval per tick (instead of jumping to now), so each 60s tick fires one catch-up post until the schedule is current. Logs catch-up events with slot count and timestamps for Railway observability. (#349)
 
 ### Added
 

--- a/src/services/core/scheduler.py
+++ b/src/services/core/scheduler.py
@@ -1,6 +1,6 @@
 """Scheduler service - JIT posting schedule with per-slot media selection."""
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Optional, List, Union
 import random
 
@@ -70,6 +70,39 @@ class SchedulerService(BaseService):
         # Pick category for this slot
         return self._pick_category_for_slot()
 
+    def _compute_catchup_sent_at(self, chat_settings) -> Optional[datetime]:
+        """If behind by >= 2 intervals, return the timestamp to advance to.
+
+        Instead of jumping last_post_sent_at to now (which skips missed
+        slots), advance by one interval so the next tick re-evaluates and
+        catches up gradually — one post per tick.
+
+        Returns:
+            datetime to use as last_post_sent_at, or None for normal behavior.
+        """
+        last_sent = ensure_utc(chat_settings.last_post_sent_at)
+        if not last_sent:
+            return None
+
+        now = datetime.now(timezone.utc)
+        window_hours = self._posting_window_hours(chat_settings)
+        interval_seconds = (window_hours * 3600) / chat_settings.posts_per_day
+        elapsed = (now - last_sent).total_seconds()
+
+        if elapsed >= 2 * interval_seconds:
+            catchup_to = last_sent + timedelta(seconds=interval_seconds)
+            missed_slots = int(elapsed / interval_seconds) - 1
+            logger.info(
+                f"[catchup] Behind by {missed_slots} slot(s) "
+                f"(last_sent={last_sent.isoformat()}, "
+                f"interval={interval_seconds:.0f}s, "
+                f"elapsed={elapsed:.0f}s). "
+                f"Advancing last_post_sent_at to {catchup_to.isoformat()}"
+            )
+            return catchup_to
+
+        return None
+
     async def process_slot(self, telegram_chat_id: int) -> dict:
         """Process a single scheduler tick for a tenant.
 
@@ -95,11 +128,16 @@ class SchedulerService(BaseService):
         if slot_result is False:
             return {"posted": False, "reason": "not_due"}
 
+        # Catch-up: if behind by >= 2 intervals, advance by one interval
+        # instead of jumping to now. Next tick re-evaluates.
+        sent_at_override = self._compute_catchup_sent_at(chat_settings)
+
         category = slot_result if isinstance(slot_result, str) else None
         return await self._select_and_send(
             chat_settings,
             category=category,
             triggered_by="scheduler",
+            sent_at_override=sent_at_override,
         )
 
     async def force_send_next(
@@ -205,10 +243,16 @@ class SchedulerService(BaseService):
         triggered_by: str,
         user_id: Optional[str] = None,
         force_sent_indicator: bool = False,
+        sent_at_override: Optional[datetime] = None,
     ) -> dict:
         """Core JIT flow: select media → create queue item → send.
 
         Only creates a service_run when there is actual work to do.
+
+        Args:
+            sent_at_override: If set, use this instead of now for
+                last_post_sent_at (used during catch-up to advance
+                by one interval rather than jumping to now).
         """
         with self.track_execution(
             method_name="select_and_send",
@@ -247,7 +291,9 @@ class SchedulerService(BaseService):
 
             # Auto-approve previously-approved media (skip Telegram)
             if media_item.times_posted > 0 and triggered_by == "scheduler":
-                result = self._auto_approve(media_item, chat_settings)
+                result = self._auto_approve(
+                    media_item, chat_settings, sent_at_override=sent_at_override
+                )
                 self.set_result_summary(
                     run_id,
                     {
@@ -273,7 +319,8 @@ class SchedulerService(BaseService):
 
             if success:
                 self.settings_service.update_last_post_sent_at(
-                    chat_settings.telegram_chat_id, datetime.now(timezone.utc)
+                    chat_settings.telegram_chat_id,
+                    sent_at_override or datetime.now(timezone.utc),
                 )
 
             result = {
@@ -338,7 +385,12 @@ class SchedulerService(BaseService):
                 pass
             return False
 
-    def _auto_approve(self, media_item, chat_settings) -> dict:
+    def _auto_approve(
+        self,
+        media_item,
+        chat_settings,
+        sent_at_override: Optional[datetime] = None,
+    ) -> dict:
         """Auto-approve a previously-approved media item without Telegram interaction.
 
         Creates a transient queue item, records history, applies a repost lock,
@@ -385,7 +437,7 @@ class SchedulerService(BaseService):
         self.queue_repo.delete(queue_id)
 
         self.settings_service.update_last_post_sent_at(
-            chat_settings.telegram_chat_id, now
+            chat_settings.telegram_chat_id, sent_at_override or now
         )
 
         logger.info(

--- a/tests/src/services/test_scheduler.py
+++ b/tests/src/services/test_scheduler.py
@@ -866,3 +866,205 @@ class TestAutoApproval:
         scheduler_service.media_repo.increment_times_posted.assert_called_once()
         MockLock.return_value.create_lock.assert_called_once()
         scheduler_service.queue_repo.delete.assert_called_once()
+
+
+# ------------------------------------------------------------------
+# Catch-up after restart (#349)
+# ------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestCatchupAfterRestart:
+    """Tests for scheduler catch-up logic when behind after restart."""
+
+    def test_no_catchup_when_on_schedule(self, scheduler_service_mocked):
+        """Returns None when last post is within one interval."""
+        service = scheduler_service_mocked
+        # Window 9-21 = 12h, 3 PPD => interval = 4h = 14400s
+        last_sent = datetime(2026, 3, 21, 10, 0, tzinfo=timezone.utc)
+        cs = _make_chat_settings(
+            posting_hours_start=9,
+            posting_hours_end=21,
+            posts_per_day=3,
+            last_post_sent_at=last_sent,
+        )
+
+        with patch("src.services.core.scheduler.datetime") as mock_dt:
+            # 3h since last post, interval is 4h — not behind
+            mock_dt.now.return_value = datetime(2026, 3, 21, 13, 0, tzinfo=timezone.utc)
+            result = service._compute_catchup_sent_at(cs)
+
+        assert result is None
+
+    def test_no_catchup_when_exactly_one_interval(self, scheduler_service_mocked):
+        """Returns None when exactly one interval has passed (normal fire)."""
+        service = scheduler_service_mocked
+        # interval = 4h
+        last_sent = datetime(2026, 3, 21, 9, 0, tzinfo=timezone.utc)
+        cs = _make_chat_settings(
+            posting_hours_start=9,
+            posting_hours_end=21,
+            posts_per_day=3,
+            last_post_sent_at=last_sent,
+        )
+
+        with patch("src.services.core.scheduler.datetime") as mock_dt:
+            # Exactly 4h since last — one interval, not two
+            mock_dt.now.return_value = datetime(2026, 3, 21, 13, 0, tzinfo=timezone.utc)
+            result = service._compute_catchup_sent_at(cs)
+
+        assert result is None
+
+    def test_catchup_when_behind_two_intervals(self, scheduler_service_mocked):
+        """Returns last_sent + interval when behind by >= 2 intervals."""
+        service = scheduler_service_mocked
+        from datetime import timedelta
+
+        # interval = 4h
+        last_sent = datetime(2026, 3, 21, 9, 0, tzinfo=timezone.utc)
+        cs = _make_chat_settings(
+            posting_hours_start=9,
+            posting_hours_end=21,
+            posts_per_day=3,
+            last_post_sent_at=last_sent,
+        )
+
+        with patch("src.services.core.scheduler.datetime") as mock_dt:
+            # 9h since last post = behind by 2+ intervals (9h / 4h = 2.25)
+            mock_dt.now.return_value = datetime(2026, 3, 21, 18, 0, tzinfo=timezone.utc)
+            result = service._compute_catchup_sent_at(cs)
+
+        assert result == last_sent + timedelta(hours=4)
+
+    def test_catchup_advances_by_one_interval_only(self, scheduler_service_mocked):
+        """Even when behind by many slots, advances by exactly one interval."""
+        service = scheduler_service_mocked
+        from datetime import timedelta
+
+        # 13h window, 15 PPD => interval = 3120s = 52 min
+        last_sent = datetime(2026, 3, 21, 9, 0, tzinfo=timezone.utc)
+        cs = _make_chat_settings(
+            posting_hours_start=9,
+            posting_hours_end=22,
+            posts_per_day=15,
+            last_post_sent_at=last_sent,
+        )
+
+        with patch("src.services.core.scheduler.datetime") as mock_dt:
+            # 3h later = behind by ~3.46 intervals
+            mock_dt.now.return_value = datetime(2026, 3, 21, 12, 0, tzinfo=timezone.utc)
+            result = service._compute_catchup_sent_at(cs)
+
+        expected = last_sent + timedelta(seconds=3120)
+        assert result == expected
+
+    def test_no_catchup_when_last_sent_is_none(self, scheduler_service_mocked):
+        """Returns None when last_post_sent_at is None (first post ever)."""
+        service = scheduler_service_mocked
+        cs = _make_chat_settings(last_post_sent_at=None)
+
+        result = service._compute_catchup_sent_at(cs)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_process_slot_passes_catchup_override(self, scheduler_service_mocked):
+        """process_slot passes sent_at_override to _select_and_send during catchup."""
+        service = scheduler_service_mocked
+        from datetime import timedelta
+
+        last_sent = datetime(2026, 3, 21, 9, 0, tzinfo=timezone.utc)
+        cs = _make_chat_settings(
+            is_paused=False,
+            posting_hours_start=9,
+            posting_hours_end=21,
+            posts_per_day=3,
+            last_post_sent_at=last_sent,
+        )
+        service.settings_service.get_settings.return_value = cs
+        service._select_and_send = AsyncMock(return_value={"posted": True})
+
+        with patch("src.services.core.scheduler.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2026, 3, 21, 18, 0, tzinfo=timezone.utc)
+            service.category_mix_repo.get_current_mix_as_dict.return_value = {}
+            await service.process_slot(telegram_chat_id=-100123)
+
+        call_kwargs = service._select_and_send.call_args.kwargs
+        assert call_kwargs["sent_at_override"] == last_sent + timedelta(hours=4)
+
+    @pytest.mark.asyncio
+    async def test_process_slot_no_override_when_on_schedule(
+        self, scheduler_service_mocked
+    ):
+        """process_slot passes sent_at_override=None when not catching up."""
+        service = scheduler_service_mocked
+        last_sent = datetime(2026, 3, 21, 9, 0, tzinfo=timezone.utc)
+        cs = _make_chat_settings(
+            is_paused=False,
+            posting_hours_start=9,
+            posting_hours_end=21,
+            posts_per_day=3,
+            last_post_sent_at=last_sent,
+        )
+        service.settings_service.get_settings.return_value = cs
+        service._select_and_send = AsyncMock(return_value={"posted": True})
+
+        with patch("src.services.core.scheduler.datetime") as mock_dt:
+            # 5h since last, interval is 4h — one interval overdue, not two
+            mock_dt.now.return_value = datetime(2026, 3, 21, 14, 0, tzinfo=timezone.utc)
+            service.category_mix_repo.get_current_mix_as_dict.return_value = {}
+            await service.process_slot(telegram_chat_id=-100123)
+
+        call_kwargs = service._select_and_send.call_args.kwargs
+        assert call_kwargs["sent_at_override"] is None
+
+    @pytest.mark.asyncio
+    async def test_catchup_uses_override_for_last_post_sent_at(
+        self, scheduler_service_mocked
+    ):
+        """When catching up, last_post_sent_at is set to override, not now."""
+        service = scheduler_service_mocked
+
+        override_time = datetime(2026, 3, 21, 13, 0, tzinfo=timezone.utc)
+
+        media = Mock(
+            id=uuid4(), file_name="catch.jpg", category="memes", times_posted=0
+        )
+        service.media_repo.get_next_eligible_for_posting.return_value = media
+        queue_item = Mock(id=uuid4())
+        service.queue_repo.create.return_value = queue_item
+        service.telegram_service.send_notification = AsyncMock(return_value=True)
+
+        cs = _make_chat_settings()
+
+        await service._select_and_send(
+            cs,
+            category=None,
+            triggered_by="scheduler",
+            sent_at_override=override_time,
+        )
+
+        service.settings_service.update_last_post_sent_at.assert_called_once_with(
+            cs.telegram_chat_id, override_time
+        )
+
+    @pytest.mark.asyncio
+    async def test_auto_approve_uses_catchup_override(self, scheduler_service_mocked):
+        """Auto-approved posts during catchup use the override timestamp."""
+        service = scheduler_service_mocked
+        service.history_repo = Mock()
+        override_time = datetime(2026, 3, 21, 13, 0, tzinfo=timezone.utc)
+
+        media = Mock(
+            id=uuid4(), file_name="repost.jpg", category="memes", times_posted=3
+        )
+        queue_item = Mock(id=uuid4())
+        service.queue_repo.create.return_value = queue_item
+        cs = _make_chat_settings()
+
+        with patch("src.services.core.media_lock.MediaLockService"):
+            service._auto_approve(media, cs, sent_at_override=override_time)
+
+        service.settings_service.update_last_post_sent_at.assert_called_once_with(
+            cs.telegram_chat_id, override_time
+        )


### PR DESCRIPTION
## Summary

Fixes #349 — scheduler never catches up after restart.

**Problem:** When the worker restarts, `last_post_sent_at` is stale in the DB. The scheduler fires one overdue post, then sets `last_post_sent_at = now`, which skips all the missed slots. With 15 PPD across a 13h window (~52 min intervals), frequent deploy restarts compound missed posts.

**Fix:** Added `_compute_catchup_sent_at()` — when behind by >= 2 intervals, it advances `last_post_sent_at` by one interval instead of jumping to `now`. This way each 60s tick fires one catch-up post, and the next tick re-evaluates. Gradual catch-up until current, no flooding.

- `last_post_sent_at` is DB-backed (`chat_settings` table) — survives restarts, no issue there
- Lazy sessions from #342 don't affect the scheduler query path — verified
- Catch-up fires are logged with slot count + timestamps for Railway observability

## Changes

- `src/services/core/scheduler.py` — Added `_compute_catchup_sent_at()`, threaded `sent_at_override` through `process_slot` → `_select_and_send` → `_auto_approve`
- `tests/src/services/test_scheduler.py` — 9 new tests covering catch-up detection, override propagation, boundary conditions
- `CHANGELOG.md` — Entry under Unreleased/Fixed

## Test plan

- [x] All 57 scheduler tests pass (including 9 new catch-up tests)
- [x] Ruff lint + format clean
- [ ] Deploy to Railway staging and verify `[catchup]` log lines appear after simulated restart with stale `last_post_sent_at`
- [ ] Verify normal cadence resumes after catch-up completes (no permanent acceleration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)