### PR TITLE
fix(telegram): respect verbose toggle on switch; hide manual steps for Auto Post

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Telegram card "show_verbose_notifications=false" toggle no longer ignored after account switch (#465)** — `rebuild_posting_workflow` in `telegram_accounts.py` called `_build_caption()` without forwarding the `verbose=` kwarg, so the function fell back to its default of `True` and re-rendered the file name / ID / 3-step manual instructions block whenever a user clicked the account switcher and returned to a post — even when the chat had verbose notifications turned off. Now reads `chat_settings.show_verbose_notifications` up front and threads it through, matching the sibling `_batch_update_pending_captions` pattern. Regression test added.
+
+### Changed
+
+- **Telegram cards — hide 3-step manual instructions for Auto Post chats (#469)** — The "1️⃣ Click & hold image → Save / 2️⃣ Tap Open Instagram / 3️⃣ Post your story" block was rendered on every verbose card. It's only useful when Auto Post isn't available. Now hidden when the active account's `auth_method='instagram_login'` (Auto Post enabled); still shown when there's no active account or for legacy `fb_login` accounts that need the manual flow. File name + truncated ID remain visible for debugging in both modes.
+
 ### Changed
 
 - **Accounts settings — "Switch" button renamed to "Make Active"** — The button that promotes an inactive Instagram account to be the chat's active one was labeled "Switch" / "Switching…", which was ambiguous (switch what to what?). Renamed to "Make Active" / "Activating…" so it pairs cleanly with the existing green "Active" badge on the currently-selected row.

--- a/src/services/core/telegram_accounts.py
+++ b/src/services/core/telegram_accounts.py
@@ -498,20 +498,29 @@ class TelegramAccountHandlers:
 
         chat_id = query.message.chat_id
 
-        # Get active account for caption and button
-        active_account = self.service.ig_account_service.get_active_account(chat_id)
-
-        # Rebuild caption with current account
-        caption = self.service._build_caption(
-            media_item, queue_item, active_account=active_account
-        )
-
-        # Rebuild keyboard with account selector
+        # Fetch chat settings first so the caption rebuild respects the chat's
+        # show_verbose_notifications preference. Without this the rebuild path
+        # silently forced verbose=True (the _build_caption default), making the
+        # per-chat toggle no-op after account-switcher round trips.
         chat_settings = self.service.settings_service.get_settings(
             chat_id, create_if_missing=False
         )
         if not chat_settings:
             return
+        verbose = self.service._is_verbose(chat_id, chat_settings=chat_settings)
+
+        # Get active account for caption and button
+        active_account = self.service.ig_account_service.get_active_account(chat_id)
+
+        # Rebuild caption with current account
+        caption = self.service._build_caption(
+            media_item,
+            queue_item,
+            verbose=verbose,
+            active_account=active_account,
+        )
+
+        # Rebuild keyboard with account selector
         if account_count is None:
             account_count = self.service.ig_account_service.count_active_accounts()
         reply_markup = build_queue_action_keyboard(

--- a/src/services/core/telegram_notification.py
+++ b/src/services/core/telegram_notification.py
@@ -282,15 +282,26 @@ class TelegramNotificationService:
             tags_str = " ".join([f"#{tag}" for tag in media_item.tags])
             lines.append(f"\n{tags_str}")
 
-        # Verbose: debug info + workflow instructions (consistent across modes)
+        # Verbose: debug info + workflow instructions.
+        # The 3-step manual instructions are only useful when Auto Post is
+        # unavailable. For accounts connected via Instagram Login the worker
+        # publishes directly via the Graph API; the manual flow is dead
+        # weight that clutters every card. Hide the steps for those accounts;
+        # keep the file/ID debug lines whenever verbose is on so the user
+        # still has identifiers in the message.
         if verbose:
             lines.append(f"\n📝 File: {media_item.file_name}")
             lines.append(f"🆔 ID: {str(media_item.id)[:8]}")
 
-            lines.append(f"\n{'━' * 20}")
-            lines.append("1️⃣ Click & hold image → Save")
-            lines.append('2️⃣ Tap "Open Instagram" below')
-            lines.append("3️⃣ Post your story!")
+            has_auto_post = (
+                active_account is not None
+                and getattr(active_account, "auth_method", None) == "instagram_login"
+            )
+            if not has_auto_post:
+                lines.append(f"\n{'━' * 20}")
+                lines.append("1️⃣ Click & hold image → Save")
+                lines.append('2️⃣ Tap "Open Instagram" below')
+                lines.append("3️⃣ Post your story!")
 
         return "\n".join(lines)
 

--- a/tests/src/services/test_telegram_accounts.py
+++ b/tests/src/services/test_telegram_accounts.py
@@ -108,6 +108,64 @@ class TestAccountSelectorCallbacks:
         # Should call edit_message_caption to rebuild the posting workflow
         mock_query.edit_message_caption.assert_called()
 
+    async def test_rebuild_posting_workflow_respects_show_verbose_notifications(
+        self, mock_account_handlers
+    ):
+        """Regression for #465.
+
+        rebuild_posting_workflow used to call _build_caption without
+        passing verbose=, so the per-chat show_verbose_notifications=false
+        toggle was silently ignored after account-switcher round trips.
+        Now the chat's verbose preference must flow through.
+        """
+        queue_id = str(uuid4())
+
+        mock_queue_item = Mock()
+        mock_queue_item.id = queue_id
+        mock_queue_item.media_item_id = uuid4()
+        mock_account_handlers.service.queue_repo.get_by_id.return_value = (
+            mock_queue_item
+        )
+
+        mock_media_item = Mock(
+            title="Test",
+            caption=None,
+            generated_caption=None,
+            link_url=None,
+            tags=[],
+        )
+        mock_account_handlers.service.media_repo.get_by_id.return_value = (
+            mock_media_item
+        )
+
+        mock_account_handlers.service.ig_account_service = Mock()
+        mock_account_handlers.service.ig_account_service.count_active_accounts.return_value = 1
+        mock_account_handlers.service.ig_account_service.get_active_account.return_value = None
+
+        # chat_settings says verbose is OFF
+        mock_account_handlers.service.settings_service = Mock()
+        mock_account_handlers.service.settings_service.get_settings.return_value = Mock(
+            enable_instagram_api=False,
+            show_verbose_notifications=False,
+        )
+        mock_account_handlers.service._is_verbose = Mock(return_value=False)
+        mock_account_handlers.service._build_caption = Mock(return_value="caption")
+
+        mock_query = AsyncMock()
+        mock_query.message = Mock(chat_id=-100123, message_id=1)
+
+        await mock_account_handlers.rebuild_posting_workflow(queue_id, mock_query)
+
+        # The rebuild must propagate the chat's verbose preference to the
+        # caption builder. If it doesn't, _build_caption defaults to True
+        # and the verbose block re-renders despite the toggle.
+        mock_account_handlers.service._build_caption.assert_called_once()
+        _, kwargs = mock_account_handlers.service._build_caption.call_args
+        assert kwargs.get("verbose") is False, (
+            "rebuild_posting_workflow must pass verbose= from chat_settings; "
+            "omitting it causes the verbose block to re-render after switches."
+        )
+
     async def test_handle_post_account_switch_stays_in_selector(
         self, mock_account_handlers
     ):

--- a/tests/src/services/test_telegram_notification.py
+++ b/tests/src/services/test_telegram_notification.py
@@ -51,7 +51,9 @@ class TestBuildCaption:
             tags=[],
         )
 
-        result = notification_service._build_caption(media, active_account=None, caption_style="enhanced")
+        result = notification_service._build_caption(
+            media, active_account=None, caption_style="enhanced"
+        )
 
         # Enhanced caption includes "Account: Not set" for no account
         assert "Account: Not set" in result
@@ -86,7 +88,9 @@ class TestBuildCaption:
         )
         account = Mock(display_name="Main Account")
 
-        result = notification_service._build_caption(media, active_account=account, caption_style="enhanced")
+        result = notification_service._build_caption(
+            media, active_account=account, caption_style="enhanced"
+        )
 
         assert "Account: Main Account" in result
 
@@ -100,7 +104,9 @@ class TestBuildCaption:
             tags=[],
         )
 
