### PR TITLE
fix: align dry_run_mode model default with code default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`dry_run_mode` model default aligned with code default** — The SQLAlchemy column default for `dry_run_mode` was `True`, contradicting the code-level `DEFAULT_DRY_RUN_MODE = False` used by the repository bootstrap. Any chat_settings row created outside the repository (raw SQL, migration, direct ORM) would silently default to dry-run mode, blocking Instagram posting. Changed model default to `False` to match.
 - **Auto-approved posts now actually post to Instagram** — The scheduler's auto-approve path (for previously-posted media) recorded posts as successful in `posting_history` but never called the Instagram Graph API. Auto-approved items now go through the full Instagram posting flow (safety check, Cloudinary upload, Graph API publish) when `enable_instagram_api` is enabled. Falls back to reapproval-only recording on failure so the scheduler is never blocked.
 
 ### Added

--- a/src/models/chat_settings.py
+++ b/src/models/chat_settings.py
@@ -36,7 +36,7 @@ class ChatSettings(Base):
     display_name = Column(String(100), nullable=True)
 
     # Operational settings
-    dry_run_mode = Column(Boolean, default=True)
+    dry_run_mode = Column(Boolean, default=False)
     enable_instagram_api = Column(Boolean, default=False)
     is_paused = Column(Boolean, default=False)
     paused_at = Column(DateTime)

--- a/tests/src/models/test_chat_settings.py
+++ b/tests/src/models/test_chat_settings.py
@@ -23,8 +23,8 @@ class TestChatSettingsModel:
     def test_telegram_chat_id_is_unique(self):
         assert ChatSettings.telegram_chat_id.unique is True
 
-    def test_dry_run_mode_defaults_to_true(self):
-        assert ChatSettings.dry_run_mode.default.arg is True
+    def test_dry_run_mode_defaults_to_false(self):
+        assert ChatSettings.dry_run_mode.default.arg is False
 
     def test_enable_instagram_api_defaults_to_false(self):
         assert ChatSettings.enable_instagram_api.default.arg is False


### PR DESCRIPTION
## Summary

- **Fixed `dry_run_mode` SQLAlchemy column default** from `True` to `False`, matching `DEFAULT_DRY_RUN_MODE = False` in `defaults.py`
- The mismatch meant any `chat_settings` row created outside the repository bootstrap (raw SQL, migration, direct ORM) would silently default to dry-run mode, blocking Instagram posting via the fresh content path (`telegram_autopost.py` line 246)
- Updated model test to assert the corrected default

## Root cause context

Instagram posting via the "Auto Post" Telegram button was broken for fresh content. The posting code path itself is correct — `telegram_autopost.py` properly chains safety check → Cloudinary upload → Instagram Graph API. But at line 246, `if ctx.chat_settings.dry_run_mode:` short-circuits to a dry-run handler that skips the API call entirely.

The **immediate blocker** is the personal chat's `dry_run_mode=TRUE` in the database — that needs to be toggled off via Telegram `/settings`. This PR fixes the model default so the mismatch can't create new dry-run-blocked chats in the future.

## Test plan

- [x] All 1939 tests pass (including updated model default assertion)
- [x] Lint clean (`ruff check` + `ruff format`)
- [ ] After merge: toggle `dry_run_mode` to `False` for the personal chat via `/settings` in Telegram

🤖 Generated with [Claude Code](https://claude.com/claude-code)