### PR TITLE
fix: register instance_manage and instance_new callback handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **"Manage Chat" and "+ New Instance" inline buttons unresponsive** — Buttons created by `/instances`, `/start` (returning user), and `/new` sent `instance_manage:{id}` and `instance_new` callback data, but neither action was registered in the Telegram callback dispatch table. Added `handle_instance_manage` (shows settings panel for the selected instance) and `instance_new` (starts onboarding flow) handlers, plus a `get_by_id()` repository method to resolve chat settings by UUID (#454).
+
 ### Changed
 
 - **Dashboard empty states upgraded with icons and CTAs** — Replaced plain "No activity yet" / "No media items found" / "No posting data yet" text with a reusable `EmptyState` component featuring a Lucide icon, descriptive message, and action button where applicable (e.g., "Go to Settings", "Upload Media"). Applied to recent activity, posting chart, category breakdown, media grid, and dead content chart.

--- a/src/repositories/chat_settings_repository.py
+++ b/src/repositories/chat_settings_repository.py
@@ -19,6 +19,16 @@ class ChatSettingsRepository(BaseRepository):
     fallback after bootstrap.
     """
 
+    def get_by_id(self, chat_settings_id: str) -> Optional[ChatSettings]:
+        """Get settings by UUID primary key."""
+        result = (
+            self.db.query(ChatSettings)
+            .filter(ChatSettings.id == chat_settings_id)
+            .first()
+        )
+        self.end_read_transaction()
+        return result
+
     def get_by_chat_id(self, telegram_chat_id: int) -> Optional[ChatSettings]:
         """Get settings for a specific chat."""
         result = (

--- a/src/services/core/telegram_service.py
+++ b/src/services/core/telegram_service.py
@@ -290,6 +290,8 @@ class TelegramService(BaseService):
             "settings_toggle": self.settings_handler.handle_settings_toggle,
             "schedule_action": self.settings_handler.handle_schedule_action,
             "schedule_confirm": self.settings_handler.handle_schedule_confirm,
+            # Instance management (telegram_settings.py)
+            "instance_manage": self.settings_handler.handle_instance_manage,
             # Account management (telegram_accounts.py)
             "switch_account": self.accounts.handle_account_switch,
             "account_remove": self.accounts.handle_account_remove_confirm,
@@ -337,6 +339,32 @@ class TelegramService(BaseService):
                 await self.accounts.handle_remove_account_menu(user, query)
             elif data == "noop":
                 await query.answer()
+            return True
+
+        elif action == "instance_new":
+            if query.message.chat.type != "private":
+                await query.answer("Use this in a DM with me.", show_alert=True)
+                return True
+
+            from src.services.core.conversation_service import ConversationService
+
+            with ConversationService() as conv_service:
+                session = conv_service.start_onboarding(str(user.id))
+
+            context.user_data["onboarding_session_id"] = str(session.id)
+
+            await query.edit_message_text(
+                "Let's set up a new instance!\n\n"
+                "What do you want to call it?\n"
+                '(e.g. "TL Enterprises", "Personal Brand")'
+            )
+
+            self.interaction_service.log_callback(
+                user_id=str(user.id),
+                callback_name="instance_new",
+                telegram_chat_id=query.message.chat_id,
+                telegram_message_id=query.message.message_id,
+            )
             return True
 
         return False

--- a/src/services/core/telegram_settings.py
+++ b/src/services/core/telegram_settings.py
@@ -215,11 +215,8 @@ class TelegramSettingsHandlers:
         """
         from src.repositories.chat_settings_repository import ChatSettingsRepository
 
-        repo = ChatSettingsRepository()
-        try:
+        with ChatSettingsRepository() as repo:
             cs = repo.get_by_id(data)
-        finally:
-            repo.close()
 
         if not cs:
             await query.answer("Instance not found.", show_alert=True)

--- a/src/services/core/telegram_settings.py
+++ b/src/services/core/telegram_settings.py
@@ -207,6 +207,36 @@ class TelegramSettingsHandlers:
         if show_answer:
             await query.answer("Setting updated!")
 
+    async def handle_instance_manage(self, data: str, user, query):
+        """Handle instance_manage callback — show settings for a specific instance.
+
+        Args:
+            data: chat_settings UUID from the callback payload.
+        """
+        from src.repositories.chat_settings_repository import ChatSettingsRepository
+
+        repo = ChatSettingsRepository()
+        try:
+            cs = repo.get_by_id(data)
+        finally:
+            repo.close()
+
+        if not cs:
+            await query.answer("Instance not found.", show_alert=True)
+            return
+
+        message, reply_markup = self.build_settings_message_and_keyboard(
+            cs.telegram_chat_id,
+            user_id=query.from_user.id,
+            is_private=query.message.chat.type == "private",
+        )
+
+        await query.edit_message_text(
+            text=message,
+            parse_mode="Markdown",
+            reply_markup=reply_markup,
+        )
+
     async def handle_settings_close(self, query):
         """Handle Close button - delete the settings message."""
         try:

--- a/tests/src/repositories/test_chat_settings_repository.py
+++ b/tests/src/repositories/test_chat_settings_repository.py
@@ -58,9 +58,7 @@ class TestChatSettingsRepository:
         assert result is mock_settings
         mock_db.add.assert_not_called()
 
-    def test_get_or_create_bootstraps_from_code_defaults(
-        self, settings_repo, mock_db
-    ):
+    def test_get_or_create_bootstraps_from_code_defaults(self, settings_repo, mock_db):
         """Test get_or_create creates a new record from src.config.defaults."""
         from src.config import defaults
 
@@ -77,9 +75,7 @@ class TestChatSettingsRepository:
         assert added_obj.telegram_chat_id == -100123
         assert added_obj.dry_run_mode is defaults.DEFAULT_DRY_RUN_MODE
         assert added_obj.posts_per_day == defaults.DEFAULT_POSTS_PER_DAY
-        assert (
-            added_obj.posting_hours_start == defaults.DEFAULT_POSTING_HOURS_START
-        )
+        assert added_obj.posting_hours_start == defaults.DEFAULT_POSTING_HOURS_START
         assert added_obj.caption_style == defaults.DEFAULT_CAPTION_STYLE
         assert added_obj.onboarding_completed is True
 
@@ -196,3 +192,24 @@ class TestChatSettingsRepository:
         result = settings_repo.get_all_sync_enabled()
 
         assert result == []
+
+    def test_get_by_id_found(self, settings_repo, mock_db):
+        """Test getting settings by UUID primary key."""
+        mock_settings = Mock(spec=ChatSettings)
+        mock_settings.id = "abc-123"
+        mock_db.query.return_value.filter.return_value.first.return_value = (
+            mock_settings
+        )
+
+        result = settings_repo.get_by_id("abc-123")
+
+        assert result is mock_settings
+        mock_db.commit.assert_called_once()  # end_read_transaction
+
+    def test_get_by_id_not_found(self, settings_repo, mock_db):
+        """Test getting settings by non-existent UUID returns None."""
+        mock_db.query.return_value.filter.return_value.first.return_value = None
+
+        result = settings_repo.get_by_id("nonexistent-uuid")
+
+        assert result is None

--- a/tests/src/services/test_telegram_service.py
+++ b/tests/src/services/test_telegram_service.py
@@ -6,7 +6,6 @@ from datetime import datetime
 from uuid import uuid4
 
 from src.config import defaults
-from src.config.settings import settings
 from src.services.core.telegram_service import TelegramService
 from src.services.core.telegram_callbacks import TelegramCallbackHandlers
 from src.services.core.telegram_autopost import TelegramAutopostHandler
@@ -503,10 +502,10 @@ class TestInlineAccountSelector:
         mock_active_account.instagram_username = "mainaccount"
 
         caption = mock_telegram_service._build_caption(
-                mock_media_item,
-                queue_item=None,
-                active_account=mock_active_account,
-            )
+            mock_media_item,
+            queue_item=None,
+            active_account=mock_active_account,
+        )
 
         assert "📸 Account: Main Account" in caption
 