-        result = notification_service._build_caption(media, active_account=None, caption_style="enhanced")
+        result = notification_service._build_caption(
+            media, active_account=None, caption_style="enhanced"
+        )
 
         assert "Account: Not set" in result
 
@@ -303,6 +309,55 @@ class TestBuildEnhancedCaption:
 
         assert "File:" not in result
         assert "ID:" not in result
+
+    def test_verbose_with_ig_login_account_hides_workflow_instructions(
+        self, notification_service
+    ):
+        """Active account on instagram_login has Auto Post — manual steps hidden."""
+        media = Mock(
+            title="Test",
+            caption=None,
+            generated_caption=None,
+            link_url=None,
+            tags=[],
+            file_name="image.jpg",
+            id="12345678-abcd-efgh",
+        )
+        account = Mock(display_name="GT", auth_method="instagram_login")
+
+        result = notification_service._build_enhanced_caption(
+            media, verbose=True, active_account=account
+        )
+
+        # Debug info still rendered
+        assert "File: image.jpg" in result
+        assert "ID: 12345678" in result
+        # Manual instructions suppressed for Auto Post chats
+        assert "Click & hold image" not in result
+        assert "Open Instagram" not in result
+        assert "Post your story" not in result
+
+    def test_verbose_with_fb_login_account_still_shows_workflow_instructions(
+        self, notification_service
+    ):
+        """Legacy fb_login accounts have no Auto Post — manual steps still shown."""
+        media = Mock(
+            title="Test",
+            caption=None,
+            generated_caption=None,
+            link_url=None,
+            tags=[],
+            file_name="image.jpg",
+            id="12345678-abcd-efgh",
+        )
+        account = Mock(display_name="Legacy", auth_method="fb_login")
+
+        result = notification_service._build_enhanced_caption(
+            media, verbose=True, active_account=account
+        )
+
+        assert "Click & hold image" in result
+        assert "Open Instagram" in result
 
     def test_verbose_off_still_shows_account(self, notification_service):
         """Test verbose=False still shows the account indicator."""
