### PR TITLE
fix: add health check server to worker process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Railway health check killing deployments** — Added `/health` endpoint to the web process (`GET /health` → 200, no auth). Configured `railway.toml` with `healthcheckPath = "/health"` and `healthcheckTimeout = 30` so Railway's health checker hits a real endpoint instead of timing out and tearing down the service. The worker process (Telegram bot + scheduler) runs as a separate Railway service with no HTTP binding — it does not need an HTTP health check. Closes #347, #350.
+- **Worker process restart-cycling on Railway** — The worker service (Telegram bot + scheduler) had no HTTP endpoint, so Railway's health check (`healthcheckPath = "/health"`) timed out and sent SIGTERM every ~8 minutes, producing 0 posts per cycle. Added a minimal stdlib `asyncio` TCP server to `src/main.py` that binds to `PORT` and returns 200 OK. Runs alongside existing tasks in `asyncio.gather()`, zero new dependencies.
+- **Railway health check killing deployments** — Added `/health` endpoint to the web process (`GET /health` → 200, no auth). Configured `railway.toml` with `healthcheckPath = "/health"` and `healthcheckTimeout = 30` so Railway's health checker hits a real endpoint instead of timing out and tearing down the service. Closes #347, #350.
 - **Scheduler catch-up after restart** — When the worker restarts after missing posting slots, the scheduler now gradually catches up instead of skipping missed posts. Detects when `last_post_sent_at` is behind by >= 2 intervals and advances it by one interval per tick (instead of jumping to now), so each 60s tick fires one catch-up post until the schedule is current. Logs catch-up events with slot count and timestamps for Railway observability. (#349)
 
 ### Added

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,7 @@
 """Main application entry point - runs scheduler + Telegram bot."""
 
 import asyncio
+import os
 import signal
 import sys
 from time import time
@@ -17,6 +18,29 @@ from src.services.core.loops.cloud_cleanup_loop import cleanup_cloud_storage_loo
 from src.services.core.loops.transaction_cleanup_loop import transaction_cleanup_loop
 from src.services.core.loops.media_sync_loop import media_sync_loop
 from src.utils.logger import logger
+
+_HEALTH_RESPONSE = (
+    b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 2\r\n\r\nok"
+)
+
+
+async def _health_check_server():
+    """Minimal HTTP server so Railway's health check gets a 200 on /health."""
+    port = int(os.environ.get("PORT", 8080))
+
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
+        try:
+            await reader.readline()  # consume request line
+            writer.write(_HEALTH_RESPONSE)
+            await writer.drain()
+        finally:
+            writer.close()
+            await writer.wait_closed()
+
+    server = await asyncio.start_server(handle, "0.0.0.0", port)
+    logger.info(f"Health check server listening on port {port}")
+    async with server:
+        await server.serve_forever()
 
 
 async def main_async():
@@ -72,6 +96,7 @@ async def main_async():
             guarded("lock_cleanup", cleanup_locks_loop(lock_service), bot=bot)
         ),
         asyncio.create_task(telegram_service.start_polling()),
+        asyncio.create_task(_health_check_server()),
     ]
 
     # Add cloud storage cleanup loop if Cloudinary is configured


### PR DESCRIPTION
## Summary

- Worker process restart-cycles on Railway (~8 min up, SIGTERM, 0 posts sent) because it has no HTTP endpoint for Railway's health check (`healthcheckPath = "/health"` in railway.toml)
- Adds a minimal stdlib `asyncio` TCP server to `src/main.py` that binds to `PORT` and returns 200 OK — runs alongside existing tasks in `asyncio.gather()`
- Zero new dependencies — pure `asyncio.start_server`
- The web process (`src/api/app.py`) already has `/health` via PR #353 but that's a separate Railway service; this fixes the **worker** service

## Test plan

- [ ] `pytest tests/ -x` — 1772 passed, 0 failed (verified locally)
- [ ] Deploy to Railway — worker stays alive past the 8-minute mark
- [ ] `curl $WORKER_URL/health` returns 200 after deploy
- [ ] Telegram bot continues posting on schedule (no more restart cycling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)