@@ -520,10 +519,10 @@ class TestInlineAccountSelector:
         mock_media_item.tags = []
 
         caption = mock_telegram_service._build_caption(
-                mock_media_item,
-                queue_item=None,
-                active_account=None,  # No active account
-            )
+            mock_media_item,
+            queue_item=None,
+            active_account=None,  # No active account
+        )
 
         assert "📸 Account: Not set" in caption
 
@@ -718,8 +717,8 @@ class TestVerboseEnhancedCaption:
         mock_media.tags = []
 
         caption = mock_telegram_service._build_caption(
-                mock_media, verbose=True, active_account=None
-            )
+            mock_media, verbose=True, active_account=None
+        )
 
         assert "Click & hold image" in caption
         assert "Open Instagram" in caption
@@ -734,8 +733,8 @@ class TestVerboseEnhancedCaption:
         mock_media.tags = []
 
         caption = mock_telegram_service._build_caption(
-                mock_media, verbose=False, active_account=None
-            )
+            mock_media, verbose=False, active_account=None
+        )
 
         assert "Click & hold image" not in caption
         assert "Open Instagram" not in caption
@@ -753,8 +752,8 @@ class TestVerboseEnhancedCaption:
         mock_account.display_name = "My Brand"
 
         caption = mock_telegram_service._build_caption(
-                mock_media, verbose=False, active_account=mock_account
-            )
+            mock_media, verbose=False, active_account=mock_account
+        )
 
         assert "My Brand" in caption
 
