### PR TITLE
fix: implement Google Drive token refresh lifecycle

### DIFF
--- a/src/services/core/media_sync.py
+++ b/src/services/core/media_sync.py
@@ -231,6 +231,10 @@ class MediaSyncService(BaseService):
 
             self._deactivate_missing_items(ctx)
 
+            # Persist any token the google-auth library refreshed in-memory
+            if resolved_type == "google_drive" and telegram_chat_id:
+                self._persist_refreshed_gdrive_credentials(provider, telegram_chat_id)
+
             logger.info(
                 f"[MediaSyncService] Sync complete: "
                 f"{ctx.result.new} new, {ctx.result.updated} updated, "
@@ -397,6 +401,33 @@ class MediaSyncService(BaseService):
             )
         else:
             return MediaSourceFactory.create(source_type)
+
+    def _persist_refreshed_gdrive_credentials(
+        self, provider, telegram_chat_id: int
+    ) -> None:
+        """Persist refreshed Google Drive OAuth credentials back to the DB.
+
+        During API calls, the google-auth library may refresh the access_token
+        in-memory. Without this step, the next sync cycle would start with
+        the old expired token and need another refresh round-trip.
+        """
+        from google.oauth2.credentials import Credentials as UserCredentials
+
+        creds = provider.credentials
+        if not isinstance(creds, UserCredentials) or not creds.refresh_token:
+            return
+
+        from src.services.integrations.google_drive_oauth import (
+            GoogleDriveOAuthService,
+        )
+
+        try:
+            with GoogleDriveOAuthService() as oauth_service:
+                oauth_service.persist_refreshed_credentials(telegram_chat_id, creds)
+        except Exception:  # noqa: BLE001 — best-effort, must not break sync
+            logger.warning(
+                "[MediaSyncService] Failed to persist refreshed GDrive credentials"
+            )
 
     def _get_file_hash(self, file_info: MediaFileInfo, provider) -> str:
         """Get content hash for a file. Uses provider-side hash if available."""

--- a/src/services/integrations/google_drive_oauth.py
+++ b/src/services/integrations/google_drive_oauth.py
@@ -378,6 +378,7 @@ class GoogleDriveOAuthService(BaseService):
                 client_id=settings.GOOGLE_CLIENT_ID,
                 client_secret=settings.GOOGLE_CLIENT_SECRET,
                 scopes=self.REQUIRED_SCOPES,
+                expiry=access_row.expires_at,
             )
         except (ValueError, InvalidToken) as e:
             logger.critical(
@@ -387,6 +388,56 @@ class GoogleDriveOAuthService(BaseService):
             )
             self._notify_decrypt_failure(telegram_chat_id)
             return None
+
+    def persist_refreshed_credentials(self, telegram_chat_id: int, credentials) -> bool:
+        """Persist refreshed OAuth credentials back to the database.
+
+        After API operations, the google-auth library may have refreshed the
+        access_token in-memory. This method writes the new token back to the
+        DB so the next provider creation cycle starts with a valid token.
+
+        Args:
+            telegram_chat_id: The Telegram chat that owns the credentials.
+            credentials: google.oauth2.credentials.Credentials instance.
+
+        Returns:
+            True if the token was updated in the DB, False otherwise.
+        """
+        if not credentials or not credentials.token:
+            return False
+
+        chat_settings = self.settings_repo.get_by_chat_id(telegram_chat_id)
+        if not chat_settings:
+            return False
+
+        chat_settings_id = str(chat_settings.id)
+
+        access_row = self.token_repo.get_token_for_chat(
+            self.SERVICE_NAME, self.TOKEN_TYPE_ACCESS, chat_settings_id
+        )
+        if not access_row:
+            return False
+
+        try:
+            stored_token = self.encryption.decrypt(access_row.token_value)
+        except (ValueError, InvalidToken):
+            stored_token = None
+
+        if stored_token == credentials.token:
+            return False
+
+        self.token_repo.create_or_update_for_chat(
+            service_name=self.SERVICE_NAME,
+            token_type=self.TOKEN_TYPE_ACCESS,
+            token_value=self.encryption.encrypt(credentials.token),
+            chat_settings_id=chat_settings_id,
+            expires_at=credentials.expiry,
+        )
+
+        logger.info(
+            f"Google Drive OAuth: persisted refreshed token for chat {telegram_chat_id}"
+        )
+        return True
 
     def _notify_decrypt_failure(self, telegram_chat_id: int) -> None:
         """Fire-and-forget Telegram alert when token decryption fails."""

