### PR TITLE
fix(refresh): send FB app credentials when refreshing on graph.facebook.com

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Token refresh — `_call_meta_refresh` now sends FB app credentials on the `graph.facebook.com` path (#470)** — Meta exposes two refresh contracts: `graph.instagram.com/refresh_access_token` (IG Login) accepts `grant_type=ig_refresh_token` + `access_token` alone; `graph.facebook.com/.../oauth/access_token` (FB Login / legacy) requires `grant_type=fb_exchange_token`, `client_id`, `client_secret`, and `fb_exchange_token`. The previous implementation always sent IG-flavored params, so any refresh against the FB host failed with Meta error 101 "Missing client_id parameter." Now branches on the resolved URL: IG-host gets the IG payload, FB-host gets credentials. Latent fix — production currently has no `fb_login` tokens to refresh, but the bug would have fired immediately if any tenant connected via Facebook Login.
+
 ### Changed
 
 - **Accounts settings — "Switch" button renamed to "Make Active"** — The button that promotes an inactive Instagram account to be the chat's active one was labeled "Switch" / "Switching…", which was ambiguous (switch what to what?). Renamed to "Make Active" / "Activating…" so it pairs cleanly with the existing green "Active" badge on the currently-selected row.

--- a/src/services/integrations/token_refresh.py
+++ b/src/services/integrations/token_refresh.py
@@ -144,19 +144,40 @@ class TokenRefreshService(BaseService):
     ) -> httpx.Response:
         """Call Meta's token refresh endpoint.
 
+        Meta exposes two different long-lived token refresh contracts that
+        share neither parameter names nor required fields:
+
+        - `graph.instagram.com/refresh_access_token` (IG Login flow) —
+          accepts the token alone: `grant_type=ig_refresh_token` +
+          `access_token`.
+        - `graph.facebook.com/.../oauth/access_token` (FB Login / legacy
+          flow) — requires the FB-style grant + app credentials:
+          `grant_type=fb_exchange_token`, `client_id`, `client_secret`,
+          and `fb_exchange_token` (the existing long-lived token).
+
+        The previous implementation always sent the IG-flavored params,
+        so any refresh against the FB host failed with Meta error 101
+        "Missing client_id parameter." Branch on the resolved URL so
+        each host gets its expected payload.
+
         Returns:
             The HTTP response from Meta's API.
         """
         refresh_url = self._get_refresh_endpoint(instagram_account_id)
+        if refresh_url == self.IG_LOGIN_REFRESH_ENDPOINT:
+            params = {
+                "grant_type": "ig_refresh_token",
+                "access_token": current_token,
+            }
+        else:
+            params = {
+                "grant_type": "fb_exchange_token",
+                "client_id": settings.FACEBOOK_APP_ID,
+                "client_secret": settings.FACEBOOK_APP_SECRET,
+                "fb_exchange_token": current_token,
+            }
         async with httpx.AsyncClient() as client:
-            return await client.get(
-                refresh_url,
-                params={
-                    "grant_type": "ig_refresh_token",
-                    "access_token": current_token,
-                },
-                timeout=30.0,
-            )
+            return await client.get(refresh_url, params=params, timeout=30.0)
 
     def _store_refreshed_token(
         self, new_token: str, expires_in: int, instagram_account_id: Optional[str]

--- a/tests/src/services/test_token_refresh.py
+++ b/tests/src/services/test_token_refresh.py
@@ -697,3 +697,98 @@ class TestTokenRefreshService:
         )
 
     # _get_env_token tests removed in PR-7 — env-fallback path is gone.
