### PR TITLE
feat: add api_tokens.meta_account_id column (credential refactor phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`api_tokens.meta_account_id` column** — Phase 1 of the Instagram credential refactor (#380). Adds an explicit, indexed column on `api_tokens` to store the Meta-side identifier (Business Account ID or Instagram User ID) that issued the token. Additive only — no behavior changes, no columns removed. Migration 035. See `documentation/planning/2026-05-18-instagram-credential-refactor.md` for the full 5-PR plan.
+
 ### Security
 
 - **HTTP security headers on all API responses** — Added `SecurityHeadersMiddleware` with HSTS (`max-age=63072000; includeSubDomains`), `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, CSP (`default-src 'self'`, `frame-ancestors 'none'`), and `Referrer-Policy: strict-origin-when-cross-origin`. Closes #382.

--- a/scripts/migrations/035_credential_refactor_add_meta_account_id.sql
+++ b/scripts/migrations/035_credential_refactor_add_meta_account_id.sql
@@ -1,0 +1,22 @@
+-- Migration 035: Add meta_account_id to api_tokens
+-- Phase 1 of Instagram credential refactor (#380).
+-- Additive only — no columns removed, no behavior changed.
+--
+-- api_tokens.meta_account_id stores the Meta-side identifier
+-- (Business Account ID or Instagram User ID) that issued
+-- the OAuth token. Moves identity out of token_metadata JSONB
+-- into a proper indexed column for direct lookup.
+
+BEGIN;
+
+ALTER TABLE api_tokens
+ADD COLUMN IF NOT EXISTS meta_account_id TEXT;
+
+CREATE INDEX IF NOT EXISTS api_tokens_meta_account_id_idx
+    ON api_tokens (meta_account_id)
+    WHERE meta_account_id IS NOT NULL;
+
+INSERT INTO schema_version (version, description)
+VALUES (35, 'Add api_tokens.meta_account_id for credential refactor phase 1');
+
+COMMIT;

--- a/scripts/migrations/035_credential_refactor_add_meta_account_id.sql
+++ b/scripts/migrations/035_credential_refactor_add_meta_account_id.sql
@@ -10,7 +10,7 @@
 BEGIN;
 
 ALTER TABLE api_tokens
-ADD COLUMN IF NOT EXISTS meta_account_id TEXT;
+ADD COLUMN IF NOT EXISTS meta_account_id VARCHAR(100);
 
 CREATE INDEX IF NOT EXISTS api_tokens_meta_account_id_idx
     ON api_tokens (meta_account_id)

--- a/src/models/api_token.py
+++ b/src/models/api_token.py
@@ -43,6 +43,11 @@ class ApiToken(Base):
         index=True,
     )
 
+    # Meta-side identifier that issued this token (Business Account ID
+    # for FB Login, Instagram User ID for IG Login).  Nullable during
+    # the dual-write migration window; backfilled in phase 3.
+    meta_account_id = Column(String(100), nullable=True, index=True)
+
     # Per-tenant scoping (used by Google Drive OAuth tokens)
     chat_settings_id = Column(
         UUID(as_uuid=True),

--- a/tests/src/models/test_credential_refactor.py
+++ b/tests/src/models/test_credential_refactor.py
@@ -1,0 +1,90 @@
+"""Tests for credential refactor Phase 1 — additive schema changes."""
+
+from pathlib import Path
+
+import pytest
+
+from src.models.api_token import ApiToken
+
+
+MIGRATIONS_DIR = Path(__file__).resolve().parents[3] / "scripts" / "migrations"
+
+
+@pytest.mark.unit
+class TestMetaAccountIdColumn:
+    """Verify the meta_account_id column on ApiToken."""
+
+    def test_column_exists_on_model(self):
+        assert hasattr(ApiToken, "meta_account_id")
+
+    def test_column_is_nullable(self):
+        col = ApiToken.__table__.columns["meta_account_id"]
+        assert col.nullable is True
+
+    def test_column_type_is_string(self):
+        col = ApiToken.__table__.columns["meta_account_id"]
+        assert str(col.type) == "VARCHAR(100)"
+
+    def test_column_default_is_none(self):
+        """New tokens created without meta_account_id get NULL."""
+        token = ApiToken(
+            service_name="instagram",
+            token_type="access_token",
+            token_value="encrypted",
+            issued_at=None,
+        )
+        assert token.meta_account_id is None
+
+    def test_column_accepts_value(self):
+        token = ApiToken(
+            service_name="instagram",
+            token_type="access_token",
+            token_value="encrypted",
+            issued_at=None,
+            meta_account_id="17841400123456789",
+        )
+        assert token.meta_account_id == "17841400123456789"
+
+
+@pytest.mark.unit
+class TestMigration035:
+    """Verify migration 035 file structure."""
+
+    def test_migration_file_exists(self):
+        path = MIGRATIONS_DIR / "035_credential_refactor_add_meta_account_id.sql"
+        assert path.exists(), f"Migration file missing: {path}"
+
+    def test_migration_adds_column(self):
+        sql = (
+            MIGRATIONS_DIR / "035_credential_refactor_add_meta_account_id.sql"
+        ).read_text()
+        assert "ADD COLUMN" in sql
+        assert "meta_account_id" in sql
+
+    def test_migration_creates_index(self):
+        sql = (
+            MIGRATIONS_DIR / "035_credential_refactor_add_meta_account_id.sql"
+        ).read_text()
+        assert "CREATE INDEX" in sql
+        assert "api_tokens_meta_account_id_idx" in sql
+
+    def test_migration_is_idempotent(self):
+        """IF NOT EXISTS guards allow re-running safely."""
+        sql = (
+            MIGRATIONS_DIR / "035_credential_refactor_add_meta_account_id.sql"
+        ).read_text()
+        assert sql.count("IF NOT EXISTS") >= 2
+
+    def test_migration_uses_transaction(self):
+        sql = (
+            MIGRATIONS_DIR / "035_credential_refactor_add_meta_account_id.sql"
+        ).read_text()
+        assert "BEGIN;" in sql
+        assert "COMMIT;" in sql
+
+    def test_migration_records_schema_version(self):
+        sql = (
+            MIGRATIONS_DIR / "035_credential_refactor_add_meta_account_id.sql"
+        ).read_text()
+        assert "INSERT INTO schema_version" in sql
+        assert "35" in sql


### PR DESCRIPTION
## Summary

- Adds `meta_account_id TEXT` column to `api_tokens` table — stores the Meta-side identifier (Business Account ID for FB Login, Instagram User ID for IG Login) that issued the OAuth token
- Migration 035: additive only (`ADD COLUMN IF NOT EXISTS` + partial index), no columns removed, no behavior changed
- SQLAlchemy model updated with the new column (`nullable=True`, `String(100)`, indexed)
- 11 tests: model column properties + migration file structure

Phase 1 of the 5-PR credential refactor plan in `documentation/planning/2026-05-18-instagram-credential-refactor.md`. Next: Phase 2 (dual-write).

Closes phase 1 of #380.

## Test plan

- [x] 11 new unit tests pass (`TestMetaAccountIdColumn`, `TestMigration035`)
- [ ] Full test suite passes (no existing tests affected — additive only)
- [ ] Migration applies cleanly on Neon: `psql "$DATABASE_URL" -f scripts/migrations/035_credential_refactor_add_meta_account_id.sql`
- [ ] Verify column exists: `SELECT meta_account_id FROM api_tokens LIMIT 1;` returns NULL rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)