### PR TITLE
fix(dashboard): hide Setup Wizard sidebar link when onboarding is complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Sidebar — hide "Setup Wizard" entry once onboarding is complete (#464)** — `/dashboard/setup` server-redirects to `/dashboard` when `setupState.onboarding_completed` is true, so the sidebar link silently bounced users back to Overview, looking like dead nav. The dashboard layout now fetches the init payload (with `revalidate: 60`) and passes a `showSetupWizard` boolean to `Sidebar` and `DashboardHeader`. The Setup Wizard entry is filtered out of the nav once onboarding is done. New chats with onboarding still in progress see the link as before.
+
 - **Accounts settings — "Switch" button renamed to "Make Active"** — The button that promotes an inactive Instagram account to be the chat's active one was labeled "Switch" / "Switching…", which was ambiguous (switch what to what?). Renamed to "Make Active" / "Activating…" so it pairs cleanly with the existing green "Active" badge on the currently-selected row.
 
 ### Fixed

--- a/landing/src/app/(dashboard)/layout.tsx
+++ b/landing/src/app/(dashboard)/layout.tsx
@@ -1,5 +1,6 @@
 import { redirect } from "next/navigation";
 import { getSession } from "@/lib/session";
+import { backendFetchJson } from "@/lib/backend";
 import { Sidebar } from "@/components/dashboard/sidebar";
 import { DashboardHeader } from "@/components/dashboard/header";
 
@@ -15,11 +16,22 @@ export default async function DashboardLayout({
   const session = await getSession();
   if (!session) redirect("/login");
 
+  // Hide the Setup Wizard sidebar entry once onboarding is complete —
+  // otherwise clicking it server-side redirects to /dashboard (see
+  // dashboard/setup/page.tsx), which looks like a broken link (#464).
+  const initData = await backendFetchJson(
+    "init",
+    session.activeChatId!,
+    session.userId,
+    { revalidate: 60 }
+  );
+  const showSetupWizard = !initData?.setup_state?.onboarding_completed;
+
   return (
     <div className="flex h-screen bg-background">
-      <Sidebar />
+      <Sidebar showSetupWizard={showSetupWizard} />
       <div className="flex flex-1 flex-col overflow-hidden">
-        <DashboardHeader user={session} />
+        <DashboardHeader user={session} showSetupWizard={showSetupWizard} />
         <main className="flex-1 overflow-y-auto p-6">{children}</main>
       </div>
     </div>

--- a/landing/src/components/dashboard/header.tsx
+++ b/landing/src/components/dashboard/header.tsx
@@ -9,7 +9,13 @@ import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet";
 import { Sidebar } from "@/components/dashboard/sidebar";
 
-export function DashboardHeader({ user }: { user: SessionPayload }) {
+export function DashboardHeader({
+  user,
+  showSetupWizard = true,
+}: {
+  user: SessionPayload;
+  showSetupWizard?: boolean;
+}) {
   const router = useRouter();
   const [instances, setInstances] = useState<Pick<Instance, "telegram_chat_id" | "display_name">[]>([]);
   const [switcherOpen, setSwitcherOpen] = useState(false);
@@ -69,7 +75,7 @@ export function DashboardHeader({ user }: { user: SessionPayload }) {
             </Button>
           </SheetTrigger>
           <SheetContent side="left" className="w-56 p-0">
-            <Sidebar mobile />
+            <Sidebar mobile showSetupWizard={showSetupWizard} />
           </SheetContent>
         </Sheet>
 

--- a/landing/src/components/dashboard/sidebar.tsx
+++ b/landing/src/components/dashboard/sidebar.tsx
@@ -22,8 +22,20 @@ const navItems = [
   { href: "/dashboard/analytics", label: "Analytics", icon: BarChart3 },
 ];
 
-export function Sidebar({ mobile }: { mobile?: boolean }) {
+export function Sidebar({
+  mobile,
+  showSetupWizard = true,
+}: {
+  mobile?: boolean;
+  showSetupWizard?: boolean;
+}) {
   const pathname = usePathname();
+  // Once onboarding is complete the Setup Wizard page server-redirects to
+  // /dashboard, so the link silently bounces back to Overview. Drop the
+  // entry rather than confuse the user with a no-op nav item (#464).
+  const visibleItems = showSetupWizard
+    ? navItems
+    : navItems.filter((item) => item.href !== "/dashboard/setup");
 
   return (
     <aside className={mobile ? "w-56 bg-card" : "hidden w-56 shrink-0 border-r bg-card md:block"}>
@@ -33,7 +45,7 @@ export function Sidebar({ mobile }: { mobile?: boolean }) {
         </Link>
       </div>
       <nav className="space-y-1 p-3">
-        {navItems.map((item) => {
+        {visibleItems.map((item) => {
           const active =
             item.href === "/dashboard"
               ? pathname === "/dashboard"


### PR DESCRIPTION
## Summary

The Setup Wizard sidebar nav entry pointed at \`/dashboard/setup\`, but that page server-redirects to \`/dashboard\` once \`setupState.onboarding_completed\` is true. Result: clicking the link silently bounced users back to Overview, looking like a broken nav item.

This PR hides the entry once onboarding is done.

## Approach (option A from #464)

The dashboard layout (server component) fetches the existing init payload (already used by the setup page itself) with the same \`revalidate: 60\` cache, computes \`showSetupWizard = !onboarding_completed\`, and passes the boolean to both \`Sidebar\` and \`DashboardHeader\`. The header forwards it into the mobile drawer's \`<Sidebar mobile />\`.

Sidebar filters \`navItems\` based on the prop. New chats with onboarding still in progress see the link as before — only fully-completed users see the cleaner sidebar.

## Files

| File | Change |
|---|---|
| \`landing/src/app/(dashboard)/layout.tsx\` | Fetch init, compute \`showSetupWizard\`, pass down |
| \`landing/src/components/dashboard/sidebar.tsx\` | Accept \`showSetupWizard\` prop; filter navItems |
| \`landing/src/components/dashboard/header.tsx\` | Forward \`showSetupWizard\` to mobile Sidebar |
| \`CHANGELOG.md\` | Entry under Changed |

## Test plan

- [x] \`next build\` clean — no type errors
- [ ] **Live (post-deploy)**: with completed onboarding, sidebar shows Overview / Media Library / Calendar / Settings / Analytics (no Setup Wizard); mobile drawer matches
- [ ] **Live (still onboarding)**: Setup Wizard remains visible

## Out of scope (filed in #464)

- (b) Allow re-entry to wizard in "review" mode
- (c) Build a "Setup Complete" summary page at /dashboard/setup with per-step status

Both are larger UX work; this is the smallest-diff stop-the-bleeding fix.

Closes #464.

🤖 Generated with [Claude Code](https://claude.com/claude-code)