--- a/src/services/media_sources/google_drive_provider.py
+++ b/src/services/media_sources/google_drive_provider.py
@@ -37,9 +37,15 @@ _DOWNLOAD_TIMEOUT_SECONDS = 300
 
 
 def _is_retryable(exc: BaseException) -> bool:
-    """Return True for transient errors that should trigger a retry."""
+    """Return True for transient errors that should trigger a retry.
+
+    Includes 401: after the initial access_token expires, AuthorizedHttp
+    refreshes it in-memory.  If that refresh itself hits a transient failure
+    (network blip, Google-side propagation delay), a single retry gives the
+    refreshed token a second chance before we surface a terminal auth error.
+    """
     if isinstance(exc, HttpError):
-        return exc.resp.status in (429, 500, 502, 503, 504)
+        return exc.resp.status in (401, 429, 500, 502, 503, 504)
     return isinstance(exc, (ConnectionError, TimeoutError, OSError))
 
 
@@ -136,6 +142,13 @@ class GoogleDriveProvider(MediaSourceProvider):
 
         self._credentials = credentials
         self._folder_cache: dict[str, str] = {}
+
+    @property
+    def credentials(
+        self,
+    ) -> UserCredentials | ServiceAccountCredentials:
+        """Expose credentials so callers can persist refreshed tokens."""
+        return self._credentials
 
     @property
     def service(self):

--- a/tests/src/services/media_sources/test_google_drive_provider.py
+++ b/tests/src/services/media_sources/test_google_drive_provider.py
@@ -535,14 +535,26 @@ class TestGoogleDriveProviderRetry:
             provider._execute_with_retry(mock_request)
         assert mock_request.execute.call_count == 1
 
-    def test_no_retry_on_401(self, provider, mock_drive_service):
-        """Does not retry on 401 (auth error, not transient)."""
+    def test_retry_on_401(self, provider, mock_drive_service):
+        """Retries on 401 — gives AuthorizedHttp a second chance after refresh."""
+        mock_request = mock_drive_service.files().get()
+        mock_request.execute.side_effect = [
+            _make_http_error(401, "Unauthorized"),
+            {"id": "file1"},
+        ]
+
+        result = provider._execute_with_retry(mock_request)
+        assert result == {"id": "file1"}
+        assert mock_request.execute.call_count == 2
+
+    def test_401_exhausts_retries(self, provider, mock_drive_service):
+        """Persistent 401 raises after exhausting retries."""
         mock_request = mock_drive_service.files().get()
         mock_request.execute.side_effect = _make_http_error(401, "Unauthorized")
 
         with pytest.raises(HttpError):
             provider._execute_with_retry(mock_request)
-        assert mock_request.execute.call_count == 1
+        assert mock_request.execute.call_count == 3
 
     def test_download_chunk_retries_on_transient(self, provider):
         """Download chunk retry works on transient errors."""

--- a/tests/src/services/test_google_drive_oauth.py
+++ b/tests/src/services/test_google_drive_oauth.py
@@ -348,6 +348,181 @@ class TestGDriveGetUserCredentials:
         assert call_kwargs["refresh_token"] == "decrypted_encrypted_refresh"
         assert call_kwargs["client_id"] == "client-id"
 