@@ -775,8 +774,8 @@ class TestVerboseSimpleCaption:
         mock_media.tags = []
 
         caption = mock_telegram_service._build_caption(
-                mock_media, verbose=True, active_account=None
-            )
+            mock_media, verbose=True, active_account=None
+        )
 
         assert "File: image.jpg" in caption
         assert "ID:" in caption
@@ -793,8 +792,8 @@ class TestVerboseSimpleCaption:
         mock_media.tags = []
 
         caption = mock_telegram_service._build_caption(
-                mock_media, verbose=False, active_account=None
-            )
+            mock_media, verbose=False, active_account=None
+        )
 
         assert "File:" not in caption
         assert "ID:" not in caption
@@ -813,8 +812,8 @@ class TestVerboseSimpleCaption:
         mock_account.display_name = "Brand Account"
 
         caption = mock_telegram_service._build_caption(
-                mock_media, verbose=True, active_account=mock_account
-            )
+            mock_media, verbose=True, active_account=mock_account
+        )
 
         assert "Brand Account" in caption
 
@@ -862,3 +861,68 @@ class TestCleanupTransactions:
 
 # TestBuildSettingsKeyboard has been moved to test_telegram_settings.py
 # TestAccountSelectorCallbacks has been moved to test_telegram_accounts.py
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestInstanceNewSpecialCase:
+    """Tests for instance_new callback in _handle_callback_special_cases."""
+
+    async def test_dm_starts_onboarding(self, mock_telegram_service):
+        """Happy path: instance_new in DM starts onboarding session."""
+        service = mock_telegram_service
+        user = Mock(id=uuid4())
+
+        query = AsyncMock()
+        query.message.chat.type = "private"
+        query.message.chat_id = 12345
+        query.message.message_id = 42
+        query.from_user = Mock(id=99999)
+
+        context = Mock()
+        context.user_data = {}
+
+        mock_session = Mock()
+        mock_session.id = uuid4()
+
+        mock_conv_svc = Mock()
+        mock_conv_svc.start_onboarding.return_value = mock_session
+
+        mock_conv = Mock()
+        mock_conv.__enter__ = Mock(return_value=mock_conv_svc)
+        mock_conv.__exit__ = Mock(return_value=False)
+
+        with patch(
+            "src.services.core.conversation_service.ConversationService",
+            return_value=mock_conv,
+        ):
+            handled = await service._handle_callback_special_cases(
+                "instance_new", None, user, query, context
+            )
+
+        assert handled is True
+        mock_conv_svc.start_onboarding.assert_called_once_with(str(user.id))
+        assert context.user_data["onboarding_session_id"] == str(mock_session.id)
+        query.edit_message_text.assert_called_once()
+        assert "new instance" in query.edit_message_text.call_args.args[0].lower()
+
+    async def test_group_chat_rejected(self, mock_telegram_service):
+        """instance_new in a group chat shows alert and does not start onboarding."""
+        service = mock_telegram_service
+        user = Mock(id=uuid4())
+
+        query = AsyncMock()
+        query.message.chat.type = "group"
+
+        context = Mock()
+        context.user_data = {}
+
+        handled = await service._handle_callback_special_cases(
+            "instance_new", None, user, query, context
+        )
+
+        assert handled is True
+        query.answer.assert_called_once_with(
+            "Use this in a DM with me.", show_alert=True
+        )
+        query.edit_message_text.assert_not_called()

