### PR TITLE
fix: first-tick immediate post survives rapid redeploys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Railway health check killing deployments** — Added `/health` endpoint to the web process (`GET /health` → 200, no auth). Configured `railway.toml` with `healthcheckPath = "/health"` and `healthcheckTimeout = 30` so Railway's health checker hits a real endpoint instead of timing out and tearing down the service. The worker process (Telegram bot + scheduler) runs as a separate Railway service with no HTTP binding — it does not need an HTTP health check. Closes #347, #350.
 - **Scheduler catch-up after restart** — When the worker restarts after missing posting slots, the scheduler now gradually catches up instead of skipping missed posts. Detects when `last_post_sent_at` is behind by >= 2 intervals and advances it by one interval per tick (instead of jumping to now), so each 60s tick fires one catch-up post until the schedule is current. Logs catch-up events with slot count and timestamps for Railway observability. (#349)
+- **First-tick immediate post survives rapid redeploys** — On the first scheduler tick after startup, if `last_post_sent_at` is stale (>= 2x interval), the catch-up post resets the timer to now instead of advancing gradually. This ensures each deploy restart fires one immediate post that counts as current, preventing rapid redeploy churn from starving the posting schedule. Subsequent ticks resume gradual catch-up from #349. (#348)
 
 ### Added
 

--- a/src/services/core/loops/scheduler_loop.py
+++ b/src/services/core/loops/scheduler_loop.py
@@ -32,8 +32,15 @@ async def _scheduler_tick(
     posting_service: PostingService,
     settings_service,
     queue_repo: QueueRepository,
+    *,
+    first_tick: bool = False,
 ) -> list:
     """Process one scheduler tick: discard stale queue items, process due slots.
+
+    Args:
+        first_tick: True on the first tick after worker startup.
+            Passed to process_slot so catch-up posts reset to now
+            instead of advancing gradually.
 
     Returns the list of active chats discovered this tick (used by health checks).
     """
@@ -75,7 +82,9 @@ async def _scheduler_tick(
         for chat in active_chats:
             chat_id = chat.telegram_chat_id
             try:
-                result = await scheduler_service.process_slot(telegram_chat_id=chat_id)
+                result = await scheduler_service.process_slot(
+                    telegram_chat_id=chat_id, first_tick=first_tick
+                )
 
                 if result.get("posted"):
                     session_state.posts_sent += 1
@@ -249,6 +258,7 @@ async def run_scheduler_loop(
     pool_check_tick_counter = 0
     pool_alert_last_sent: dict[int, float] = {}
     token_alert_last_sent: dict[int, float] = {}
+    is_first_tick = True
 
     while True:
         record_heartbeat("scheduler")
@@ -257,8 +267,13 @@ async def run_scheduler_loop(
         active_chats = []
         try:
             active_chats = await _scheduler_tick(
-                scheduler_service, posting_service, settings_service, queue_repo
+                scheduler_service,
+                posting_service,
+                settings_service,
+                queue_repo,
+                first_tick=is_first_tick,
             )
+            is_first_tick = False
         except Exception as e:
             logger.error(f"Error in scheduler loop: {e}", exc_info=True)
         finally:

--- a/src/services/core/scheduler.py
+++ b/src/services/core/scheduler.py
@@ -70,15 +70,23 @@ class SchedulerService(BaseService):
         # Pick category for this slot
         return self._pick_category_for_slot()
 
-    def _compute_catchup_sent_at(self, chat_settings) -> Optional[datetime]:
+    def _compute_catchup_sent_at(
+        self, chat_settings, *, first_tick: bool = False
+    ) -> Optional[datetime]:
         """If behind by >= 2 intervals, return the timestamp to advance to.
 
-        Instead of jumping last_post_sent_at to now (which skips missed
-        slots), advance by one interval so the next tick re-evaluates and
-        catches up gradually — one post per tick.
+        On a normal tick, advances by one interval so the next tick
+        re-evaluates and catches up gradually — one post per tick.
+
+        On the first tick after startup, returns None (use now) so the
+        post counts as current.  This prevents redeploy churn from
+        starving the schedule: even if deploys restart the worker every
+        few minutes, each startup fires one immediate post that resets
+        the timer to now.
 
         Returns:
-            datetime to use as last_post_sent_at, or None for normal behavior.
+            datetime to use as last_post_sent_at, or None for normal
+            behavior (set to now).
         """
         last_sent = ensure_utc(chat_settings.last_post_sent_at)
         if not last_sent:
@@ -90,8 +98,17 @@ class SchedulerService(BaseService):
         elapsed = (now - last_sent).total_seconds()
 
         if elapsed >= 2 * interval_seconds:
-            catchup_to = last_sent + timedelta(seconds=interval_seconds)
             missed_slots = int(elapsed / interval_seconds) - 1
+            if first_tick:
+                logger.info(
+                    f"[catchup] First tick after startup, behind by "
+                    f"{missed_slots} slot(s) "
+                    f"(last_sent={last_sent.isoformat()}, "
+                    f"elapsed={elapsed:.0f}s). "
+                    f"Posting immediately, resetting to now"
+                )
+                return None
+            catchup_to = last_sent + timedelta(seconds=interval_seconds)
             logger.info(
                 f"[catchup] Behind by {missed_slots} slot(s) "
                 f"(last_sent={last_sent.isoformat()}, "
@@ -103,7 +120,9 @@ class SchedulerService(BaseService):
 
         return None
 
-    async def process_slot(self, telegram_chat_id: int) -> dict:
+    async def process_slot(
+        self, telegram_chat_id: int, *, first_tick: bool = False
+    ) -> dict:
         """Process a single scheduler tick for a tenant.
 
         This is the main entry point called by the scheduler loop every
@@ -111,6 +130,11 @@ class SchedulerService(BaseService):
 
         Args:
             telegram_chat_id: Tenant to check
+            first_tick: True on the first tick after worker startup.
+                When catching up, the first tick posts immediately
+                (last_post_sent_at = now) instead of advancing
+                gradually, so redeploy churn doesn't starve the
+                schedule.
 
         Returns:
             Dict with keys: posted (bool), reason (str), and optionally
@@ -128,9 +152,11 @@ class SchedulerService(BaseService):
         if slot_result is False:
             return {"posted": False, "reason": "not_due"}
 
-        # Catch-up: if behind by >= 2 intervals, advance by one interval
-        # instead of jumping to now. Next tick re-evaluates.
-        sent_at_override = self._compute_catchup_sent_at(chat_settings)
+        # Catch-up: on first tick, post immediately (reset to now).
+        # On subsequent ticks, advance by one interval per tick.
+        sent_at_override = self._compute_catchup_sent_at(
+            chat_settings, first_tick=first_tick
+        )
 
         category = slot_result if isinstance(slot_result, str) else None
         return await self._select_and_send(

--- a/tests/src/services/test_scheduler.py
+++ b/tests/src/services/test_scheduler.py
@@ -1068,3 +1068,126 @@ class TestCatchupAfterRestart:
         service.settings_service.update_last_post_sent_at.assert_called_once_with(
             cs.telegram_chat_id, override_time
         )
+
+
+# ------------------------------------------------------------------
+# First-tick immediate post after startup (#348)
+# ------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestFirstTickImmediatePost:
+    """Tests for first-tick-after-startup behavior that resets to now."""
+
+    def test_first_tick_returns_none_when_behind(self, scheduler_service_mocked):
+        """On first tick, _compute_catchup_sent_at returns None (use now)."""
+        service = scheduler_service_mocked
+        last_sent = datetime(2026, 3, 21, 9, 0, tzinfo=timezone.utc)
+        cs = _make_chat_settings(
+            posting_hours_start=9,
+            posting_hours_end=21,
+            posts_per_day=3,
+            last_post_sent_at=last_sent,
+        )
+
+        with patch("src.services.core.scheduler.datetime") as mock_dt:
+            # 9h since last = behind by 2+ intervals
+            mock_dt.now.return_value = datetime(2026, 3, 21, 18, 0, tzinfo=timezone.utc)
+            result = service._compute_catchup_sent_at(cs, first_tick=True)
+
+        assert result is None
+
+    def test_subsequent_tick_advances_gradually(self, scheduler_service_mocked):
+        """On non-first tick, still advances by one interval (PR #354 behavior)."""
+        service = scheduler_service_mocked
+        from datetime import timedelta
+
+        last_sent = datetime(2026, 3, 21, 9, 0, tzinfo=timezone.utc)
+        cs = _make_chat_settings(
+            posting_hours_start=9,
+            posting_hours_end=21,
+            posts_per_day=3,
+            last_post_sent_at=last_sent,
+        )
+
+        with patch("src.services.core.scheduler.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2026, 3, 21, 18, 0, tzinfo=timezone.utc)
+            result = service._compute_catchup_sent_at(cs, first_tick=False)
+
+        assert result == last_sent + timedelta(hours=4)
+
+    def test_first_tick_no_effect_when_on_schedule(self, scheduler_service_mocked):
+        """first_tick=True doesn't change behavior when not behind."""
+        service = scheduler_service_mocked
+        last_sent = datetime(2026, 3, 21, 10, 0, tzinfo=timezone.utc)
+        cs = _make_chat_settings(
+            posting_hours_start=9,
+            posting_hours_end=21,
+            posts_per_day=3,
+            last_post_sent_at=last_sent,
+        )
+
+        with patch("src.services.core.scheduler.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2026, 3, 21, 13, 0, tzinfo=timezone.utc)
+            result = service._compute_catchup_sent_at(cs, first_tick=True)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_process_slot_first_tick_no_override(self, scheduler_service_mocked):
+        """process_slot with first_tick=True passes sent_at_override=None."""
+        service = scheduler_service_mocked
+        last_sent = datetime(2026, 3, 21, 9, 0, tzinfo=timezone.utc)
+        cs = _make_chat_settings(
+            is_paused=False,
+            posting_hours_start=9,
+            posting_hours_end=21,
+            posts_per_day=3,
+            last_post_sent_at=last_sent,
+        )
+        service.settings_service.get_settings.return_value = cs
+        service._select_and_send = AsyncMock(return_value={"posted": True})
+
+        with patch("src.services.core.scheduler.datetime") as mock_dt:
+            # Behind by 2+ intervals
+            mock_dt.now.return_value = datetime(2026, 3, 21, 18, 0, tzinfo=timezone.utc)
+            service.category_mix_repo.get_current_mix_as_dict.return_value = {}
+            await service.process_slot(telegram_chat_id=-100123, first_tick=True)
+
+        call_kwargs = service._select_and_send.call_args.kwargs
+        # None means "use now" — immediate post, not gradual advance
+        assert call_kwargs["sent_at_override"] is None
+
+    @pytest.mark.asyncio
+    async def test_process_slot_second_tick_advances(self, scheduler_service_mocked):
+        """process_slot without first_tick still advances gradually."""
+        service = scheduler_service_mocked
+        from datetime import timedelta
+
+        last_sent = datetime(2026, 3, 21, 9, 0, tzinfo=timezone.utc)
+        cs = _make_chat_settings(
+            is_paused=False,
+            posting_hours_start=9,
+            posting_hours_end=21,
+            posts_per_day=3,
+            last_post_sent_at=last_sent,
+        )
+        service.settings_service.get_settings.return_value = cs
+        service._select_and_send = AsyncMock(return_value={"posted": True})
+
+        with patch("src.services.core.scheduler.datetime") as mock_dt:
+            mock_dt.now.return_value = datetime(2026, 3, 21, 18, 0, tzinfo=timezone.utc)
+            service.category_mix_repo.get_current_mix_as_dict.return_value = {}
+            await service.process_slot(telegram_chat_id=-100123, first_tick=False)
+
+        call_kwargs = service._select_and_send.call_args.kwargs
+        assert call_kwargs["sent_at_override"] == last_sent + timedelta(hours=4)
+
+    def test_first_tick_no_effect_when_last_sent_none(self, scheduler_service_mocked):
+        """first_tick doesn't matter when last_post_sent_at is None."""
+        service = scheduler_service_mocked
+        cs = _make_chat_settings(last_post_sent_at=None)
+
+        result = service._compute_catchup_sent_at(cs, first_tick=True)
+
+        assert result is None

--- a/tests/src/test_main_scheduler_loop.py
+++ b/tests/src/test_main_scheduler_loop.py
@@ -57,10 +57,14 @@ class TestSchedulerLoop:
             except StopAsyncIteration:
                 pass
 
-        # Should have called process_slot for each chat
+        # Should have called process_slot for each chat (first_tick=True on first tick)
         assert scheduler_service.process_slot.call_count == 2
-        scheduler_service.process_slot.assert_any_call(telegram_chat_id=-100111)
-        scheduler_service.process_slot.assert_any_call(telegram_chat_id=-100222)
+        scheduler_service.process_slot.assert_any_call(
+            telegram_chat_id=-100111, first_tick=True
+        )
+        scheduler_service.process_slot.assert_any_call(
+            telegram_chat_id=-100222, first_tick=True
+        )
 
     @pytest.mark.asyncio
     async def test_scheduler_loop_no_calls_when_no_tenants(self):
@@ -346,6 +350,49 @@ class TestSchedulerLoop:
 
         # Session was rolled back so the next tick starts clean.
         queue_repo.rollback.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_first_tick_flag_is_true_then_false(self):
+        """first_tick=True on first tick, False on subsequent ticks."""
+        scheduler_service = Mock()
+        scheduler_service.process_slot = AsyncMock(return_value={"posted": False})
+        scheduler_service.cleanup_transactions = Mock()
+
+        posting_service = Mock()
+        posting_service.cleanup_transactions = Mock()
+
+        chat1 = Mock(telegram_chat_id=-100111)
+        settings_service = Mock()
+        settings_service.get_all_active_chats.return_value = [chat1]
+        settings_service.cleanup_transactions = Mock()
+
+        tick_count = 0
+
+        async def counting_sleep(seconds):
+            nonlocal tick_count
+            tick_count += 1
+            if tick_count >= 2:
+                raise StopAsyncIteration
+
+        with (
+            patch(f"{_SCHEDULER}.asyncio.sleep", new_callable=AsyncMock) as mock_sleep,
+            patch(f"{_SCHEDULER}.QueueRepository") as mock_queue_repo_cls,
+            patch(f"{_SCHEDULER}.ServiceRunRepository"),
+        ):
+            mock_queue_repo_cls.return_value.discard_abandoned_processing.return_value = 0
+            mock_sleep.side_effect = counting_sleep
+            try:
+                await run_scheduler_loop(
+                    scheduler_service, posting_service, settings_service
+                )
+            except StopAsyncIteration:
+                pass
+
+        # Two ticks = two calls
+        assert scheduler_service.process_slot.call_count == 2
+        calls = scheduler_service.process_slot.call_args_list
+        assert calls[0].kwargs["first_tick"] is True
+        assert calls[1].kwargs["first_tick"] is False
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## Summary

Fixes #348 — rapid PR merges cause continuous redeploy churn that starves the posting schedule.

**Problem:** PR #354 added gradual catch-up (advance `last_post_sent_at` by one interval per tick). But with deploys every ~8 minutes, the worker restarts before the second tick fires. Each restart fires one catch-up post that advances by 52 min, but `last_post_sent_at` never reaches "now" — the next deploy kills the worker before it can fire again. Net: posts keep lagging.

**Fix:** On the **first tick after startup**, if stale by >= 2 intervals, the catch-up post resets `last_post_sent_at = now` instead of advancing gradually. This way:
- Each deploy restart fires one immediate post that counts as fully current
- Even with 8-min deploy cycles, the schedule stays on track (one post per startup)
- After first tick, subsequent ticks resume the gradual catch-up from #354 (for long outages without redeploys)

## Changes

- `src/services/core/scheduler.py` — `_compute_catchup_sent_at` accepts `first_tick` kwarg; returns `None` (use now) on first tick when behind
- `src/services/core/loops/scheduler_loop.py` — `is_first_tick` flag tracks startup state, passed through `_scheduler_tick` → `process_slot`
- `tests/src/services/test_scheduler.py` — 6 new first-tick tests
- `tests/src/test_main_scheduler_loop.py` — Updated call assertions, added first_tick flag lifecycle test
- `CHANGELOG.md` — Entry under Unreleased/Fixed

## Test plan

- [x] All 87 tests pass (scheduler + loop tests)
- [x] Ruff lint + format clean
- [ ] Deploy to Railway and simulate rapid redeploys — verify `[catchup] First tick after startup` log line and immediate post
- [ ] Verify that a single long outage (no redeploys) still catches up gradually via #354 path

🤖 Generated with [Claude Code](https://claude.com/claude-code)