### PR TITLE
security: harden API — 6 audit findings bundled

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,10 @@ jobs:
       - name: Install package
         run: pip install -e .
 
+      - name: Generate test encryption key
+        id: gen-key
+        run: echo "key=$(python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())')" >> "$GITHUB_OUTPUT"
+
       - name: Run tests with coverage
         env:
           # Database configuration (individual components for Settings class)
@@ -88,8 +92,9 @@ jobs:
           TELEGRAM_BOT_TOKEN: test_token
           TELEGRAM_CHANNEL_ID: -1001234567890
           ADMIN_TELEGRAM_CHAT_ID: -1001234567890
-          # Security
-          ENCRYPTION_KEY: MDEyMzQ1Njc4OWFiY2RlZjAxMjM0NTY3ODlhYmNkZWY=
+          # Security — generate a fresh Fernet key per run instead of
+          # committing a static test key in the workflow file.
+          ENCRYPTION_KEY: ${{ steps.gen-key.outputs.key }}
           # Development
           DRY_RUN_MODE: "true"
           LOG_LEVEL: DEBUG

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **HTTP security headers on all API responses** — Added `SecurityHeadersMiddleware` with HSTS (`max-age=63072000; includeSubDomains`), `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, CSP (`default-src 'self'`, `frame-ancestors 'none'`), and `Referrer-Policy: strict-origin-when-cross-origin`. Closes #382.
+- **Thumbnail proxy blocks SVG content type** — SVG files can contain embedded JavaScript. The thumbnail proxy now rejects `image/svg+xml` responses from upstream, in addition to non-image types. Closes #383.
+- **Instagram API errors no longer leak internal details** — The `/add-account` endpoint previously forwarded raw Instagram Graph API error messages (which can contain token fragments, internal endpoint paths, or OAuth details) to the client. Now logs the raw error server-side and returns one of three sanitized messages depending on the error category. Closes #384.
+- **Required secrets validated at startup** — `ENCRYPTION_KEY` or `ENCRYPTION_KEYS` is now checked during `validate_all()` at boot. Missing encryption keys previously only surfaced at runtime when an OAuth flow tried to encrypt a token. Closes #385.
+- **Auth endpoints have stricter rate limits** — OAuth start endpoints limited to 5/min, OAuth callbacks to 10/min, and `/add-account` to 5/min (down from the 30/min global default). Closes #386.
+- **CI no longer commits a test encryption key** — The hardcoded Fernet key in `.github/workflows/ci.yml` is replaced with a dynamically generated key per CI run. Closes #387.
+
 ### Fixed
 
 - **All Telegram posts failed for 5 days — session-detach race in `transaction_cleanup_loop`** — The SQLAlchemy `SessionLocal` factory in `src/config/database.py` did not set `expire_on_commit=False`, leaving it at SQLAlchemy's default of `True`. Every 30 seconds the worker's `transaction_cleanup_loop` called `end_read_transaction()` on every repo, which committed the session and (because `expire_on_commit=True`) expired every ORM instance loaded in that session. Any code path holding a `ChatSettings` instance across that 30s window — most importantly `send_notification` reading `chat_settings.caption_style` and `chat_settings.enable_instagram_api` — would raise `Instance <ChatSettings> is not bound to a Session; attribute refresh operation cannot proceed` on the next attribute access. The race was always present but masked by `chat_settings.X or env_settings.X` fallback chains; commit `7ea90ff` ("DB is source of truth for per-chat config; remove env fallbacks") removed those fallbacks and the race became a 100%-failure-rate outage. Last successful post was 2026-05-13 02:33 UTC; 909+ consecutive `send_notification` failures observed during investigation. Fix sets `expire_on_commit=False` on the session factory — for a long-running worker that fans ORM instances across services and async tasks, this is the right default. Closes #388. Pin in `tests/src/config/test_database.py` so a future flip back to the SQLAlchemy default doesn't silently re-introduce the outage.

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -3,19 +3,39 @@
 import time
 from pathlib import Path
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request, Response
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 from slowapi import _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
+from starlette.middleware.base import BaseHTTPMiddleware
 from uvicorn.middleware.proxy_headers import ProxyHeadersMiddleware
 
 from src.api.rate_limit import limiter
 from src.api.routes.oauth import router as oauth_router
 from src.api.routes.onboarding import router as onboarding_router
 from src.config.settings import settings
+
+
+class SecurityHeadersMiddleware(BaseHTTPMiddleware):
+    """Add standard security headers to every response."""
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        response = await call_next(request)
+        response.headers["X-Content-Type-Options"] = "nosniff"
+        response.headers["X-Frame-Options"] = "DENY"
+        response.headers["Strict-Transport-Security"] = (
+            "max-age=63072000; includeSubDomains"
+        )
+        response.headers["Content-Security-Policy"] = (
+            "default-src 'self'; style-src 'self' 'unsafe-inline'; "
+            "img-src 'self' data:; frame-ancestors 'none'"
+        )
+        response.headers["Referrer-Policy"] = "strict-origin-when-cross-origin"
+        return response
+
 
 _START_TIME = time.time()
 
@@ -24,6 +44,9 @@ app = FastAPI(
     description="OAuth and API endpoints for Storydump",
     version="0.1.0",
 )
+
+# Security headers — HSTS, CSP, X-Frame-Options, X-Content-Type-Options
+app.add_middleware(SecurityHeadersMiddleware)
 
 # Proxy headers — trust X-Forwarded-For/Proto from Railway's load balancer
 # so request.client.host returns the real client IP, not the proxy IP.

--- a/src/api/routes/oauth.py
+++ b/src/api/routes/oauth.py
@@ -2,9 +2,10 @@
 
 import html
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import HTMLResponse, RedirectResponse
 
+from src.api.rate_limit import limiter
 from src.api.routes.onboarding.helpers import service_error_handler
 from src.services.core.oauth_service import OAuthService
 from src.services.integrations.google_drive_oauth import GoogleDriveOAuthService
@@ -15,7 +16,9 @@ router = APIRouter(tags=["oauth"])
 
 
 @router.get("/instagram/start")
+@limiter.limit("5/minute")
 async def instagram_oauth_start(
+    request: Request,
     chat_id: int = Query(..., description="Telegram chat ID initiating the flow"),
 ):
     """
@@ -30,7 +33,9 @@ async def instagram_oauth_start(
 
 
 @router.get("/instagram/callback")
+@limiter.limit("10/minute")
 async def instagram_oauth_callback(
+    request: Request,
     code: str = Query(None, description="Authorization code from Meta"),
     state: str = Query(..., description="Signed state token"),
     error: str = Query(None, description="Error code if user denied"),
@@ -109,7 +114,9 @@ async def instagram_oauth_callback(
 
 
 @router.get("/instagram-login/callback")
+@limiter.limit("10/minute")
 async def instagram_login_oauth_callback(
+    request: Request,
     code: str = Query(None, description="Authorization code from Instagram"),
     state: str = Query(..., description="Signed state token"),
     error: str = Query(None, description="Error code if user denied"),
@@ -183,7 +190,9 @@ async def instagram_login_oauth_callback(
 
 
 @router.get("/google-drive/start")
+@limiter.limit("5/minute")
 async def google_drive_oauth_start(
+    request: Request,
     chat_id: int = Query(..., description="Telegram chat ID initiating the flow"),
 ):
     """
@@ -198,7 +207,9 @@ async def google_drive_oauth_start(
 
 
 @router.get("/google-drive/callback")
+@limiter.limit("10/minute")
 async def google_drive_oauth_callback(
+    request: Request,
     code: str = Query(None, description="Authorization code from Google"),
     state: str = Query(..., description="Signed state token"),
     error: str = Query(None, description="Error code if user denied"),

--- a/src/api/routes/onboarding/dashboard.py
+++ b/src/api/routes/onboarding/dashboard.py
@@ -558,7 +558,7 @@ async def onboarding_media_thumbnail(
         raise HTTPException(status_code=upstream.status_code, detail="Upstream error")
 
     content_type = upstream.headers.get("content-type", "")
-    if not content_type.startswith("image/"):
+    if not content_type.startswith("image/") or "svg" in content_type.lower():
         raise HTTPException(status_code=502, detail="Unexpected upstream content type")
 
     return Response(

--- a/src/api/routes/onboarding/settings.py
+++ b/src/api/routes/onboarding/settings.py
@@ -253,23 +253,24 @@ async def onboarding_queue_preview(request: InitRequest) -> dict:
 
 
 @router.post("/add-account")
-async def onboarding_add_account(request: AddAccountRequest) -> dict:
+@limiter.limit("5/minute")
+async def onboarding_add_account(request: Request, body: AddAccountRequest) -> dict:
     """Add an Instagram account via secure Mini App form.
 
     Validates credentials against Instagram Graph API, then creates
     or updates the account. Credentials are transmitted via HTTPS
     and never appear in Telegram chat history.
     """
-    _validate_request(request.init_data, request.chat_id)
+    _validate_request(body.init_data, body.chat_id)
 
     # Validate credentials against Instagram API
     try:
         async with httpx.AsyncClient() as client:
             response = await client.get(
-                f"{settings.meta_graph_base}/{request.instagram_account_id}",
+                f"{settings.meta_graph_base}/{body.instagram_account_id}",
                 params={
                     "fields": "username",
-                    "access_token": request.access_token,
+                    "access_token": body.access_token,
                 },
                 timeout=30.0,
             )
@@ -282,13 +283,23 @@ async def onboarding_add_account(request: AddAccountRequest) -> dict:
 
     if response.status_code != 200:
         error_data = response.json()
-        error_msg = error_data.get("error", {}).get("message", "Unknown error")
-        # Replace technical OAuth errors with user-friendly message
-        if "Invalid OAuth" in error_msg or "access token" in error_msg.lower():
-            error_msg = (
-                "Invalid access token. Please check it hasn't expired and try again."
+        raw_msg = error_data.get("error", {}).get("message", "")
+        logger.warning(
+            f"Instagram API rejected add-account (HTTP {response.status_code}): "
+            f"{raw_msg}"
+        )
+        # Never expose raw API error messages — they may contain token
+        # fragments, internal endpoint paths, or OAuth implementation details.
+        if response.status_code == 429:
+            detail = "Too many requests to Instagram. Please wait and try again."
+        elif "does not exist" in raw_msg.lower():
+            detail = "Instagram account not found. Please check the account ID."
+        else:
+            detail = (
+                "Invalid credentials. Please verify your account ID and "
+                "access token, then try again."
             )
-        raise HTTPException(status_code=400, detail=error_msg)
+        raise HTTPException(status_code=400, detail=detail)
 
     api_data = response.json()
     username = api_data.get("username")
@@ -301,27 +312,27 @@ async def onboarding_add_account(request: AddAccountRequest) -> dict:
     # Create or update account
     with InstagramAccountService() as account_service, service_error_handler():
         existing = account_service.get_account_by_instagram_id(
-            request.instagram_account_id
+            body.instagram_account_id
         )
 
         if existing:
             account = account_service.update_account_token(
-                instagram_account_id=request.instagram_account_id,
-                access_token=request.access_token,
+                instagram_account_id=body.instagram_account_id,
+                access_token=body.access_token,
                 instagram_username=username,
                 set_as_active=True,
-                telegram_chat_id=request.chat_id,
+                telegram_chat_id=body.chat_id,
                 auth_method=AUTH_METHOD_MANUAL,
             )
             is_update = True
         else:
             account = account_service.add_account(
-                display_name=request.display_name,
-                instagram_account_id=request.instagram_account_id,
+                display_name=body.display_name,
+                instagram_account_id=body.instagram_account_id,
                 instagram_username=username,
-                access_token=request.access_token,
+                access_token=body.access_token,
                 set_as_active=True,
-                telegram_chat_id=request.chat_id,
+                telegram_chat_id=body.chat_id,
                 auth_method=AUTH_METHOD_MANUAL,
             )
             is_update = False

--- a/src/utils/validators.py
+++ b/src/utils/validators.py
@@ -67,6 +67,24 @@ class ConfigValidator:
         if not settings.DB_NAME:
             errors.append("DB_NAME is required")
 
+        # Validate encryption keys — required for OAuth token storage.
+        # TokenEncryption defers this to first use, but a missing key at
+        # startup means every OAuth flow will fail at runtime.
+        if not settings.ENCRYPTION_KEY and not settings.ENCRYPTION_KEYS:
+            errors.append(
+                "ENCRYPTION_KEY or ENCRYPTION_KEYS is required — "
+                "OAuth token storage will fail without it"
+            )
+
+        # Validate database connectivity — catch misconfigured DATABASE_URL
+        # or missing DB_PASSWORD before the first real query fails deep in
+        # a service call.
+        if not settings.DATABASE_URL and not settings.DB_PASSWORD:
+            logger.warning(
+                "DB_PASSWORD is empty and DATABASE_URL is not set — "
+                "database connection may fail if password is required"
+            )
+
         # Validate paths — auto-create MEDIA_DIR for cloud deployments
         media_dir = Path(settings.MEDIA_DIR)
         if not media_dir.exists():

--- a/tests/src/api/conftest.py
+++ b/tests/src/api/conftest.py
@@ -6,9 +6,18 @@ from unittest.mock import Mock, patch
 from fastapi.testclient import TestClient
 
 from src.api.app import app
+from src.api.rate_limit import limiter
 
 VALID_USER = {"user_id": 12345, "first_name": "Chris"}
 CHAT_ID = -1001234567890
+
+
+@pytest.fixture(autouse=True)
+def _disable_rate_limits():
+    """Disable SlowAPI rate limiting during tests to avoid cross-test 429s."""
+    limiter.enabled = False
+    yield
+    limiter.enabled = True
 
 
 @pytest.fixture

--- a/tests/src/api/test_onboarding_dashboard.py
+++ b/tests/src/api/test_onboarding_dashboard.py
@@ -1338,7 +1338,9 @@ class TestAddAccount:
             response = self._post(client)
 
         assert response.status_code == 400
-        assert "Invalid access token" in response.json()["detail"]
+        detail = response.json()["detail"]
+        # Error must be sanitized — no raw API message, just a generic safe message
+        assert "Invalid credentials" in detail or "Invalid access token" in detail
 
     def test_add_account_non_numeric_id(self, client):
         """Non-numeric account ID rejected by Pydantic validation."""

--- a/tests/src/api/test_security_hardening.py
+++ b/tests/src/api/test_security_hardening.py
@@ -1,0 +1,256 @@
+"""Tests for security hardening: headers, thumbnail MIME, error sanitization, rate limits."""
+
+import pytest
+from unittest.mock import AsyncMock, Mock, patch, MagicMock
+
+from tests.src.api.conftest import CHAT_ID, mock_validate, service_ctx
+
+
+# =============================================================================
+# Security headers (#382)
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestSecurityHeaders:
+    """Verify security headers are set on every response."""
+
+    def test_health_endpoint_has_security_headers(self, client):
+        resp = client.get("/health")
+        assert resp.headers["X-Content-Type-Options"] == "nosniff"
+        assert resp.headers["X-Frame-Options"] == "DENY"
+        assert "max-age=" in resp.headers["Strict-Transport-Security"]
+        assert "default-src" in resp.headers["Content-Security-Policy"]
+        assert "Referrer-Policy" in resp.headers
+
+    def test_csp_blocks_frames(self, client):
+        resp = client.get("/health")
+        assert "frame-ancestors 'none'" in resp.headers["Content-Security-Policy"]
+
+    def test_hsts_includes_subdomains(self, client):
+        resp = client.get("/health")
+        assert "includeSubDomains" in resp.headers["Strict-Transport-Security"]
+
+
+# =============================================================================
+# Thumbnail proxy SVG block (#383)
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestThumbnailSvgBlock:
+    """Verify SVG content type is rejected by thumbnail proxy."""
+
+    def _mock_upstream(self, content_type="image/jpeg", status_code=200):
+        """Create a mock httpx response."""
+        resp = MagicMock()
+        resp.status_code = status_code
+        resp.headers = {"content-type": content_type}
+        resp.content = b"fake-image-bytes"
+        return resp
+
+    @patch("src.api.routes.onboarding.dashboard.MediaRepository")
+    @patch("src.api.routes.onboarding.dashboard.SettingsService")
+    def test_svg_content_type_rejected(self, mock_settings_cls, mock_media_cls, client):
+        """image/svg+xml from upstream should be rejected as 502."""
+        mock_settings_svc = service_ctx(mock_settings_cls)
+        mock_settings_svc.get_settings.return_value = Mock(id="cs-1")
+
+        mock_media_repo = service_ctx(mock_media_cls)
+        mock_item = Mock(thumbnail_url="https://lh3.example.com/thumb.svg")
+        mock_media_repo.get_by_id.return_value = mock_item
+
+        mock_resp = self._mock_upstream(content_type="image/svg+xml")
+
+        with mock_validate(
+            {"user_id": 12345, "first_name": "Chris", "chat_id": CHAT_ID}
+        ):
+            with patch(
+                "src.api.routes.onboarding.dashboard.httpx.AsyncClient"
+            ) as mock_httpx:
+                mock_client = AsyncMock()
+                mock_client.get.return_value = mock_resp
+                mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+                mock_client.__aexit__ = AsyncMock(return_value=False)
+                mock_httpx.return_value = mock_client
+
+                resp = client.get(
+                    f"/api/onboarding/media/m1/thumbnail?init_data=fake&chat_id={CHAT_ID}"
+                )
+
+        assert resp.status_code == 502
+
+    @patch("src.api.routes.onboarding.dashboard.MediaRepository")
+    @patch("src.api.routes.onboarding.dashboard.SettingsService")
+    def test_jpeg_content_type_allowed(self, mock_settings_cls, mock_media_cls, client):
+        """image/jpeg from upstream should pass through."""
+        mock_settings_svc = service_ctx(mock_settings_cls)
+        mock_settings_svc.get_settings.return_value = Mock(id="cs-1")
+
+        mock_media_repo = service_ctx(mock_media_cls)
+        mock_item = Mock(thumbnail_url="https://lh3.example.com/thumb.jpg")
+        mock_media_repo.get_by_id.return_value = mock_item
+
+        mock_resp = self._mock_upstream(content_type="image/jpeg")
+
+        with mock_validate(
+            {"user_id": 12345, "first_name": "Chris", "chat_id": CHAT_ID}
+        ):
+            with patch(
+                "src.api.routes.onboarding.dashboard.httpx.AsyncClient"
+            ) as mock_httpx:
+                mock_client = AsyncMock()
+                mock_client.get.return_value = mock_resp
+                mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+                mock_client.__aexit__ = AsyncMock(return_value=False)
+                mock_httpx.return_value = mock_client
+
+                resp = client.get(
+                    f"/api/onboarding/media/m1/thumbnail?init_data=fake&chat_id={CHAT_ID}"
+                )
+
+        assert resp.status_code == 200
+
+
+# =============================================================================
+# Error sanitization (#384)
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestAddAccountErrorSanitization:
+    """Verify Instagram API errors don't leak internal details."""
+
+    @patch("src.api.routes.onboarding.settings.InstagramAccountService")
+    def test_oauth_error_returns_generic_message(self, mock_acct_cls, client):
+        """Raw Instagram API error messages must not appear in response."""
+        mock_ig_response = Mock()
+        mock_ig_response.status_code = 400
+        mock_ig_response.json.return_value = {
+            "error": {
+                "message": "Invalid OAuth 2.0 Access Token - token=EAABsb...",
+                "type": "OAuthException",
+                "code": 190,
+            }
+        }
+
+        with mock_validate(
+            {"user_id": 12345, "first_name": "Chris", "chat_id": CHAT_ID}
+        ):
+            with patch(
+                "src.api.routes.onboarding.settings.httpx.AsyncClient"
+            ) as mock_httpx:
+                mock_client = AsyncMock()
+                mock_client.get.return_value = mock_ig_response
+                mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+                mock_client.__aexit__ = AsyncMock(return_value=False)
+                mock_httpx.return_value = mock_client
+
+                resp = client.post(
+                    "/api/onboarding/add-account",
+                    json={
+                        "init_data": "fake",
+                        "chat_id": CHAT_ID,
+                        "display_name": "Test",
+                        "instagram_account_id": "12345",
+                        "access_token": "EAABsb_fake_token",
+                    },
+                )
+
+        assert resp.status_code == 400
+        detail = resp.json()["detail"]
+        # Must NOT contain the raw token fragment or "OAuthException"
+        assert "EAABsb" not in detail
+        assert "OAuthException" not in detail
+        assert "Invalid credentials" in detail
+
+    @patch("src.api.routes.onboarding.settings.InstagramAccountService")
+    def test_not_found_error_returns_safe_message(self, mock_acct_cls, client):
+        """Account-not-found errors get a specific safe message."""
+        mock_ig_response = Mock()
+        mock_ig_response.status_code = 400
+        mock_ig_response.json.return_value = {
+            "error": {
+                "message": "Unsupported get request. Object with ID '999' does not exist",
+                "type": "GraphMethodException",
+                "code": 100,
+            }
+        }
+
+        with mock_validate(
+            {"user_id": 12345, "first_name": "Chris", "chat_id": CHAT_ID}
+        ):
+            with patch(
+                "src.api.routes.onboarding.settings.httpx.AsyncClient"
+            ) as mock_httpx:
+                mock_client = AsyncMock()
+                mock_client.get.return_value = mock_ig_response
+                mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+                mock_client.__aexit__ = AsyncMock(return_value=False)
+                mock_httpx.return_value = mock_client
+
+                resp = client.post(
+                    "/api/onboarding/add-account",
+                    json={
+                        "init_data": "fake",
+                        "chat_id": CHAT_ID,
+                        "display_name": "Test",
+                        "instagram_account_id": "999",
+                        "access_token": "fake_token",
+                    },
+                )
+
+        assert resp.status_code == 400
+        assert "not found" in resp.json()["detail"].lower()
+
+
+# =============================================================================
+# Startup validation (#385)
+# =============================================================================
+
+
+@pytest.mark.unit
+class TestStartupSecretValidation:
+    """Verify startup validation catches missing encryption keys."""
+
+    def _run_validation(self, **overrides):
+        """Run ConfigValidator.validate_all with mocked settings."""
+        from src.utils.validators import ConfigValidator
+
+        defaults = {
+            "TELEGRAM_BOT_TOKEN": "test_token",
+            "TELEGRAM_CHANNEL_ID": -1001234567890,
+            "ADMIN_TELEGRAM_CHAT_ID": -1001234567890,
+            "DB_NAME": "testdb",
+            "ENCRYPTION_KEY": "some-key",
+            "ENCRYPTION_KEYS": None,
+            "DATABASE_URL": None,
+            "DB_PASSWORD": "pass",
+            "MEDIA_DIR": "/tmp/test-media",
+        }
+        defaults.update(overrides)
+
+        with (
+            patch("src.utils.validators.settings") as mock_settings,
+            patch.object(ConfigValidator, "_check_telegram_token", return_value=None),
+        ):
+            for k, v in defaults.items():
+                setattr(mock_settings, k, v)
+            return ConfigValidator.validate_all()
+
+    def test_missing_encryption_keys_fails(self):
+        is_valid, errors = self._run_validation(
+            ENCRYPTION_KEY=None, ENCRYPTION_KEYS=None
+        )
+        assert not is_valid
+        assert any("ENCRYPTION_KEY" in e for e in errors)
+
+    def test_encryption_key_set_passes(self):
+        is_valid, errors = self._run_validation(ENCRYPTION_KEY="some-key")
+        assert is_valid
+
+    def test_encryption_keys_plural_set_passes(self):
+        is_valid, errors = self._run_validation(
+            ENCRYPTION_KEY=None, ENCRYPTION_KEYS="key1,key2"
+        )
+        assert is_valid


### PR DESCRIPTION
## Summary

Bundles 6 security audit findings into one PR:

- **#382 HTTP security headers** — `SecurityHeadersMiddleware` adds HSTS, `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, CSP (`frame-ancestors 'none'`), and `Referrer-Policy` to all responses
- **#383 Thumbnail proxy SVG block** — Rejects `image/svg+xml` from upstream (XSS vector via embedded JS in SVGs)
- **#384 Error message sanitization** — `/add-account` no longer forwards raw Instagram API error messages (which may contain token fragments or internal paths); logs server-side, returns generic safe messages
- **#385 Startup secret validation** — `ENCRYPTION_KEY` or `ENCRYPTION_KEYS` checked at boot via `ConfigValidator.validate_all()` instead of deferring to first OAuth token operation
- **#386 Auth endpoint rate limits** — OAuth start: 5/min, callbacks: 10/min, add-account: 5/min (down from 30/min global default)
- **#387 CI encryption key** — Static Fernet key replaced with dynamically generated key per CI run

Closes #382, #383, #384, #385, #386, #387

## Files changed (10 files, +368/-24)

| File | Change |
|------|--------|
| `src/api/app.py` | `SecurityHeadersMiddleware` class + registration |
| `src/api/routes/oauth.py` | `@limiter.limit` on all 5 OAuth endpoints |
| `src/api/routes/onboarding/dashboard.py` | SVG rejection in thumbnail MIME check |
| `src/api/routes/onboarding/settings.py` | Error sanitization + rate limit on add-account |
| `src/utils/validators.py` | Encryption key check at startup |
| `.github/workflows/ci.yml` | Dynamic key generation step |
| `tests/src/api/test_security_hardening.py` | 10 new tests |
| `tests/src/api/conftest.py` | Disable rate limiting in tests |
| `tests/src/api/test_onboarding_dashboard.py` | Updated assertion for sanitized error |

## Test plan

- [x] All 1847 tests pass (54.98s)
- [x] `ruff check` and `ruff format` clean on all modified files
- [x] 10 new tests covering: security headers (3), SVG block (2), error sanitization (2), startup validation (3)
- [ ] Verify security headers in production via `curl -I`
- [ ] Verify CI workflow generates key correctly on next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)