### PR TITLE
feat: upgrade dashboard empty states with icons and CTAs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Dashboard empty states upgraded with icons and CTAs** — Replaced plain "No activity yet" / "No media items found" / "No posting data yet" text with a reusable `EmptyState` component featuring a Lucide icon, descriptive message, and action button where applicable (e.g., "Go to Settings", "Upload Media"). Applied to recent activity, posting chart, category breakdown, media grid, and dead content chart.
+
 ### Fixed
 
 - **Auto-approved posts now actually post to Instagram** — The scheduler's auto-approve path (for previously-posted media) recorded posts as successful in `posting_history` but never called the Instagram Graph API. Auto-approved items now go through the full Instagram posting flow (safety check, Cloudinary upload, Graph API publish) when `enable_instagram_api` is enabled. Falls back to reapproval-only recording on failure so the scheduler is never blocked.

--- a/landing/src/components/dashboard/category-breakdown.tsx
+++ b/landing/src/components/dashboard/category-breakdown.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { Layers } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { EmptyState } from "@/components/dashboard/empty-state";
 
 interface CategoryData {
   category: string;
@@ -19,9 +21,11 @@ export function CategoryBreakdown({ categories }: { categories: CategoryData[] }
       </CardHeader>
       <CardContent>
         {categories.length === 0 ? (
-          <p className="text-sm text-muted-foreground py-4 text-center">
-            No category data yet.
-          </p>
+          <EmptyState
+            icon={Layers}
+            title="No category data yet"
+            description="Category performance appears after your first posts."
+          />
         ) : (
           <div className="space-y-4">
             {categories.map((cat) => {

--- a/landing/src/components/dashboard/empty-state.tsx
+++ b/landing/src/components/dashboard/empty-state.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { type LucideIcon } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
@@ -24,7 +25,7 @@ export function EmptyState({ icon: Icon, title, description, action }: EmptyStat
         <div className="mt-4">
           {action.href ? (
             <Button variant="outline" size="sm" asChild>
-              <a href={action.href}>{action.label}</a>
+              <Link href={action.href}>{action.label}</Link>
             </Button>
           ) : (
             <Button variant="outline" size="sm" onClick={action.onClick}>

--- a/landing/src/components/dashboard/empty-state.tsx
+++ b/landing/src/components/dashboard/empty-state.tsx
@@ -1,0 +1,38 @@
+import { type LucideIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface EmptyStateProps {
+  icon: LucideIcon;
+  title: string;
+  description: string;
+  action?: {
+    label: string;
+    href?: string;
+    onClick?: () => void;
+  };
+}
+
+export function EmptyState({ icon: Icon, title, description, action }: EmptyStateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-center">
+      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-muted mb-4">
+        <Icon className="h-6 w-6 text-muted-foreground" />
+      </div>
+      <h3 className="text-sm font-medium">{title}</h3>
+      <p className="text-sm text-muted-foreground mt-1 max-w-xs">{description}</p>
+      {action && (
+        <div className="mt-4">
+          {action.href ? (
+            <Button variant="outline" size="sm" asChild>
+              <a href={action.href}>{action.label}</a>
+            </Button>
+          ) : (
+            <Button variant="outline" size="sm" onClick={action.onClick}>
+              {action.label}
+            </Button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/landing/src/components/dashboard/media/dead-content-chart.tsx
+++ b/landing/src/components/dashboard/media/dead-content-chart.tsx
@@ -9,12 +9,14 @@ import {
   Tooltip,
   CartesianGrid,
 } from "recharts";
+import { Sparkles } from "lucide-react";
 import {
   Card,
   CardContent,
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import { EmptyState } from "@/components/dashboard/empty-state";
 
 interface CategoryDead {
   category: string;
@@ -30,9 +32,11 @@ export function DeadContentChart({ data }: { data: CategoryDead[] }) {
           <CardTitle className="text-base">Dead Content by Category</CardTitle>
         </CardHeader>
         <CardContent>
-          <p className="text-sm text-muted-foreground py-8 text-center">
-            No dead content found.
-          </p>
+          <EmptyState
+            icon={Sparkles}
+            title="No dead content"
+            description="All your content is getting posted. Nice work!"
+          />
         </CardContent>
       </Card>
     );

--- a/landing/src/components/dashboard/media/media-grid.tsx
+++ b/landing/src/components/dashboard/media/media-grid.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { ImageOff } from "lucide-react";
 import { getApi } from "@/lib/dashboard-api";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/dashboard/empty-state";
 import {
   Card,
   CardContent,
@@ -134,9 +136,14 @@ export function MediaGrid({
         )}
       >
         {data.items.length === 0 ? (
-          <p className="col-span-full text-center text-sm text-muted-foreground py-12">
-            No media items found.
-          </p>
+          <div className="col-span-full">
+            <EmptyState
+              icon={ImageOff}
+              title="No media items found"
+              description="Upload your first image or connect Google Drive to get started."
+              action={{ label: "Upload Media", href: "/dashboard/media" }}
+            />
+          </div>
         ) : (
           data.items.map((item) => (
             <Card key={item.id} className="overflow-hidden">

--- a/landing/src/components/dashboard/posting-chart.tsx
+++ b/landing/src/components/dashboard/posting-chart.tsx
@@ -9,7 +9,9 @@ import {
   Tooltip,
   CartesianGrid,
 } from "recharts";
+import { BarChart3 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { EmptyState } from "@/components/dashboard/empty-state";
 
 interface DailyCount {
   date: string;
@@ -35,9 +37,11 @@ export function PostingChart({ data }: { data: DailyCount[] }) {
       </CardHeader>
       <CardContent>
         {formatted.length === 0 ? (
-          <p className="text-sm text-muted-foreground py-8 text-center">
-            No posting data yet.
-          </p>
+          <EmptyState
+            icon={BarChart3}
+            title="No posting data yet"
+            description="Chart data will appear once your first posts go out."
+          />
         ) : (
           <ResponsiveContainer width="100%" height={300}>
             <BarChart data={formatted}>

--- a/landing/src/components/dashboard/recent-activity.tsx
+++ b/landing/src/components/dashboard/recent-activity.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { Clock } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
+import { EmptyState } from "@/components/dashboard/empty-state";
 
 interface HistoryItem {
   posted_at: string;
@@ -26,9 +28,12 @@ export function RecentActivity({ items }: { items: HistoryItem[] }) {
       </CardHeader>
       <CardContent>
         {items.length === 0 ? (
-          <p className="text-sm text-muted-foreground py-4 text-center">
-            No activity yet.
-          </p>
+          <EmptyState
+            icon={Clock}
+            title="No activity yet"
+            description="Posts will appear here once your scheduler starts running."
+            action={{ label: "Go to Settings", href: "/dashboard/settings" }}
+          />
         ) : (
           <div className="space-y-3">
             {items.map((item, i) => (


### PR DESCRIPTION
## Summary

- New reusable `EmptyState` component with Lucide icon, title, description, and optional action button
- Replaced 5 plain-text empty states across dashboard components:
  - **Recent Activity**: "No activity yet" + "Go to Settings" CTA
  - **Posting Chart**: "No posting data yet" with chart icon
  - **Category Breakdown**: "No category data yet" with layers icon
  - **Media Grid**: "No media items found" + "Upload Media" CTA
  - **Dead Content Chart**: "No dead content" with positive messaging

**Before:** bare `<p>` tags with muted text, no visual hierarchy, no guidance
**After:** centered icon + message + action button that guides users to the next step

## Test plan

- [ ] View each dashboard page with no data and verify the new empty states render
- [ ] Click CTA buttons ("Go to Settings", "Upload Media") and verify they navigate correctly
- [ ] Verify empty states look correct on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)