### PR TITLE
refactor: dashboard frontend cleanup (#340)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **`api_tokens.meta_account_id` column** — Phase 1 of the Instagram credential refactor (#380). Adds an explicit, indexed column on `api_tokens` to store the Meta-side identifier (Business Account ID or Instagram User ID) that issued the token. Additive only — no behavior changes, no columns removed. Migration 035. See `documentation/planning/2026-05-18-instagram-credential-refactor.md` for the full 5-PR plan.
 
+### Changed
+
+- **Dashboard frontend cleanup** — Lifted shared `InstagramAccount` type into `lib/types.ts` (removes duplicates from setup-wizard and accounts-tab), extracted `openOAuthWindow` helper into `lib/dashboard-api.ts` (removes duplicate OAuth-window logic from three components), added `visibilitychange` listener to auto-detect OAuth completion when the tab regains focus, and added `aria-label` to all settings toggle switches for screen reader accessibility. Closes #340.
+
 ### Security
 
 - **HTTP security headers on all API responses** — Added `SecurityHeadersMiddleware` with HSTS (`max-age=63072000; includeSubDomains`), `X-Content-Type-Options: nosniff`, `X-Frame-Options: DENY`, CSP (`default-src 'self'`, `frame-ancestors 'none'`), and `Referrer-Policy: strict-origin-when-cross-origin`. Closes #382.

--- a/landing/src/components/dashboard/settings/accounts-tab.tsx
+++ b/landing/src/components/dashboard/settings/accounts-tab.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -15,17 +15,11 @@ import {
   DialogTrigger,
   DialogClose,
 } from "@/components/ui/dialog";
-import { postApi, getApi } from "@/lib/dashboard-api";
-
-interface Account {
-  id: string;
-  display_name: string;
-  instagram_username: string;
-  is_active: boolean;
-}
+import { postApi, openOAuthWindow } from "@/lib/dashboard-api";
+import type { InstagramAccount } from "@/lib/types";
 
 interface AccountsTabProps {
-  accounts: Account[];
+  accounts: InstagramAccount[];
 }
 
 export function AccountsTab({ accounts }: AccountsTabProps) {
@@ -34,6 +28,18 @@ export function AccountsTab({ accounts }: AccountsTabProps) {
   const [connecting, setConnecting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [removingDialogOpen, setRemovingDialogOpen] = useState<string | null>(null);
+  const oauthPending = useRef(false);
+
+  useEffect(() => {
+    function onVisible() {
+      if (document.visibilityState === "visible" && oauthPending.current) {
+        oauthPending.current = false;
+        router.refresh();
+      }
+    }
+    document.addEventListener("visibilitychange", onVisible);
+    return () => document.removeEventListener("visibilitychange", onVisible);
+  }, [router]);
 
   async function switchAccount(accountId: string) {
     setError(null);
@@ -66,10 +72,8 @@ export function AccountsTab({ accounts }: AccountsTabProps) {
     setError(null);
     setConnecting(true);
     try {
-      const data = await getApi("oauth-url/instagram");
-      if (data.auth_url) {
-        window.open(data.auth_url, "_blank", "noopener,noreferrer");
-      }
+      await openOAuthWindow("instagram");
+      oauthPending.current = true;
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to connect Instagram");
     } finally {

--- a/landing/src/components/dashboard/settings/general-tab.tsx
+++ b/landing/src/components/dashboard/settings/general-tab.tsx
@@ -198,6 +198,7 @@ export function GeneralTab({ settings }: { settings: GeneralSettings }) {
                   checked={toggleState[toggle.key]}
                   onCheckedChange={() => handleToggle(toggle.key)}
                   disabled={togglingKey === toggle.key}
+                  aria-label={toggle.label}
                 />
               </div>
             </div>

--- a/landing/src/components/dashboard/settings/integrations-tab.tsx
+++ b/landing/src/components/dashboard/settings/integrations-tab.tsx
@@ -1,11 +1,11 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { postApi, getApi } from "@/lib/dashboard-api";
+import { postApi, openOAuthWindow } from "@/lib/dashboard-api";
 
 interface IntegrationsTabProps {
   gdriveConnected: boolean;
@@ -29,15 +29,25 @@ export function IntegrationsTab({
   const [disconnecting, setDisconnecting] = useState(false);
   const [connecting, setConnecting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const oauthPending = useRef(false);
+
+  useEffect(() => {
+    function onVisible() {
+      if (document.visibilityState === "visible" && oauthPending.current) {
+        oauthPending.current = false;
+        router.refresh();
+      }
+    }
+    document.addEventListener("visibilitychange", onVisible);
+    return () => document.removeEventListener("visibilitychange", onVisible);
+  }, [router]);
 
   async function connectGdrive() {
     setError(null);
     setConnecting(true);
     try {
-      const data = await getApi("oauth-url/google-drive");
-      if (data.auth_url) {
-        window.open(data.auth_url, "_blank", "noopener,noreferrer");
-      }
+      await openOAuthWindow("google-drive");
+      oauthPending.current = true;
     } catch (e) {
       setError(e instanceof Error ? e.message : "Failed to connect Google Drive");
     } finally {

--- a/landing/src/components/dashboard/setup-wizard.tsx
+++ b/landing/src/components/dashboard/setup-wizard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { CheckCircle2, Loader2, ExternalLink } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -87,7 +87,7 @@ export function SetupWizard({ initialState, initialAccounts = [] }: SetupWizardP
     initialState.schedule_configured === true && initialState.onboarding_completed
   );
 
-  async function refreshState() {
+  const refreshState = useCallback(async () => {
     setError(null);
     try {
       const data = await getApi("init");
@@ -102,7 +102,7 @@ export function SetupWizard({ initialState, initialAccounts = [] }: SetupWizardP
       setError(e instanceof Error ? e.message : "Operation failed");
       return undefined;
     }
-  }
+  }, []);
 
   async function handleOAuth(provider: "instagram" | "google-drive") {
     setError(null);
@@ -117,6 +117,16 @@ export function SetupWizard({ initialState, initialAccounts = [] }: SetupWizardP
     }
   }
 
+  const refreshAccounts = useCallback(async () => {
+    setError(null);
+    try {
+      const data = await getApi("accounts");
+      if (data?.accounts) setAccounts(data.accounts);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load accounts");
+    }
+  }, []);
+
   useEffect(() => {
     function onVisible() {
       if (document.visibilityState === "visible" && oauthPending.current) {
@@ -127,7 +137,7 @@ export function SetupWizard({ initialState, initialAccounts = [] }: SetupWizardP
     }
     document.addEventListener("visibilitychange", onVisible);
     return () => document.removeEventListener("visibilitychange", onVisible);
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [refreshState, refreshAccounts]);
 
   async function handleRefreshConnection() {
     setLoading(true);
@@ -137,16 +147,6 @@ export function SetupWizard({ initialState, initialAccounts = [] }: SetupWizardP
       await Promise.allSettled([refreshState(), refreshAccounts()]);
     } finally {
       setLoading(false);
-    }
-  }
-
-  async function refreshAccounts() {
-    setError(null);
-    try {
-      const data = await getApi("accounts");
-      if (data?.accounts) setAccounts(data.accounts);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to load accounts");
     }
   }
 

--- a/landing/src/components/dashboard/setup-wizard.tsx
+++ b/landing/src/components/dashboard/setup-wizard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { CheckCircle2, Loader2, ExternalLink } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -23,7 +23,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { postApi, getApi } from "@/lib/dashboard-api";
+import { postApi, getApi, openOAuthWindow } from "@/lib/dashboard-api";
+import type { InstagramAccount } from "@/lib/types";
 import { CategoryMixCard } from "@/components/dashboard/settings/category-mix-card";
 
 interface SetupState {
@@ -39,13 +40,6 @@ interface SetupState {
   posting_hours_end: number;
   schedule_configured?: boolean;
   onboarding_completed: boolean;
-}
-
-interface InstagramAccount {
-  id: string;
-  display_name: string;
-  instagram_username: string;
-  is_active: boolean;
 }
 
 interface SetupWizardProps {
@@ -76,6 +70,7 @@ export function SetupWizard({ initialState, initialAccounts = [] }: SetupWizardP
   const [error, setError] = useState<string | null>(null);
   const [accounts, setAccounts] = useState<InstagramAccount[]>(initialAccounts);
   const [accountActionId, setAccountActionId] = useState<string | null>(null);
+  const oauthPending = useRef(false);
 
   // Single source of truth for "Instagram connected" in this component.
   // setup_state.instagram_connected can drift from the accounts list between
@@ -113,14 +108,26 @@ export function SetupWizard({ initialState, initialAccounts = [] }: SetupWizardP
     setError(null);
     setLoading(true);
     try {
-      const data = await getApi(`oauth-url/${provider}`);
-      if (data?.auth_url) window.open(data.auth_url, "_blank", "noopener,noreferrer");
+      await openOAuthWindow(provider);
+      oauthPending.current = true;
     } catch (e) {
       setError(e instanceof Error ? e.message : "Operation failed");
     } finally {
       setLoading(false);
     }
   }
+
+  useEffect(() => {
+    function onVisible() {
+      if (document.visibilityState === "visible" && oauthPending.current) {
+        oauthPending.current = false;
+        refreshState();
+        refreshAccounts();
+      }
+    }
+    document.addEventListener("visibilitychange", onVisible);
+    return () => document.removeEventListener("visibilitychange", onVisible);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
   async function handleRefreshConnection() {
     setLoading(true);
@@ -599,7 +606,6 @@ function OAuthStep({
           <Badge variant="secondary">Not connected</Badge>
         )}
       </div>
-      {/* TODO: Add polling (setInterval + refreshState every 3s, capped at 60s) to auto-detect OAuth completion */}
       {!connected && (
         <div className="flex gap-2">
           <Button onClick={onConnect} disabled={loading}>

--- a/landing/src/lib/dashboard-api.ts
+++ b/landing/src/lib/dashboard-api.ts
@@ -27,12 +27,12 @@ export async function getApi(path: string) {
 
 /**
  * Fetch an OAuth URL for the given provider and open it in a new tab.
- * Returns the auth URL on success, or throws on failure.
+ * Throws if the backend doesn't return an auth URL.
  */
-export async function openOAuthWindow(provider: string): Promise<string> {
+export async function openOAuthWindow(provider: string): Promise<void> {
   const data = await getApi(`oauth-url/${provider}`);
-  if (data?.auth_url) {
-    window.open(data.auth_url, "_blank", "noopener,noreferrer");
+  if (!data?.auth_url) {
+    throw new Error("No auth URL returned");
   }
-  return data.auth_url;
+  window.open(data.auth_url, "_blank", "noopener,noreferrer");
 }

--- a/landing/src/lib/dashboard-api.ts
+++ b/landing/src/lib/dashboard-api.ts
@@ -24,3 +24,15 @@ export async function getApi(path: string) {
   }
   return res.json();
 }
+
+/**
+ * Fetch an OAuth URL for the given provider and open it in a new tab.
+ * Returns the auth URL on success, or throws on failure.
+ */
+export async function openOAuthWindow(provider: string): Promise<string> {
+  const data = await getApi(`oauth-url/${provider}`);
+  if (data?.auth_url) {
+    window.open(data.auth_url, "_blank", "noopener,noreferrer");
+  }
+  return data.auth_url;
+}

--- a/landing/src/lib/types.ts
+++ b/landing/src/lib/types.ts
@@ -1,3 +1,11 @@
+/** Instagram account returned by backend. */
+export interface InstagramAccount {
+  id: string;
+  display_name: string;
+  instagram_username: string;
+  is_active: boolean;
+}
+
 /** Backend instance summary returned by GET /api/instances. */
 export interface Instance {
   chat_settings_id: string;


### PR DESCRIPTION
## Summary

- Lift shared `InstagramAccount` type into `lib/types.ts` — removes duplicate interfaces from setup-wizard and accounts-tab
- Extract `openOAuthWindow` helper into `lib/dashboard-api.ts` — consolidates identical OAuth-popup logic from three components
- Add `visibilitychange` listener to auto-detect OAuth completion when the tab regains focus (replaces the TODO polling comment)
- Add `aria-label` to all settings toggle switches for screen reader accessibility

Closes #340

## Test plan

- [ ] Dashboard settings page loads without errors
- [ ] Connect Instagram / Connect Google Drive buttons open OAuth popup
- [ ] After completing OAuth in popup, switching back to tab auto-refreshes state
- [ ] Settings toggles are announced correctly by screen reader (VoiceOver / NVDA)
- [ ] Setup wizard Instagram + Google Drive OAuth flows still work end-to-end
- [ ] `npx tsc --noEmit` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)