### PR TITLE
docs: Google OAuth verification submission runbook (#333)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Google OAuth verification submission runbook** — new `documentation/operations/google-oauth-verification.md` walks through the manual steps to clear the "Google hasn't verified this app" warning on the Drive consent screen: domain verification via Google Search Console, OAuth consent screen field-by-field, scope justification copy for `drive.readonly`, demo video requirements, submission flow, and the test-user allowlist as a stop-gap while review is pending. Captures the #327 outcome ("`drive.readonly` is the minimum viable scope") as the rationale for taking this route. Closes the documentation half of #333; the submission itself remains a manual operations task.
 - **`ensure_utc(dt)` datetime helper** (`src/utils/datetime_utils.py`) — single source of truth for "naive datetime → UTC-aware" coercion. Returns `None` unchanged; passes already-aware datetimes through without re-allocating. Replaces 5 copies of the same inline idiom in `setup_state_service.py`, `telegram_commands.py`, `scheduler.py`, `dashboard_history_queries.py`, and `telegram_utils.py`. Also used in `ApiToken.is_expired` and `ApiToken.hours_until_expiry`, which previously compared `expires_at` to a naive `datetime.utcnow()` — that latent bug never surfaced because both sides happened to be naive, but it would have broken the moment either side became aware (e.g., a future column migration to `DateTime(timezone=True)`). Closes #335.
 
 ### Security

--- a/documentation/operations/google-oauth-verification.md
+++ b/documentation/operations/google-oauth-verification.md
@@ -24,7 +24,7 @@ Before opening the OAuth Brand / consent screen submission form:
 - [x] **Terms of Service URL** — `https://storydump.app/terms` (`landing/src/app/(marketing)/terms/page.tsx`)
 - [ ] **App icon** — 120×120 PNG, no transparency. Need to design.
 - [ ] **Authorized domain** — `storydump.app` verified via Google Search Console.
-- [ ] **OAuth Redirect URI registered** — `${OAUTH_REDIRECT_BASE_URL}/auth/google-drive/callback`. Currently `https://storyline-ai-production.up.railway.app/auth/google-drive/callback` on Railway. Should be added under the OAuth client in Google Cloud Console.
+- [ ] **OAuth Redirect URI registered** — `${OAUTH_REDIRECT_BASE_URL}/auth/google-drive/callback`. Currently `https://storyline-ai-production.up.railway.app/auth/google-drive/callback` on Railway. Add it under **APIs & Services → Credentials → [OAuth 2.0 Client] → Authorized redirect URIs**. (`OAUTH_REDIRECT_BASE_URL` is documented in [`documentation/guides/cloud-deployment.md`](../guides/cloud-deployment.md).)
 - [ ] **Scope justification copy** — short text explaining why we need `drive.readonly` (see template below).
 - [ ] **Demo video** — screencast (≤ 5 min) demonstrating each requested scope in use. YouTube unlisted is fine.
 
@@ -72,7 +72,7 @@ Under **Scopes**, make sure these are listed:
 
 For each, click **Edit scope** → fill in the justification. **`drive.readonly` is the one Google will scrutinize.** Suggested copy:
 
-> Storydump is an Instagram Story scheduling tool. Users connect a Google Drive folder containing the media they want Storydump to post. We list files recursively under that single user-chosen folder to build a content catalog (filename, MIME type, thumbnail URL, category from subfolder structure) and read each file's bytes once per post to upload to Instagram. We never write to, modify, or delete files in the user's Drive. We do not access files outside the folder the user explicitly pointed us at, but the `drive.file` scope is too restrictive for this workflow because it doesn't grant folder-traversal of pre-existing user files. We use `drive.readonly` to enable read-only access to one user-chosen folder; we discard scope to any other Drive content via app-side filtering on `parents` chain.
+> Storydump is an Instagram Story scheduling tool. Users connect a Google Drive folder containing the media they want Storydump to post. We use `files.list` to enumerate files recursively under that single user-chosen folder (building a content catalog of filename, MIME type, thumbnail URL, and category from subfolder structure) and `files.get` with `alt=media` to read each file's bytes once per post for upload to Instagram. We never write to, modify, or delete files in the user's Drive — no `files.create`, `files.update`, or `files.delete`. We restrict access to the user-chosen folder via app-side filtering on the `parents` chain and never read files outside it. The `drive.file` scope was evaluated and rejected because it does not grant traversal of pre-existing user files, only files the app itself creates or the user opens via the Picker — incompatible with our "point at an existing folder" workflow.
 
 (Adjust wording to current implementation — the gist is: read-only, narrow folder scope, no writes, no exfiltration.)
 
@@ -83,12 +83,13 @@ Bottom of the consent screen → **Submit for verification**.
 Google will ask for the demo video URL. Record one that shows:
 
 1. A user signing into Storydump.
-2. Granting the Drive scope.
-3. Storydump listing files from the connected folder.
-4. A post going out (which reads file bytes from Drive).
-5. The user disconnecting / revoking access.
+2. Reaching the **Google OAuth consent screen** — pause long enough to clearly show the requested scopes listed (reviewers commonly reject videos that skip past this; they want to see the scope list on-screen).
+3. Granting the Drive scope.
+4. Storydump listing files from the connected folder.
+5. A post going out (which reads file bytes from Drive).
+6. The user disconnecting / revoking access.
 
-YouTube unlisted is the standard hosting. Keep the video under 5 minutes.
+YouTube unlisted is the standard hosting. Aim for under 5 minutes (convention, not a hard limit — Google will accept longer if the content justifies it).
 
 ### 6. Wait + respond to review
 
@@ -96,7 +97,7 @@ Google review timeline is typically **2–6 weeks**. The team may send back a li
 
 While waiting:
 - The unverified-app warning continues to show. Users still have the "Go to storydump (unsafe)" workaround.
-- Testing-mode allowlists (added under OAuth consent → Test users) bypass the warning for whitelisted Google accounts. Useful for letting beta testers in without the scary screen.
+- Google accounts added under **OAuth consent → Test users** (up to 100) **bypass the warning entirely** — they see a clean consent screen. Every other user sees the red "Google hasn't verified this app" page. Useful for letting beta testers in without the scary screen.
 
 ### 7. After approval
 
@@ -118,6 +119,11 @@ For internal/closed beta until verification clears:
 
 - Add each beta tester's Google account under **OAuth consent → Test users**. Up to 100 testers. They bypass the unverified warning entirely.
 - Stays valid even after re-submitting verification.
+
+## See also
+
+- [`documentation/guides/cloud-deployment.md`](../guides/cloud-deployment.md) — `OAUTH_REDIRECT_BASE_URL` and Railway env-var setup.
+- [`documentation/planning/2026-03-31-meta-app-launch-design.md`](../planning/2026-03-31-meta-app-launch-design.md) — sibling Meta/Instagram OAuth verification story (different provider, similar shape).
 
 ## Related issues
 

--- a/documentation/operations/google-oauth-verification.md
+++ b/documentation/operations/google-oauth-verification.md
@@ -1,0 +1,125 @@
+# Google OAuth Verification — Runbook
+
+**Status:** Pending submission. **Owner:** chrisrogers37. **Closes:** #333.
+
+The Google OAuth consent screen shows users a red **"Google hasn't verified this app"** warning when they connect Google Drive. They must click *Advanced → Go to storydump (unsafe)* to proceed. This blocks any tenant who isn't a developer of the project. This document walks through everything needed to clear it.
+
+## Why the warning fires
+
+Google flags **sensitive scopes** for verification before they can be used in Production mode without warnings. Storydump's Drive integration requests:
+
+| Scope | File | Class |
+|---|---|---|
+| `https://www.googleapis.com/auth/drive.readonly` | `src/services/integrations/google_drive_oauth.py:58` | **Sensitive** |
+| `https://www.googleapis.com/auth/userinfo.email` | (same) | Standard |
+
+The `drive.readonly` scope is what triggers the warning. Issue [#327](https://github.com/chrisrogers37/storydump/issues/327) audited the alternatives (`drive.file`, `drive.metadata.readonly`) and concluded that `drive.readonly` is the minimum viable scope — `drive.file` would break folder browsing (user media predates the app), and `drive.metadata.readonly` blocks file downloads (which we need to upload to Instagram). With scope-narrowing off the table, **verification submission is the only path to clear the warning** for non-developer users.
+
+## Prerequisites checklist
+
+Before opening the OAuth Brand / consent screen submission form:
+
+- [x] **App Homepage URL** — `https://storydump.app` (live)
+- [x] **Privacy Policy URL** — `https://storydump.app/privacy` (`landing/src/app/(marketing)/privacy/page.tsx`)
+- [x] **Terms of Service URL** — `https://storydump.app/terms` (`landing/src/app/(marketing)/terms/page.tsx`)
+- [ ] **App icon** — 120×120 PNG, no transparency. Need to design.
+- [ ] **Authorized domain** — `storydump.app` verified via Google Search Console.
+- [ ] **OAuth Redirect URI registered** — `${OAUTH_REDIRECT_BASE_URL}/auth/google-drive/callback`. Currently `https://storyline-ai-production.up.railway.app/auth/google-drive/callback` on Railway. Should be added under the OAuth client in Google Cloud Console.
+- [ ] **Scope justification copy** — short text explaining why we need `drive.readonly` (see template below).
+- [ ] **Demo video** — screencast (≤ 5 min) demonstrating each requested scope in use. YouTube unlisted is fine.
+
+## Step-by-step submission
+
+### 1. Verify domain ownership
+
+1. Open [Google Search Console](https://search.google.com/search-console).
+2. Add `storydump.app` as a property (Domain type, not URL prefix).
+3. Pick **DNS verification** → copy the TXT record.
+4. Add the TXT record at the registrar (whichever DNS provider hosts `storydump.app`).
+5. Wait 5–60 min for propagation; click **Verify**.
+
+### 2. Promote app to Production (if not already)
+
+1. Open [Google Cloud Console](https://console.cloud.google.com/) → pick the storydump project.
+2. **APIs & Services → OAuth consent screen.**
+3. Confirm **Publishing status: In production**. If it says **Testing**, click **Publish App**. Confirm the warning ("Your app will be available to any user with a Google Account") and submit.
+
+> **Note:** Promoting to Production *without* verification keeps the unverified-app warning for non-test users. The next steps clear it.
+
+### 3. Fill OAuth consent screen fields
+
+Still under **OAuth consent screen**:
+
+| Field | Value |
+|---|---|
+| App name | `Storydump` |
+| User support email | `christophertrogers37@gmail.com` (or a team email) |
+| App logo | upload the 120×120 PNG |
+| Application home page | `https://storydump.app` |
+| Application privacy policy link | `https://storydump.app/privacy` |
+| Application terms of service link | `https://storydump.app/terms` |
+| Authorized domains | `storydump.app` (must match the verified domain in step 1) |
+| Developer contact information | `christophertrogers37@gmail.com` |
+
+Save.
+
+### 4. Justify the scopes
+
+Under **Scopes**, make sure these are listed:
+
+- `.../auth/userinfo.email`
+- `.../auth/drive.readonly`
+
+For each, click **Edit scope** → fill in the justification. **`drive.readonly` is the one Google will scrutinize.** Suggested copy:
+
+> Storydump is an Instagram Story scheduling tool. Users connect a Google Drive folder containing the media they want Storydump to post. We list files recursively under that single user-chosen folder to build a content catalog (filename, MIME type, thumbnail URL, category from subfolder structure) and read each file's bytes once per post to upload to Instagram. We never write to, modify, or delete files in the user's Drive. We do not access files outside the folder the user explicitly pointed us at, but the `drive.file` scope is too restrictive for this workflow because it doesn't grant folder-traversal of pre-existing user files. We use `drive.readonly` to enable read-only access to one user-chosen folder; we discard scope to any other Drive content via app-side filtering on `parents` chain.
+
+(Adjust wording to current implementation — the gist is: read-only, narrow folder scope, no writes, no exfiltration.)
+
+### 5. Submit for verification
+
+Bottom of the consent screen → **Submit for verification**.
+
+Google will ask for the demo video URL. Record one that shows:
+
+1. A user signing into Storydump.
+2. Granting the Drive scope.
+3. Storydump listing files from the connected folder.
+4. A post going out (which reads file bytes from Drive).
+5. The user disconnecting / revoking access.
+
+YouTube unlisted is the standard hosting. Keep the video under 5 minutes.
+
+### 6. Wait + respond to review
+
+Google review timeline is typically **2–6 weeks**. The team may send back a list of clarifying questions or screencast re-records. Reply through the Cloud Console verification ticket — *do not* open a new submission.
+
+While waiting:
+- The unverified-app warning continues to show. Users still have the "Go to storydump (unsafe)" workaround.
+- Testing-mode allowlists (added under OAuth consent → Test users) bypass the warning for whitelisted Google accounts. Useful for letting beta testers in without the scary screen.
+
+### 7. After approval
+
+- Consent screen shows the app logo and a verified badge (no red warning).
+- New tenants can complete Drive connect with a clean Google flow.
+- **No code changes needed.**
+
+## If verification is rejected
+
+Most common reasons:
+
+1. **Demo video incomplete** — re-record showing every requested scope.
+2. **Privacy policy missing required disclosures** — the `/privacy` page already covers the [Google API Services User Data Policy Limited Use](https://developers.google.com/terms/api-services-user-data-policy#limited-use) clause. Keep the wording aligned with that policy.
+3. **Scope justification too vague** — be specific about which API endpoints we call and why each is needed.
+
+## Operational alternative
+
+For internal/closed beta until verification clears:
+
+- Add each beta tester's Google account under **OAuth consent → Test users**. Up to 100 testers. They bypass the unverified warning entirely.
+- Stays valid even after re-submitting verification.
+
+## Related issues
+
+- [#327](https://github.com/chrisrogers37/storydump/issues/327) — *Closed.* Drive scope audit; team kept `drive.readonly`. Captures the tradeoff context for future reference.
+- [#333](https://github.com/chrisrogers37/storydump/issues/333) — This runbook closes the documentation piece. Submission itself is a manual operations task tracked there.


### PR DESCRIPTION
## Summary

- New `documentation/operations/google-oauth-verification.md` runbook documenting the manual steps to clear the "Google hasn't verified this app" red warning on the Drive consent screen.
- Issue #327 already audited scope-narrowing (`drive.file`/`drive.metadata.readonly`) and concluded `drive.readonly` is the minimum viable scope. With scope-narrowing off the table, verification submission is the only path to clean onboarding for non-developer tenants.

Closes the documentation half of #333. The submission itself stays a manual operations task tracked on the issue.

## What's in the runbook

- **Why the warning fires** — `drive.readonly` is a Google-classified sensitive scope.
- **Prerequisites checklist** — tied to current state of `storydump.app`. Privacy/Terms pages already live, App ID/redirect URI on Railway. Outstanding: app logo, Google Search Console domain verification.
- **Step-by-step submission** — domain verification → consent screen fields → scope justification (template copy included) → demo video → submit.
- **Wait-time expectations** — 2-6 weeks typical.
- **Stop-gap for the meantime** — test-user allowlist bypasses the warning for whitelisted Google accounts (up to 100). Useful for beta testers.
- **Rejection-recovery** — common reasons + responses.

## Test plan

- [x] Document references match the actual code (scopes in `google_drive_oauth.py:57-58`, redirect URI in `google_drive_oauth.py:78-79`, privacy/terms paths in `landing/src/app/(marketing)/`).
- [x] No code changes; nothing to test runtime.

## Out of scope

- The submission itself — that's a manual operations task on the user side. The runbook gates that task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)