+    @patch("src.services.integrations.google_drive_oauth.settings")
+    def test_credentials_include_expiry(self, mock_settings):
+        """Credentials constructor receives expires_at from the DB token row."""
+        from datetime import datetime, timezone
+
+        mock_settings.GOOGLE_CLIENT_ID = "client-id"
+        mock_settings.GOOGLE_CLIENT_SECRET = "client-secret"
+
+        mock_chat = Mock()
+        mock_chat.id = uuid.uuid4()
+        self.service.settings_repo.get_by_chat_id.return_value = mock_chat
+
+        expires = datetime(2026, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+        mock_access = Mock()
+        mock_access.token_value = "encrypted_access"
+        mock_access.expires_at = expires
+        mock_refresh = Mock()
+        mock_refresh.token_value = "encrypted_refresh"
+
+        def get_token_side_effect(service_name, token_type, chat_id):
+            if token_type == "oauth_access":
+                return mock_access
+            return mock_refresh
+
+        self.service.token_repo.get_token_for_chat.side_effect = get_token_side_effect
+        self.service._encryption.decrypt.side_effect = lambda v: f"decrypted_{v}"
+
+        with patch("google.oauth2.credentials.Credentials") as MockCreds:
+            MockCreds.return_value = Mock()
+            self.service.get_user_credentials(-100123)
+
+        call_kwargs = MockCreds.call_args[1]
+        assert call_kwargs["expiry"] == expires
+
+    @patch("src.services.integrations.google_drive_oauth.settings")
+    def test_credentials_expiry_none_when_not_set(self, mock_settings):
+        """Credentials expiry is None when access_row.expires_at is None."""
+        mock_settings.GOOGLE_CLIENT_ID = "client-id"
+        mock_settings.GOOGLE_CLIENT_SECRET = "client-secret"
+
+        mock_chat = Mock()
+        mock_chat.id = uuid.uuid4()
+        self.service.settings_repo.get_by_chat_id.return_value = mock_chat
+
+        mock_access = Mock()
+        mock_access.token_value = "encrypted_access"
+        mock_access.expires_at = None
+
+        self.service.token_repo.get_token_for_chat.side_effect = lambda sn, tt, cid: (
+            mock_access if tt == "oauth_access" else None
+        )
+        self.service._encryption.decrypt.side_effect = lambda v: f"decrypted_{v}"
+
+        with patch("google.oauth2.credentials.Credentials") as MockCreds:
+            MockCreds.return_value = Mock()
+            self.service.get_user_credentials(-100123)
+
+        call_kwargs = MockCreds.call_args[1]
+        assert call_kwargs["expiry"] is None
+
+
+# ==================== Persist Refreshed Credentials Tests ====================
+
+
+@pytest.mark.unit
+class TestGDrivePersistRefreshedCredentials:
+    """Tests for persist_refreshed_credentials."""
+
+    @pytest.fixture(autouse=True)
+    def setup_service(self):
+        with patch.object(GoogleDriveOAuthService, "__init__", lambda self: None):
+            self.service = GoogleDriveOAuthService()
+            self.service.service_run_repo = Mock()
+            self.service.service_name = "GoogleDriveOAuthService"
+            self.service._encryption = Mock()
+            self.service.token_repo = Mock()
+            self.service.settings_repo = Mock()
+            self.service.SERVICE_NAME = "google_drive"
+            self.service.TOKEN_TYPE_ACCESS = "oauth_access"
+
+    def test_persists_when_token_changed(self):
+        """Writes new token to DB when credentials.token differs from stored."""
+        from datetime import datetime, timezone
+
+        mock_chat = Mock()
+        mock_chat.id = uuid.uuid4()
+        self.service.settings_repo.get_by_chat_id.return_value = mock_chat
+
+        mock_access = Mock()
+        mock_access.token_value = "encrypted_old"
+        self.service.token_repo.get_token_for_chat.return_value = mock_access
+        self.service._encryption.decrypt.return_value = "old_access_token"
+        self.service._encryption.encrypt.return_value = "encrypted_new"
+
+        new_expiry = datetime(2026, 6, 1, 13, 0, 0, tzinfo=timezone.utc)
+        creds = Mock()
+        creds.token = "new_access_token"
+        creds.expiry = new_expiry
+
+        result = self.service.persist_refreshed_credentials(-100123, creds)
+
+        assert result is True
+        self.service.token_repo.create_or_update_for_chat.assert_called_once_with(
+            service_name="google_drive",
+            token_type="oauth_access",
+            token_value="encrypted_new",
+            chat_settings_id=str(mock_chat.id),
+            expires_at=new_expiry,
+        )
+
+    def test_skips_when_token_unchanged(self):
+        """Returns False and does not write when token is the same."""
+        mock_chat = Mock()
+        mock_chat.id = uuid.uuid4()
+        self.service.settings_repo.get_by_chat_id.return_value = mock_chat
+
+        mock_access = Mock()
+        mock_access.token_value = "encrypted_same"
+        self.service.token_repo.get_token_for_chat.return_value = mock_access
+        self.service._encryption.decrypt.return_value = "same_token"
+
+        creds = Mock()
+        creds.token = "same_token"
+
+        result = self.service.persist_refreshed_credentials(-100123, creds)
+
+        assert result is False
+        self.service.token_repo.create_or_update_for_chat.assert_not_called()
+
+    def test_returns_false_for_none_credentials(self):
+        """Returns False when credentials is None."""
+        assert self.service.persist_refreshed_credentials(-100123, None) is False
+
+    def test_returns_false_when_no_chat_settings(self):
+        """Returns False when chat has no settings."""
+        self.service.settings_repo.get_by_chat_id.return_value = None
+
+        creds = Mock()
+        creds.token = "some_token"
+
+        assert self.service.persist_refreshed_credentials(-100123, creds) is False
+
+    def test_returns_false_when_no_access_row(self):
+        """Returns False when no access token exists in DB."""
+        mock_chat = Mock()
+        mock_chat.id = uuid.uuid4()
+        self.service.settings_repo.get_by_chat_id.return_value = mock_chat
+        self.service.token_repo.get_token_for_chat.return_value = None
+
+        creds = Mock()
+        creds.token = "some_token"
+
+        assert self.service.persist_refreshed_credentials(-100123, creds) is False
+
+    def test_persists_when_stored_token_decrypt_fails(self):
+        """Persists new token when the stored token can't be decrypted."""
+        mock_chat = Mock()
+        mock_chat.id = uuid.uuid4()
+        self.service.settings_repo.get_by_chat_id.return_value = mock_chat
+
+        mock_access = Mock()
+        mock_access.token_value = "corrupted"
+        self.service.token_repo.get_token_for_chat.return_value = mock_access
+        self.service._encryption.decrypt.side_effect = ValueError("bad key")
+        self.service._encryption.encrypt.return_value = "encrypted_new"
+
+        creds = Mock()
+        creds.token = "new_token"
+        creds.expiry = None
+
+        result = self.service.persist_refreshed_credentials(-100123, creds)
+
+        assert result is True
+        self.service.token_repo.create_or_update_for_chat.assert_called_once()
+
 
 # ==================== Notify Telegram Tests ====================
 

--- a/tests/src/services/test_media_sync.py
+++ b/tests/src/services/test_media_sync.py
@@ -562,6 +562,125 @@ class TestMediaSyncServiceProviderCreation:
         mock_factory.create.assert_called_once_with("local", base_path="/tmp/media")
 
 
+# ==================== Credential Persistence Tests ====================
+
+
+@pytest.mark.unit
+class TestMediaSyncCredentialPersistence:
+    """Tests for _persist_refreshed_gdrive_credentials and its integration with sync."""
+
+    @patch("src.services.core.media_sync.MediaSourceFactory")
+    @patch("src.services.core.media_sync.settings")
+    def test_sync_persists_refreshed_gdrive_credentials(
+        self, mock_settings, mock_factory, sync_service
+    ):
+        """After a google_drive sync, persist_refreshed_credentials is called."""
+        from google.oauth2.credentials import Credentials as UserCredentials
+
+        mock_creds = Mock(spec=UserCredentials)
+        mock_creds.refresh_token = "refresh_tok"
+        mock_creds.token = "new_access_token"
+
+        mock_provider = Mock()
+        mock_provider.credentials = mock_creds
+        mock_provider.is_configured.return_value = True
+        mock_provider.list_files.return_value = []
+        mock_factory.create.return_value = mock_provider
+
+        mock_settings.TELEGRAM_CHANNEL_ID = -100123
+        sync_service.media_repo.get_active_by_source_type.return_value = []
+
+        with patch(
+            "src.services.integrations.google_drive_oauth.GoogleDriveOAuthService"
+        ) as MockOAuth:
+            mock_oauth = MockOAuth.return_value
+            mock_oauth.__enter__ = Mock(return_value=mock_oauth)
+            mock_oauth.__exit__ = Mock(return_value=False)
+            mock_oauth.persist_refreshed_credentials.return_value = True
+
+            sync_service.sync(
+                source_type="google_drive",
+                source_root="folder_xyz",
+                telegram_chat_id=-100999,
+            )
+
+            mock_oauth.persist_refreshed_credentials.assert_called_once_with(
+                -100999, mock_creds
+            )
+
+    @patch("src.services.core.media_sync.MediaSourceFactory")
+    @patch("src.services.core.media_sync.settings")
+    def test_sync_skips_persistence_for_local_provider(
+        self, mock_settings, mock_factory, sync_service
+    ):
+        """Local provider sync does not attempt credential persistence."""
+        mock_provider = Mock()
+        mock_provider.is_configured.return_value = True
+        mock_provider.list_files.return_value = []
+        mock_factory.create.return_value = mock_provider
+
+        mock_settings.MEDIA_DIR = "/media"
+        sync_service.media_repo.get_active_by_source_type.return_value = []
+
+        with patch(
+            "src.services.integrations.google_drive_oauth.GoogleDriveOAuthService"
+        ) as MockOAuth:
+            sync_service.sync(source_type="local", source_root="/media")
+
+            MockOAuth.assert_not_called()
+
+    def test_persist_skips_non_oauth_credentials(self, sync_service):
+        """Does not persist when provider uses service account credentials."""
+        from google.oauth2.service_account import Credentials as SACredentials
+
+        mock_creds = Mock(spec=SACredentials)
+        mock_provider = Mock()
+        mock_provider.credentials = mock_creds
+
+        with patch(
+            "src.services.integrations.google_drive_oauth.GoogleDriveOAuthService"
+        ) as MockOAuth:
+            sync_service._persist_refreshed_gdrive_credentials(mock_provider, -100123)
+            MockOAuth.assert_not_called()
+
+    def test_persist_skips_when_no_refresh_token(self, sync_service):
+        """Does not persist when credentials have no refresh_token."""
+        from google.oauth2.credentials import Credentials as UserCredentials
+
+        mock_creds = Mock(spec=UserCredentials)
+        mock_creds.refresh_token = None
+        mock_provider = Mock()
+        mock_provider.credentials = mock_creds
+
+        with patch(
+            "src.services.integrations.google_drive_oauth.GoogleDriveOAuthService"
+        ) as MockOAuth:
+            sync_service._persist_refreshed_gdrive_credentials(mock_provider, -100123)
+            MockOAuth.assert_not_called()
+
+    def test_persist_failure_does_not_break_sync(self, sync_service):
+        """Credential persistence error is swallowed — sync must not fail."""
+        from google.oauth2.credentials import Credentials as UserCredentials
+
+        mock_creds = Mock(spec=UserCredentials)
+        mock_creds.refresh_token = "refresh_tok"
+        mock_provider = Mock()
+        mock_provider.credentials = mock_creds
+
+        with patch(
+            "src.services.integrations.google_drive_oauth.GoogleDriveOAuthService"
+        ) as MockOAuth:
+            mock_oauth = MockOAuth.return_value
+            mock_oauth.__enter__ = Mock(return_value=mock_oauth)
+            mock_oauth.__exit__ = Mock(return_value=False)
+            mock_oauth.persist_refreshed_credentials.side_effect = RuntimeError(
+                "DB down"
+            )
+
+            # Should not raise
+            sync_service._persist_refreshed_gdrive_credentials(mock_provider, -100123)
+
+
 # ==================== File Path Building Tests ====================
 
 


### PR DESCRIPTION
## Summary

- Passes `expiry` to the `google.oauth2.credentials.Credentials` constructor so the library knows when to proactively refresh tokens
- Persists refreshed access tokens back to the DB after each sync cycle, so the next cycle starts with a valid token instead of re-refreshing every time
- Adds 401 to retryable status codes, giving a second chance when AuthorizedHttp's refresh hits a transient failure
- Exposes a typed `credentials` property on `GoogleDriveProvider` for the persistence hook

## Root cause

See #372 for the full analysis. Three compounding bugs meant once the 1-hour access_token expired, the system had no reliable recovery path — no proactive refresh, no persistence of refreshed tokens, and no retry on auth failure.

## Test plan

- [x] `test_credentials_include_expiry` — verifies `expiry` is passed from DB to Credentials
- [x] `test_credentials_expiry_none_when_not_set` — handles None gracefully
- [x] `test_persists_when_token_changed` — writes new token when refresh detected
- [x] `test_skips_when_token_unchanged` — no DB write on no-op path
- [x] `test_persists_when_stored_token_decrypt_fails` — handles corrupted stored token
- [x] `test_retry_on_401` / `test_401_exhausts_retries` — 401 retry behavior
- [x] `test_sync_persists_refreshed_gdrive_credentials` — end-to-end integration
- [x] `test_persist_failure_does_not_break_sync` — error swallowed, sync unaffected
- [x] All 105 tests pass

Closes #372

🤖 Generated with [Claude Code](https://claude.com/claude-code)