### PR TITLE
ci: skip CHANGELOG check on docs-only PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,10 +144,24 @@ jobs:
 
       - name: Check CHANGELOG.md was updated
         run: |
-          if git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -q "CHANGELOG.md"; then
+          CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD)
+
+          # Docs-only PRs (everything under documentation/ or root .md files
+          # other than CHANGELOG itself) don't need a CHANGELOG entry — the
+          # changelog tracks user-facing behavior changes, not docs.
+          NON_DOC=$(echo "$CHANGED" | grep -v -E '^(documentation/|.*\.md$|\.github/)' || true)
+          if [ -z "$NON_DOC" ]; then
+            echo "✅ Docs-only PR — CHANGELOG.md update not required"
+            exit 0
+          fi
+
+          if echo "$CHANGED" | grep -q "^CHANGELOG\.md$"; then
             echo "✅ CHANGELOG.md was updated"
           else
             echo "⚠️ WARNING: CHANGELOG.md was not updated"
             echo "Please add an entry under ## [Unreleased] describing your changes"
+            echo ""
+            echo "Files changed:"
+            echo "$CHANGED" | sed 's/^/  /'
             exit 1
           fi


### PR DESCRIPTION
## Summary

The `changelog-check` job in CI fails any PR that doesn't touch `CHANGELOG.md`. That's right for code changes but creates needless friction for pure-documentation PRs (planning docs, runbooks, README edits) where a CHANGELOG entry has no signal value.

This PR teaches the check to skip when the diff only touches docs / CI config / markdown files. If even one file outside those paths changes, the check still requires a CHANGELOG entry.

## What counts as "docs-only"

Skipped paths (regex):
- `documentation/**` — planning docs, guides, operations runbooks
- `*.md` at any path — top-level READMEs, in-tree docs
- `.github/**` — CI config, issue templates, PR templates

Anything else → CHANGELOG required as before.

## Edge cases

- **CHANGELOG.md is the only file changed** (e.g. backfilling an entry): still passes via the existing "CHANGELOG.md was updated" branch.
- **PR mixes docs and code**: still requires CHANGELOG (the non-doc files trigger the requirement).
- **`.gitignore` / `.editorconfig` / root config files**: not in the docs-only list — still require CHANGELOG. Tiny edge case; can be added later if it becomes annoying.

## Bonus

Failure message now lists the changed files so the author can see at a glance what triggered the requirement.

## Test plan

- [x] This PR itself is docs-only-ish (`.github/workflows/ci.yml` only) and should be the first PR to exercise the new branch. GitHub Actions uses the PR branch's version of the workflow file for same-repo PRs, so the new logic applies to its own check.
- [ ] After merge, PR #379 (planning doc, currently failing CHANGELOG check) will pass on re-trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)