### PR TITLE
fix: auto-approved posts now post to Instagram

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Auto-approved posts now actually post to Instagram** — The scheduler's auto-approve path (for previously-posted media) recorded posts as successful in `posting_history` but never called the Instagram Graph API. Auto-approved items now go through the full Instagram posting flow (safety check, Cloudinary upload, Graph API publish) when `enable_instagram_api` is enabled. Falls back to reapproval-only recording on failure so the scheduler is never blocked.
+
 ### Added
 
 - **`api_tokens.meta_account_id` column** — Phase 1 of the Instagram credential refactor (#380). Adds an explicit, indexed column on `api_tokens` to store the Meta-side identifier (Business Account ID or Instagram User ID) that issued the token. Additive only — no behavior changes, no columns removed. Migration 035. See `documentation/planning/2026-05-18-instagram-credential-refactor.md` for the full 5-PR plan.

--- a/src/services/core/scheduler.py
+++ b/src/services/core/scheduler.py
@@ -324,7 +324,7 @@ class SchedulerService(BaseService):
 
             # Auto-approve previously-approved media (skip Telegram)
             if media_item.times_posted > 0 and triggered_by == "scheduler":
-                result = self._auto_approve(
+                result = await self._auto_approve(
                     media_item, chat_settings, sent_at_override=sent_at_override
                 )
                 self.set_result_summary(
@@ -492,7 +492,7 @@ class SchedulerService(BaseService):
                 f"network outage. Last error: {error_message}"
             )
 
-    def _auto_approve(
+    async def _auto_approve(
         self,
         media_item,
         chat_settings,
@@ -501,7 +501,10 @@ class SchedulerService(BaseService):
         """Auto-approve a previously-approved media item without Telegram interaction.
 
         Creates a transient queue item, records history, applies a repost lock,
-        and increments times_posted. Sends a quiet log notification to Telegram.
+        and increments times_posted.
+
+        When Instagram API is enabled, uploads to Cloudinary and posts via the
+        Graph API. Falls back to reapproval-only on failure.
         """
         from src.repositories.history_repository import HistoryCreateParams
 
@@ -517,6 +520,16 @@ class SchedulerService(BaseService):
         )
         queue_id = str(queue_item.id)
 
+        posting_method = "auto_reapproval"
+        instagram_story_id = None
+
+        # Post to Instagram when API is enabled
+        if chat_settings.enable_instagram_api and not chat_settings.dry_run_mode:
+            ig_result = await self._auto_approve_instagram(media_item, chat_settings)
+            if ig_result:
+                posting_method = "instagram_api"
+                instagram_story_id = ig_result
+
         self.history_repo.create(
             HistoryCreateParams(
                 media_item_id=media_id,
@@ -527,7 +540,8 @@ class SchedulerService(BaseService):
                 posted_at=now,
                 status="posted",
                 success=True,
-                posting_method="auto_reapproval",
+                posting_method=posting_method,
+                instagram_story_id=instagram_story_id,
                 chat_settings_id=cs_id,
             )
         )
@@ -547,9 +561,15 @@ class SchedulerService(BaseService):
             chat_settings.telegram_chat_id, sent_at_override or now
         )
 
+        method_label = (
+            f"instagram_api (story_id={instagram_story_id})"
+            if posting_method == "instagram_api"
+            else "auto_reapproval"
+        )
         logger.info(
             f"Auto-approved returning media: {media_item.file_name} "
-            f"[{media_item.category}] (posted {media_item.times_posted}x before)"
+            f"[{media_item.category}] (posted {media_item.times_posted}x before, "
+            f"method={method_label})"
         )
 
         return {
@@ -561,6 +581,91 @@ class SchedulerService(BaseService):
             "category": media_item.category,
             "error": None,
         }
+
+    async def _auto_approve_instagram(
+        self,
+        media_item,
+        chat_settings,
+    ) -> Optional[str]:
+        """Post auto-approved media to Instagram.
+
+        Runs safety check, uploads to Cloudinary, posts via Graph API,
+        cleans up Cloudinary. Returns story_id on success, None on failure.
+        """
+        from src.services.integrations.cloud_storage import (
+            CloudStorageService,
+            CLOUD_UPLOAD_FOLDER,
+        )
+        from src.services.integrations.instagram_api import InstagramAPIService
+        from src.services.media_sources.factory import MediaSourceFactory
+
+        instagram_service = InstagramAPIService()
+        cloud_service = CloudStorageService()
+        cloud_public_id = None
+
+        try:
+            safety = instagram_service.safety_check_before_post(
+                telegram_chat_id=chat_settings.telegram_chat_id
+            )
+            if not safety["safe_to_post"]:
+                logger.warning(
+                    f"Auto-approve Instagram safety check failed: {safety['errors']}"
+                )
+                return None
+
+            provider = MediaSourceFactory.get_provider_for_media_item(
+                media_item, telegram_chat_id=chat_settings.telegram_chat_id
+            )
+            file_bytes = provider.download_file(media_item.source_identifier)
+
+            folder = f"{CLOUD_UPLOAD_FOLDER}/{chat_settings.id}"
+            upload_result = cloud_service.upload_media(
+                file_bytes=file_bytes,
+                filename=media_item.file_name,
+                folder=folder,
+            )
+            cloud_url = upload_result.get("url")
+            cloud_public_id = upload_result.get("public_id")
+
+            if not cloud_url:
+                logger.warning("Auto-approve Cloudinary upload returned no URL")
+                return None
+
+            media_type = (
+                "VIDEO"
+                if media_item.file_path
+                and media_item.file_path.lower().endswith((".mp4", ".mov"))
+                else "IMAGE"
+            )
+            story_url = (
+                cloud_service.get_story_optimized_url(cloud_url)
+                if media_type == "IMAGE"
+                else cloud_url
+            )
+
+            post_result = await instagram_service.post_story(
+                media_url=story_url,
+                media_type=media_type,
+                telegram_chat_id=chat_settings.telegram_chat_id,
+            )
+
+            return post_result.get("story_id")
+
+        except Exception as e:
+            logger.warning(
+                f"Auto-approve Instagram posting failed for "
+                f"{media_item.file_name}, falling back to reapproval: {e}"
+            )
+            return None
+
+        finally:
+            if cloud_public_id:
+                try:
+                    cloud_service.delete_media(cloud_public_id)
+                except Exception:
+                    pass
+            instagram_service.close()
+            cloud_service.close()
 
     # ------------------------------------------------------------------
     # Internal: slot timing

--- a/src/services/core/scheduler.py
+++ b/src/services/core/scheduler.py
@@ -523,7 +523,6 @@ class SchedulerService(BaseService):
         posting_method = "auto_reapproval"
         instagram_story_id = None
 
-        # Post to Instagram when API is enabled
         if chat_settings.enable_instagram_api and not chat_settings.dry_run_mode:
             ig_result = await self._auto_approve_instagram(media_item, chat_settings)
             if ig_result:
@@ -561,15 +560,11 @@ class SchedulerService(BaseService):
             chat_settings.telegram_chat_id, sent_at_override or now
         )
 
-        method_label = (
-            f"instagram_api (story_id={instagram_story_id})"
-            if posting_method == "instagram_api"
-            else "auto_reapproval"
-        )
         logger.info(
             f"Auto-approved returning media: {media_item.file_name} "
             f"[{media_item.category}] (posted {media_item.times_posted}x before, "
-            f"method={method_label})"
+            f"method={posting_method}"
+            f"{f', story_id={instagram_story_id}' if instagram_story_id else ''})"
         )
 
         return {

--- a/tests/src/services/test_scheduler.py
+++ b/tests/src/services/test_scheduler.py
@@ -42,6 +42,8 @@ def _make_chat_settings(
     telegram_chat_id=-100123,
     settings_id=None,
     posting_timezone=None,
+    enable_instagram_api=False,
+    dry_run_mode=False,
 ):
     """Helper to build a mock chat_settings object."""
     cs = Mock()
@@ -53,6 +55,8 @@ def _make_chat_settings(
     cs.telegram_chat_id = telegram_chat_id
     cs.id = settings_id or uuid4()
     cs.posting_timezone = posting_timezone
+    cs.enable_instagram_api = enable_instagram_api
+    cs.dry_run_mode = dry_run_mode
     return cs
 
 
@@ -1020,7 +1024,7 @@ class TestAutoApproval:
         cs = _make_chat_settings()
 
         with patch("src.services.core.media_lock.MediaLockService") as MockLock:
-            result = scheduler_service._auto_approve(media, cs)
+            result = await scheduler_service._auto_approve(media, cs)
 
         assert result["posted"] is True
         assert result["auto_approved"] is True
@@ -1028,6 +1032,229 @@ class TestAutoApproval:
         scheduler_service.media_repo.increment_times_posted.assert_called_once()
         MockLock.return_value.create_lock.assert_called_once()
         scheduler_service.queue_repo.delete.assert_called_once()
+
+
+# ------------------------------------------------------------------
+# Auto-approve Instagram posting
+# ------------------------------------------------------------------
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestAutoApproveInstagram:
+    """Tests for Instagram posting within the auto-approve flow."""
+
+    @pytest.fixture
+    def scheduler_service(self):
+        with patch.object(SchedulerService, "__init__", lambda self: None):
+            service = SchedulerService()
+            service.media_repo = Mock()
+            service.queue_repo = Mock()
+            service.history_repo = Mock()
+            service.lock_repo = Mock()
+            service.category_mix_repo = Mock()
+            service.settings_service = Mock()
+            service.telegram_service = AsyncMock()
+            service.service_run_repo = Mock()
+            service.service_name = "SchedulerService"
+            service.SCHEDULE_JITTER_MINUTES = 30
+            service.track_execution = mock_track_execution
+            service.set_result_summary = Mock()
+            return service
+
+    async def test_posts_to_instagram_when_enabled(self, scheduler_service):
+        """Auto-approve calls Instagram API when enable_instagram_api is True."""
+        media = Mock(
+            id=uuid4(),
+            file_name="meme.jpg",
+            file_path="meme.jpg",
+            category="memes",
+            times_posted=3,
+            source_identifier="test/meme.jpg",
+            mime_type="image/jpeg",
+        )
+        queue_item = Mock(id=uuid4())
+        scheduler_service.queue_repo.create.return_value = queue_item
+        cs = _make_chat_settings(enable_instagram_api=True)
+
+        mock_ig = Mock()
+        mock_ig.safety_check_before_post.return_value = {
+            "safe_to_post": True,
+            "errors": [],
+        }
+        mock_ig.post_story = AsyncMock(
+            return_value={
+                "success": True,
+                "story_id": "17890012345678901",
+            }
+        )
+
+        mock_cloud = Mock()
+        mock_cloud.upload_media.return_value = {
+            "url": "https://res.cloudinary.com/test/image/upload/v1/test.jpg",
+            "public_id": "test/meme",
+        }
+        mock_cloud.get_story_optimized_url.return_value = (
+            "https://res.cloudinary.com/test/image/upload/transformed/test.jpg"
+        )
+
+        mock_provider = Mock()
+        mock_provider.download_file.return_value = b"fake-bytes"
+
+        with (
+            patch("src.services.core.media_lock.MediaLockService"),
+            patch(
+                "src.services.integrations.instagram_api.InstagramAPIService",
+                return_value=mock_ig,
+            ),
+            patch(
+                "src.services.integrations.cloud_storage.CloudStorageService",
+                return_value=mock_cloud,
+            ),
+            patch(
+                "src.services.media_sources.factory.MediaSourceFactory"
+            ) as mock_factory,
+        ):
+            mock_factory.get_provider_for_media_item.return_value = mock_provider
+            result = await scheduler_service._auto_approve(media, cs)
+
+        assert result["posted"] is True
+        params = scheduler_service.history_repo.create.call_args[0][0]
+        assert params.posting_method == "instagram_api"
+        assert params.instagram_story_id == "17890012345678901"
+        mock_ig.post_story.assert_awaited_once()
+        mock_cloud.delete_media.assert_called_once_with("test/meme")
+
+    async def test_falls_back_to_reapproval_on_safety_failure(self, scheduler_service):
+        """Falls back to auto_reapproval when safety check fails."""
+        media = Mock(
+            id=uuid4(),
+            file_name="meme.jpg",
+            file_path="meme.jpg",
+            category="memes",
+            times_posted=3,
+        )
+        queue_item = Mock(id=uuid4())
+        scheduler_service.queue_repo.create.return_value = queue_item
+        cs = _make_chat_settings(enable_instagram_api=True)
+
+        mock_ig = Mock()
+        mock_ig.safety_check_before_post.return_value = {
+            "safe_to_post": False,
+            "errors": ["No valid token"],
+        }
+
+        with (
+            patch("src.services.core.media_lock.MediaLockService"),
+            patch(
+                "src.services.integrations.instagram_api.InstagramAPIService",
+                return_value=mock_ig,
+            ),
+            patch("src.services.integrations.cloud_storage.CloudStorageService"),
+            patch("src.services.media_sources.factory.MediaSourceFactory"),
+        ):
+            result = await scheduler_service._auto_approve(media, cs)
+
+        assert result["posted"] is True
+        params = scheduler_service.history_repo.create.call_args[0][0]
+        assert params.posting_method == "auto_reapproval"
+        assert params.instagram_story_id is None
+
+    async def test_falls_back_on_instagram_api_error(self, scheduler_service):
+        """Falls back to auto_reapproval when Instagram API raises an error."""
+        from src.exceptions.instagram import InstagramAPIError
+
+        media = Mock(
+            id=uuid4(),
+            file_name="meme.jpg",
+            file_path="meme.jpg",
+            category="memes",
+            times_posted=3,
+            source_identifier="test/meme.jpg",
+            mime_type="image/jpeg",
+        )
+        queue_item = Mock(id=uuid4())
+        scheduler_service.queue_repo.create.return_value = queue_item
+        cs = _make_chat_settings(enable_instagram_api=True)
+
+        mock_ig = Mock()
+        mock_ig.safety_check_before_post.return_value = {
+            "safe_to_post": True,
+            "errors": [],
+        }
+        mock_ig.post_story = AsyncMock(
+            side_effect=InstagramAPIError("Container failed")
+        )
+
+        mock_cloud = Mock()
+        mock_cloud.upload_media.return_value = {
+            "url": "https://example.com/img.jpg",
+            "public_id": "test/meme",
+        }
+        mock_cloud.get_story_optimized_url.return_value = "https://example.com/img.jpg"
+
+        mock_provider = Mock()
+        mock_provider.download_file.return_value = b"fake-bytes"
+
+        with (
+            patch("src.services.core.media_lock.MediaLockService"),
+            patch(
+                "src.services.integrations.instagram_api.InstagramAPIService",
+                return_value=mock_ig,
+            ),
+            patch(
+                "src.services.integrations.cloud_storage.CloudStorageService",
+                return_value=mock_cloud,
+            ),
+            patch(
+                "src.services.media_sources.factory.MediaSourceFactory"
+            ) as mock_factory,
+        ):
+            mock_factory.get_provider_for_media_item.return_value = mock_provider
+            result = await scheduler_service._auto_approve(media, cs)
+
+        assert result["posted"] is True
+        params = scheduler_service.history_repo.create.call_args[0][0]
+        assert params.posting_method == "auto_reapproval"
+        mock_cloud.delete_media.assert_called_once_with("test/meme")
+
+    async def test_skips_instagram_when_disabled(self, scheduler_service):
+        """Does not attempt Instagram posting when enable_instagram_api is False."""
+        media = Mock(
+            id=uuid4(),
+            file_name="meme.jpg",
+            category="memes",
+            times_posted=3,
+        )
+        queue_item = Mock(id=uuid4())
+        scheduler_service.queue_repo.create.return_value = queue_item
+        cs = _make_chat_settings(enable_instagram_api=False)
+
+        with patch("src.services.core.media_lock.MediaLockService"):
+            result = await scheduler_service._auto_approve(media, cs)
+
+        assert result["posted"] is True
+        params = scheduler_service.history_repo.create.call_args[0][0]
+        assert params.posting_method == "auto_reapproval"
+
+    async def test_skips_instagram_in_dry_run(self, scheduler_service):
+        """Does not post to Instagram when dry_run_mode is True."""
+        media = Mock(
+            id=uuid4(),
+            file_name="meme.jpg",
+            category="memes",
+            times_posted=3,
+        )
+        queue_item = Mock(id=uuid4())
+        scheduler_service.queue_repo.create.return_value = queue_item
+        cs = _make_chat_settings(enable_instagram_api=True, dry_run_mode=True)
+
+        with patch("src.services.core.media_lock.MediaLockService"):
+            result = await scheduler_service._auto_approve(media, cs)
+
+        assert result["posted"] is True
+        params = scheduler_service.history_repo.create.call_args[0][0]
+        assert params.posting_method == "auto_reapproval"
 
 
 # ------------------------------------------------------------------
@@ -1225,7 +1452,7 @@ class TestCatchupAfterRestart:
         cs = _make_chat_settings()
 
         with patch("src.services.core.media_lock.MediaLockService"):
-            service._auto_approve(media, cs, sent_at_override=override_time)
+            await service._auto_approve(media, cs, sent_at_override=override_time)
 
         service.settings_service.update_last_post_sent_at.assert_called_once_with(
             cs.telegram_chat_id, override_time


### PR DESCRIPTION
## Summary

- The scheduler's `_auto_approve()` path recorded returning media (times_posted > 0) as "posted" in `posting_history` but **never called the Instagram Graph API** — content was silently marked successful without actually being published to Instagram.
- Auto-approved items now run the full Instagram posting flow (safety check → Cloudinary upload → Graph API container creation → publish → cleanup) when `enable_instagram_api` is True.
- Falls back to `auto_reapproval` recording on any failure (safety check, API error, upload failure) so the scheduler is never blocked.
- Respects `dry_run_mode` — skips Instagram posting when dry run is active.

## Root cause

`_auto_approve()` was written for Phase 1 (Telegram-only) and never updated for Phase 2 (Instagram API). The method created a history record with `posting_method="auto_reapproval"` and `success=True`, then moved on — no Cloudinary upload, no Graph API call, no actual Instagram post.

## Test plan

- [x] Existing auto-approve tests updated for async (method signature changed from sync to async)
- [x] New test: posts to Instagram when `enable_instagram_api=True` — verifies full flow (safety check, upload, API call, cleanup)
- [x] New test: falls back to `auto_reapproval` when safety check fails
- [x] New test: falls back to `auto_reapproval` on Instagram API error
- [x] New test: skips Instagram when `enable_instagram_api=False`
- [x] New test: skips Instagram in `dry_run_mode`
- [x] All 77 scheduler tests pass
- [x] Lint clean (`ruff check` + `ruff format --check`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)