+
+    # ==================== _call_meta_refresh Tests ====================
+
+    @pytest.mark.asyncio
+    async def test_call_meta_refresh_ig_login_uses_ig_params(self, token_service):
+        """IG Login refresh hits graph.instagram.com with the IG-style params."""
+        from src.services.integrations.token_refresh import TokenRefreshService
+
+        account = Mock(auth_method="instagram_login")
+        token_service.account_repo = Mock()
+        token_service.account_repo.get_by_id.return_value = account
+
+        with patch(
+            "src.services.integrations.token_refresh.httpx.AsyncClient"
+        ) as mock_client:
+            mock_instance = mock_client.return_value
+            mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+            mock_instance.__aexit__ = AsyncMock(return_value=False)
+            mock_instance.get = AsyncMock(return_value=Mock(status_code=200))
+
+            await token_service._call_meta_refresh("the_token", "acct-uuid")
+
+        url = mock_instance.get.call_args[0][0]
+        params = mock_instance.get.call_args[1]["params"]
+        assert url == TokenRefreshService.IG_LOGIN_REFRESH_ENDPOINT
+        assert params == {
+            "grant_type": "ig_refresh_token",
+            "access_token": "the_token",
+        }
+
+    @pytest.mark.asyncio
+    @patch("src.services.integrations.token_refresh.settings")
+    async def test_call_meta_refresh_fb_login_includes_client_credentials(
+        self, mock_settings, token_service
+    ):
+        """Regression for #470.
+
+        FB Login / legacy refresh hits graph.facebook.com, which Meta
+        rejects with error 101 "Missing client_id parameter" unless we
+        include the app credentials and use the FB-style grant_type.
+        """
+        mock_settings.FACEBOOK_APP_ID = "fb_app_123"
+        mock_settings.FACEBOOK_APP_SECRET = "fb_secret_xyz"
+        mock_settings.meta_graph_base = "https://graph.facebook.com/v21.0"
+
+        account = Mock(auth_method="fb_login")
+        token_service.account_repo = Mock()
+        token_service.account_repo.get_by_id.return_value = account
+
+        with patch(
+            "src.services.integrations.token_refresh.httpx.AsyncClient"
+        ) as mock_client:
+            mock_instance = mock_client.return_value
+            mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+            mock_instance.__aexit__ = AsyncMock(return_value=False)
+            mock_instance.get = AsyncMock(return_value=Mock(status_code=200))
+
+            await token_service._call_meta_refresh("legacy_token", "acct-uuid")
+
+        url = mock_instance.get.call_args[0][0]
+        params = mock_instance.get.call_args[1]["params"]
+        assert url == "https://graph.facebook.com/v21.0/oauth/access_token"
+        assert params == {
+            "grant_type": "fb_exchange_token",
+            "client_id": "fb_app_123",
+            "client_secret": "fb_secret_xyz",
+            "fb_exchange_token": "legacy_token",
+        }
+
+    @pytest.mark.asyncio
+    @patch("src.services.integrations.token_refresh.settings")
+    async def test_call_meta_refresh_legacy_no_account_uses_fb_params(
+        self, mock_settings, token_service
+    ):
+        """Orphan tokens (no instagram_account_id) take the FB legacy
+        branch and must still include app credentials."""
+        mock_settings.FACEBOOK_APP_ID = "fb_app_123"
+        mock_settings.FACEBOOK_APP_SECRET = "fb_secret_xyz"
+        mock_settings.meta_graph_base = "https://graph.facebook.com/v21.0"
+
+        with patch(
+            "src.services.integrations.token_refresh.httpx.AsyncClient"
+        ) as mock_client:
+            mock_instance = mock_client.return_value
+            mock_instance.__aenter__ = AsyncMock(return_value=mock_instance)
+            mock_instance.__aexit__ = AsyncMock(return_value=False)
+            mock_instance.get = AsyncMock(return_value=Mock(status_code=200))
+
+            await token_service._call_meta_refresh("orphan_token", None)
+
+        params = mock_instance.get.call_args[1]["params"]
+        assert params["client_id"] == "fb_app_123"
+        assert params["client_secret"] == "fb_secret_xyz"
+        assert params["fb_exchange_token"] == "orphan_token"
+        assert "access_token" not in params


### PR DESCRIPTION
## Summary

Meta exposes two different long-lived token refresh contracts that share neither parameter names nor required fields:

| Host | Required params |
|---|---|
| \`graph.instagram.com/refresh_access_token\` (IG Login) | \`grant_type=ig_refresh_token\` + \`access_token\` |
| \`graph.facebook.com/v{X}/oauth/access_token\` (FB Login / legacy) | \`grant_type=fb_exchange_token\` + \`client_id\` + \`client_secret\` + \`fb_exchange_token\` |

The previous \`_call_meta_refresh\` always sent the IG-flavored params, so any refresh attempt against the FB host failed with Meta error 101 "Missing client_id parameter." This PR branches on the resolved URL and sends each host the payload it expects.

## Evidence

Live error captured 2026-06-02 00:11:55 during the /investigate-app session, on an orphan legacy token attempt:

\`\`\`
Instagram token refresh failed for legacy:
  {'error': {'message': 'Missing client_id parameter.',
             'type': 'OAuthException', 'code': 101,
             'fbtrace_id': 'A0W79HZyfI1GB_OKHQXlSq3'}}
\`\`\`

## Current blast radius

Latent — production has zero \`fb_login\` tokens after the 2026-06-02 cleanup, so this path isn't currently being exercised. Fixed in place so the bug stops being a footgun for any future tenant who reconnects via Facebook Login.

## Tests

Three new test cases in \`tests/src/services/test_token_refresh.py\`:

- \`test_call_meta_refresh_ig_login_uses_ig_params\` — confirms the IG host still gets IG-style params
- \`test_call_meta_refresh_fb_login_includes_client_credentials\` — regression for #470, asserts FB host gets app credentials + \`fb_exchange_token\` (not \`access_token\`)
- \`test_call_meta_refresh_legacy_no_account_uses_fb_params\` — orphan tokens (no \`instagram_account_id\`) take the FB branch correctly

## Test plan

- [x] \`pytest tests/src/services/test_token_refresh.py\` — 35 passed (32 existing + 3 new)
- [x] \`ruff check\` clean on touched files
- [x] \`ruff format --check\` clean

Closes #470.

🤖 Generated with [Claude Code](https://claude.com/claude-code)