@@ -694,9 +749,8 @@ class TestSendNotification:
         ) as mock_factory:
             mock_factory.get_provider_for_media_item.return_value = mock_provider
 
-
             with pytest.raises(GoogleDriveAuthError, match="Token expired"):
-                    await notification_service.send_notification("some-id")
+                await notification_service.send_notification("some-id")
 
     async def test_refresh_error_converted_to_google_drive_auth_error(
         self, notification_service, mock_telegram_service
@@ -738,9 +792,8 @@ class TestSendNotification:
         ) as mock_factory:
             mock_factory.get_provider_for_media_item.return_value = mock_provider
 
-
             with pytest.raises(GoogleDriveAuthError, match="expired or revoked"):
-                    await notification_service.send_notification("some-id")
+                await notification_service.send_notification("some-id")
 
     async def test_non_auth_error_still_returns_false(
         self, notification_service, mock_telegram_service


### PR DESCRIPTION
## Summary

Two related fixes to Telegram posting card rendering, bundled because they touch the same notification path.

### #465 — `show_verbose_notifications=false` ignored after account switch

`rebuild_posting_workflow` in `telegram_accounts.py:486` called `_build_caption()` without forwarding the `verbose=` kwarg, so it defaulted to `verbose=True` and re-rendered the file name / ID / 3-step manual block whenever a user clicked the account switcher and returned to a post — silently overriding the chat's `show_verbose_notifications=false` toggle.

Fix: fetch `chat_settings` up front and thread `verbose` through to `_build_caption`. Mirrors the sibling `_batch_update_pending_captions` pattern (line 549+) that already does this correctly.

### #469 — Hide 3-step manual instructions for Auto Post chats

The "1️⃣ Click & hold image → Save / 2️⃣ Tap Open Instagram / 3️⃣ Post your story" block was rendered on every verbose card, but it's only useful when Auto Post isn't available. Now hidden when `active_account.auth_method == 'instagram_login'` (Auto Post works); still rendered when `active_account is None` or `auth_method='fb_login'` (legacy, needs the manual flow).

The `📝 File:` and `🆔 ID:` debug lines remain visible in both modes so the user still has identifiers for debugging.

## Tests

- `test_rebuild_posting_workflow_respects_show_verbose_notifications` — regression for #465, asserts `_build_caption` is called with `verbose=False` when the chat setting is false
- `test_verbose_with_ig_login_account_hides_workflow_instructions` — new for #469, asserts the manual block disappears when Auto Post is available
- `test_verbose_with_fb_login_account_still_shows_workflow_instructions` — new for #469, asserts legacy accounts still see the manual steps as a fallback

Existing tests (active_account=None, no auth_method) continue to pass because absent account = no Auto Post = manual steps shown.

## Test plan

- [x] `pytest tests/src/services/test_telegram_notification.py tests/src/services/test_telegram_accounts.py` (64 passed)
- [x] `ruff check src/services/core/telegram_*.py` (clean)
- [x] `ruff format --check` (formatted)
- [ ] Live: post a card, click account switcher, return — verbose block should not re-appear if the chat has it off
- [ ] Live: switch to an `instagram_login` account — 3-step block should disappear from new cards

Closes #465, #469.

🤖 Generated with [Claude Code](https://claude.com/claude-code)