### PR TITLE
feat(landing): SEO fundamentals — meta, sitemap, structured data

### DIFF
--- a/landing/src/app/(marketing)/setup/google-drive/page.tsx
+++ b/landing/src/app/(marketing)/setup/google-drive/page.tsx
@@ -7,8 +7,10 @@ import { Screenshot } from "@/components/setup/screenshot"
 import { CopyButton } from "@/components/setup/copy-button"
 
 export const metadata: Metadata = {
-  title: "Google Drive Setup — Storydump",
-  robots: { index: false, follow: false },
+  title: "Google Drive Setup",
+  description:
+    "Create a Google Cloud project with Drive API enabled and OAuth credentials so Storydump can read your media files for Instagram Story automation.",
+  alternates: { canonical: "/setup/google-drive" },
 }
 
 export default function GoogleDriveSetup() {

--- a/landing/src/app/(marketing)/setup/instagram/page.tsx
+++ b/landing/src/app/(marketing)/setup/instagram/page.tsx
@@ -6,8 +6,10 @@ import { Callout } from "@/components/setup/callout"
 import { Screenshot } from "@/components/setup/screenshot"
 
 export const metadata: Metadata = {
-  title: "Instagram Account Setup — Storydump",
-  robots: { index: false, follow: false },
+  title: "Instagram Business Account Setup",
+  description:
+    "How to switch your Instagram account to Business or Creator and link it to a Facebook Page for API access and automated Story posting.",
+  alternates: { canonical: "/setup/instagram" },
 }
 
 export default function InstagramSetup() {

--- a/landing/src/app/(marketing)/setup/media-organize/page.tsx
+++ b/landing/src/app/(marketing)/setup/media-organize/page.tsx
@@ -5,8 +5,10 @@ import { StepCard } from "@/components/setup/step-card"
 import { Callout } from "@/components/setup/callout"
 
 export const metadata: Metadata = {
-  title: "Organize Your Media — Storydump",
-  robots: { index: false, follow: false },
+  title: "Organize Your Media",
+  description:
+    "How to structure your Google Drive folders for Storydump. Folder layout determines content categories and posting mix for your Instagram Stories.",
+  alternates: { canonical: "/setup/media-organize" },
 }
 
 export default function MediaOrganize() {

--- a/landing/src/app/(marketing)/setup/meta-developer/page.tsx
+++ b/landing/src/app/(marketing)/setup/meta-developer/page.tsx
@@ -7,8 +7,10 @@ import { Screenshot } from "@/components/setup/screenshot"
 import { CopyButton } from "@/components/setup/copy-button"
 
 export const metadata: Metadata = {
-  title: "Meta Developer Setup — Storydump",
-  robots: { index: false, follow: false },
+  title: "Meta Developer App Setup",
+  description:
+    "Step-by-step guide to creating a Meta Developer app with Instagram Graph API permissions for automated Story publishing.",
+  alternates: { canonical: "/setup/meta-developer" },
 }
 
 export default function MetaDeveloperSetup() {

--- a/landing/src/app/(marketing)/setup/page.tsx
+++ b/landing/src/app/(marketing)/setup/page.tsx
@@ -4,8 +4,10 @@ import { ArrowRight, Clock } from "lucide-react"
 import { Checklist } from "@/components/setup/checklist"
 
 export const metadata: Metadata = {
-  title: "Getting Started — Storydump",
-  robots: { index: false, follow: false },
+  title: "Getting Started",
+  description:
+    "Set up Storydump in under an hour. Connect your Instagram Business account, Google Drive, and Telegram to start automating your Stories.",
+  alternates: { canonical: "/setup" },
 }
 
 const prerequisites = [

--- a/landing/src/app/layout.tsx
+++ b/landing/src/app/layout.tsx
@@ -17,7 +17,10 @@ const geistMono = Geist_Mono({
 })
 
 export const metadata: Metadata = {
-  title: siteConfig.name + " — " + "Keep Your Stories Alive",
+  title: {
+    template: "%s | Storydump",
+    default: siteConfig.name + " — Keep Your Stories Alive",
+  },
   description: siteConfig.description,
   keywords: siteConfig.keywords,
   authors: [{ name: "Chris Rogers", url: siteConfig.contact.portfolio }],

--- a/landing/src/app/sitemap.ts
+++ b/landing/src/app/sitemap.ts
@@ -13,6 +13,36 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 1,
     },
     {
+      url: `${siteConfig.url}/setup`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.8,
+    },
+    {
+      url: `${siteConfig.url}/setup/instagram`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.7,
+    },
+    {
+      url: `${siteConfig.url}/setup/meta-developer`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.7,
+    },
+    {
+      url: `${siteConfig.url}/setup/google-drive`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.7,
+    },
+    {
+      url: `${siteConfig.url}/setup/media-organize`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.7,
+    },
+    {
       url: `${siteConfig.url}/login`,
       lastModified: now,
       changeFrequency: "monthly",

--- a/landing/src/components/landing/features.tsx
+++ b/landing/src/components/landing/features.tsx
@@ -47,9 +47,9 @@ const features = [
 
 export function Features() {
   return (
-    <section className="bg-muted/50 py-16 md:py-24">
+    <section aria-labelledby="features-heading" className="bg-muted/50 py-16 md:py-24">
       <div className="mx-auto max-w-5xl px-4">
-        <h2 className="text-center text-3xl font-bold tracking-tight">
+        <h2 id="features-heading" className="text-center text-3xl font-bold tracking-tight">
           Features
         </h2>
         <div className="mt-12 grid gap-6 sm:grid-cols-2 lg:grid-cols-3">

--- a/landing/src/components/landing/hero.tsx
+++ b/landing/src/components/landing/hero.tsx
@@ -9,7 +9,7 @@ const trustBadges = [
 
 export function Hero() {
   return (
-    <section className="py-20 md:py-32">
+    <section aria-label="Hero" className="py-20 md:py-32">
       <div className="mx-auto max-w-5xl px-4 text-center">
         <h1 className="text-4xl font-bold tracking-tight sm:text-5xl md:text-6xl">
           Instagram Stories on Autopilot

--- a/landing/src/components/landing/how-it-works.tsx
+++ b/landing/src/components/landing/how-it-works.tsx
@@ -26,9 +26,9 @@ const steps = [
 
 export function HowItWorks() {
   return (
-    <section className="bg-muted/50 py-16 md:py-24">
+    <section aria-labelledby="how-it-works-heading" className="bg-muted/50 py-16 md:py-24">
       <div className="mx-auto max-w-5xl px-4">
-        <h2 className="text-center text-3xl font-bold tracking-tight">
+        <h2 id="how-it-works-heading" className="text-center text-3xl font-bold tracking-tight">
           How It Works
         </h2>
         <div className="relative mt-12 grid gap-8 md:grid-cols-3 md:gap-12">

--- a/landing/src/components/landing/social-proof.tsx
+++ b/landing/src/components/landing/social-proof.tsx
@@ -6,7 +6,7 @@ const stats = [
 
 export function SocialProof() {
   return (
-    <section className="border-y bg-muted/50 py-12">
+    <section aria-label="Social proof" className="border-y bg-muted/50 py-12">
       <div className="mx-auto max-w-5xl px-4">
         <div className="grid grid-cols-3 gap-4 text-center">
           {stats.map((stat) => (

--- a/landing/src/components/landing/structured-data.tsx
+++ b/landing/src/components/landing/structured-data.tsx
@@ -17,6 +17,19 @@ const softwareAppSchema = {
   },
 }
 
+const organizationSchema = {
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  name: siteConfig.name,
+  url: siteConfig.url,
+  logo: `${siteConfig.url}/og-image.png`,
+  contactPoint: {
+    "@type": "ContactPoint",
+    email: siteConfig.contact.email,
+    contactType: "customer support",
+  },
+}
+
 const faqSchema = {
   "@context": "https://schema.org",
   "@type": "FAQPage",
@@ -36,6 +49,10 @@ export function StructuredData() {
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(softwareAppSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationSchema) }}
       />
       <script
         type="application/ld+json"

--- a/landing/src/components/layout/footer.tsx
+++ b/landing/src/components/layout/footer.tsx
@@ -6,7 +6,7 @@ export function Footer() {
     <footer className="border-t py-8">
       <div className="mx-auto flex max-w-5xl flex-col items-center justify-between gap-4 px-4 text-sm text-muted-foreground sm:flex-row">
         <p>&copy; {new Date().getFullYear()} {siteConfig.name}</p>
-        <p>
+        <nav aria-label="Footer">
           Built by{" "}
           <a
             href={siteConfig.contact.portfolio}
@@ -44,7 +44,7 @@ export function Footer() {
           >
             Terms
           </Link>
-        </p>
+        </nav>
       </div>
     </footer>
   )

--- a/landing/src/config/site.ts
+++ b/landing/src/config/site.ts
@@ -10,6 +10,12 @@ export const siteConfig = {
     "instagram story scheduler",
     "social media automation",
     "telegram instagram bot",
+    "auto post instagram stories",
+    "instagram story planner",
+    "schedule instagram stories automatically",
+    "instagram content rotation",
+    "story scheduling app",
+    "instagram stories on autopilot",
   ],
   contact: {
     portfolio: "https://crog.gg",


### PR DESCRIPTION
## Summary
- Add title template (`%s | Storydump`) so subpages get distinct, crawlable titles
- Expand sitemap from 4 to 9 URLs — setup guide pages were missing entirely
- Make setup guides indexable (removed blanket `noindex`) with proper meta descriptions and canonical URLs
- Add Organization JSON-LD schema alongside existing SoftwareApplication + FAQPage
- Add 6 long-tail keywords targeting real search queries (`auto post instagram stories`, `schedule instagram stories automatically`, etc.)
- Add `aria-label`/`aria-labelledby` on landing page sections and `<nav>` landmark on footer

## Why
Setup guides are unique, helpful content that people search for ("how to set up instagram business account", "meta developer app setup"). Hiding them from Google with `noindex` was leaving organic traffic on the table. The title template fix means every page gets a unique `<title>` tag instead of inheriting the generic root title.

## Test plan
- [ ] Verify `<title>` tags render correctly on subpages (e.g. "Getting Started | Storydump")
- [ ] Check `/sitemap.xml` includes all 9 URLs
- [ ] Validate structured data at https://search.google.com/structured-data/testing-tool
- [ ] Confirm setup guide pages no longer have `noindex` meta tag in rendered HTML
- [ ] Spot-check `aria-labelledby` IDs match their heading elements