--- a/tests/src/services/test_telegram_settings.py
+++ b/tests/src/services/test_telegram_settings.py
@@ -398,3 +398,73 @@ class TestMediaSyncToggleButton:
         sync_buttons = [b for b in all_buttons if "Media Sync" in b.text]
         assert len(sync_buttons) == 1
         assert "OFF" in sync_buttons[0].text
+
+
+@pytest.mark.unit
+@pytest.mark.asyncio
+class TestHandleInstanceManage:
+    """Tests for handle_instance_manage callback handler."""
+
+    async def test_found_shows_settings(self, mock_settings_handlers):
+        """Test that a valid UUID shows the settings panel for that instance."""
+        mock_cs = Mock()
+        mock_cs.telegram_chat_id = -100999
+
+        mock_settings_handlers.service.settings_service.get_settings_display.return_value = {
+            "dry_run_mode": False,
+            "enable_instagram_api": False,
+            "is_paused": False,
+            "posts_per_day": 3,
+            "posting_hours_start": 9,
+            "posting_hours_end": 21,
+            "show_verbose_notifications": False,
+            "media_sync_enabled": False,
+            "media_source_type": None,
+            "media_source_root": None,
+        }
+        mock_settings_handlers.service.ig_account_service.get_accounts_for_display.return_value = {
+            "active_account_id": None,
+            "active_account_name": "Not selected",
+        }
+
+        query = AsyncMock()
+        query.from_user = Mock(id=12345)
+        query.message.chat.type = "private"
+        user = Mock(id=uuid4())
+
+        mock_repo = Mock()
+        mock_repo.get_by_id.return_value = mock_cs
+        mock_repo.__enter__ = Mock(return_value=mock_repo)
+        mock_repo.__exit__ = Mock(return_value=False)
+
+        with patch(
+            "src.repositories.chat_settings_repository.ChatSettingsRepository",
+            return_value=mock_repo,
+        ):
+            await mock_settings_handlers.handle_instance_manage(
+                "some-uuid", user, query
+            )
+
+        mock_repo.get_by_id.assert_called_once_with("some-uuid")
+        query.edit_message_text.assert_called_once()
+        call_kwargs = query.edit_message_text.call_args.kwargs
+        assert "Quick Setup" in call_kwargs["text"]
+
+    async def test_not_found_answers_with_alert(self, mock_settings_handlers):
+        """Test that a missing UUID shows 'Instance not found.' alert."""
+        query = AsyncMock()
+        user = Mock(id=uuid4())
+
+        mock_repo = Mock()
+        mock_repo.get_by_id.return_value = None
+        mock_repo.__enter__ = Mock(return_value=mock_repo)
+        mock_repo.__exit__ = Mock(return_value=False)
+
+        with patch(
+            "src.repositories.chat_settings_repository.ChatSettingsRepository",
+            return_value=mock_repo,
+        ):
+            await mock_settings_handlers.handle_instance_manage("bad-uuid", user, query)
+
+        query.answer.assert_called_once_with("Instance not found.", show_alert=True)
+        query.edit_message_text.assert_not_called()


### PR DESCRIPTION
## Summary

- **Fixes #454** — "Manage Chat" and "+ New Instance" inline buttons were unresponsive because their callback actions (`instance_manage`, `instance_new`) were never registered in the Telegram callback dispatch table.

- `instance_manage:{uuid}` → added to standard dispatch table. Resolves the chat_settings UUID via new `ChatSettingsRepository.get_by_id()`, then shows the settings panel for that instance.

- `instance_new` → added to `_handle_callback_special_cases()` (needs `context` for `context.user_data`). Starts the onboarding flow via `ConversationService.start_onboarding()`, same as `/new` command but triggered from a button press.

## Files changed

- `src/repositories/chat_settings_repository.py` — added `get_by_id(chat_settings_id)` lookup
- `src/services/core/telegram_settings.py` — added `handle_instance_manage(data, user, query)`
- `src/services/core/telegram_service.py` — registered `instance_manage` in dispatch table, added `instance_new` to special cases
- `CHANGELOG.md` — entry under Unreleased

## Test plan

- [x] `ruff check` passes (0 errors)
- [x] Full test suite passes (1948 passed, 16 skipped)
- [ ] Manual: tap "Manage <name>" button from `/instances` or `/start` → settings panel appears
- [ ] Manual: tap "+ New Instance" button → onboarding prompt ("What do you want to call it?")

🤖 Generated with [Claude Code](https://claude.com/claude-code)