### PR TITLE
feat(dashboard): split KPIs by posting_method; surface failures in chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Dashboard Overview — KPIs and chart split by `posting_method` (#466)** — Previously "Total Posts / Success Rate / Skipped / Failed" lumped Instagram publish attempts together with Telegram delivery attempts, so a 958-row Telegram delivery burst in 2026-05 (see #467 postmortem) read as 1% success rate even though every actual Instagram post had succeeded. The four KPI cards now read **Posts published** (`instagram_api.posted`), **Instagram success rate** (IG posted ÷ IG attempted — Telegram delivery never enters the denominator), **Cards skipped** (`telegram_manual.skipped`), and **Delivery issues** (`telegram_manual.failed`, with hover hint). Backend `get_analytics()` now emits `ig_posted`, `ig_failed`, `ig_success_rate`, `telegram_skipped`, `telegram_failed` alongside the legacy aggregate fields (kept for back-compat). The daily-activity chart adds a red **Failed** bar to the stack so burst days are no longer invisible. New repo method `get_stats_by_method_and_status()` powers the method×status pivot.
+
 ### Fixed
 
 - **Token refresh — `_call_meta_refresh` now sends FB app credentials on the `graph.facebook.com` path (#470)** — Meta exposes two refresh contracts: `graph.instagram.com/refresh_access_token` (IG Login) accepts `grant_type=ig_refresh_token` + `access_token` alone; `graph.facebook.com/.../oauth/access_token` (FB Login / legacy) requires `grant_type=fb_exchange_token`, `client_id`, `client_secret`, and `fb_exchange_token`. The previous implementation always sent IG-flavored params, so any refresh against the FB host failed with Meta error 101 "Missing client_id parameter." Now branches on the resolved URL: IG-host gets the IG payload, FB-host gets credentials. Latent fix — production currently has no `fb_login` tokens to refresh, but the bug would have fired immediately if any tenant connected via Facebook Login.

--- a/landing/src/components/dashboard/analytics-cards.tsx
+++ b/landing/src/components/dashboard/analytics-cards.tsx
@@ -1,6 +1,8 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 interface AnalyticsSummary {
+  // Legacy lump-everything-together fields (kept for back-compat;
+  // the new cards below use the method-split fields instead).
   total_posts: number;
   posted: number;
   skipped: number;
@@ -8,29 +10,54 @@ interface AnalyticsSummary {
   failed: number;
   success_rate: number;
   avg_per_day: number;
+  // Method-split — published 2026-06 to fix #466. The legacy
+  // "Success Rate" lumped Instagram publish attempts together with
+  // Telegram delivery attempts, so a 958-row Telegram delivery burst
+  // (see #467 postmortem) showed up as a 1% success rate on the
+  // dashboard even though every actual Instagram post had succeeded.
+  ig_posted?: number;
+  ig_failed?: number;
+  ig_success_rate?: number;
+  telegram_skipped?: number;
+  telegram_failed?: number;
 }
 
 export function AnalyticsCards({ summary }: { summary: AnalyticsSummary }) {
+  // Prefer method-split values; fall back to the legacy aggregates if
+  // the backend hasn't been updated yet (older deployments). This keeps
+  // the dashboard rendering during a partial deploy window.
+  const igPosted = summary.ig_posted ?? summary.posted;
+  const igFailed = summary.ig_failed ?? 0;
+  const igRate = summary.ig_success_rate ?? summary.success_rate;
+  const tgSkipped = summary.telegram_skipped ?? summary.skipped;
+  const tgFailed = summary.telegram_failed ?? summary.failed;
+
   const cards = [
     {
-      title: "Total Posts",
-      value: summary.total_posts,
+      title: "Posts published",
+      value: igPosted,
       detail: `${summary.avg_per_day.toFixed(1)}/day avg`,
     },
     {
-      title: "Success Rate",
-      value: `${(summary.success_rate * 100).toFixed(0)}%`,
-      detail: `${summary.posted} posted`,
+      title: "Instagram success rate",
+      value: `${(igRate * 100).toFixed(0)}%`,
+      detail:
+        igFailed > 0
+          ? `${igPosted} posted / ${igFailed} failed`
+          : `${igPosted} posted`,
     },
     {
-      title: "Skipped",
-      value: summary.skipped,
-      detail: `${summary.rejected} rejected`,
-    },
-    {
-      title: "Failed",
-      value: summary.failed,
+      title: "Cards skipped",
+      value: tgSkipped,
       detail: "last 30 days",
+    },
+    {
+      title: "Delivery issues",
+      value: tgFailed,
+      detail:
+        tgFailed > 0
+          ? "telegram_manual.failed — last 30 days"
+          : "last 30 days",
     },
   ];
 

--- a/landing/src/components/dashboard/posting-chart.tsx
+++ b/landing/src/components/dashboard/posting-chart.tsx
@@ -18,6 +18,7 @@ interface DailyCount {
   posted: number;
   skipped: number;
   rejected: number;
+  failed?: number;
 }
 
 export function PostingChart({ data }: { data: DailyCount[] }) {
@@ -72,6 +73,13 @@ export function PostingChart({ data }: { data: DailyCount[] }) {
                 stackId="a"
                 fill="hsl(0, 84%, 60%)"
                 name="Rejected"
+                radius={[0, 0, 0, 0]}
+              />
+              <Bar
+                dataKey="failed"
+                stackId="a"
+                fill="hsl(0, 70%, 35%)"
+                name="Failed"
                 radius={[4, 4, 0, 0]}
               />
             </BarChart>

--- a/src/repositories/history_repository.py
+++ b/src/repositories/history_repository.py
@@ -242,6 +242,43 @@ class HistoryRepository(BaseRepository):
         self.end_read_transaction()
         return {method or "unknown": count for method, count in rows}
 
+    def get_stats_by_method_and_status(
+        self, days: int = 30, chat_settings_id: Optional[str] = None
+    ) -> dict:
+        """Count posts grouped by (posting_method, status).
+
+        The summary KPIs need to distinguish Instagram publish attempts
+        from Telegram delivery attempts so that, for example, a burst
+        of Telegram delivery failures doesn't drag the apparent
+        Instagram success rate to 1%. `get_stats_by_method` only counts
+        successful rows; this counts every row and pivots so the caller
+        can read e.g. ``result["instagram_api"]["posted"]`` directly.
+
+        Returns: ``{"instagram_api": {"posted": N, "failed": M, ...},
+                   "telegram_manual": {...}}``
+        """
+        since = datetime.now(timezone.utc) - timedelta(days=days)
+        rows = (
+            self._tenant_query(PostingHistory, chat_settings_id)
+            .with_entities(
+                PostingHistory.posting_method,
+                PostingHistory.status,
+                func.count(PostingHistory.id),
+            )
+            .filter(PostingHistory.posted_at >= since)
+            .group_by(PostingHistory.posting_method, PostingHistory.status)
+            .all()
+        )
+        self.end_read_transaction()
+
+        result: dict = {}
+        for method, status, count in rows:
+            method_key = method or "unknown"
+            if method_key not in result:
+                result[method_key] = {}
+            result[method_key][status] = count
+        return result
+
     def get_daily_counts(
         self, days: int = 30, chat_settings_id: Optional[str] = None
     ) -> list:

--- a/src/services/core/dashboard_history_queries.py
+++ b/src/services/core/dashboard_history_queries.py
@@ -57,6 +57,9 @@ class HistoryDashboardQueries:
             method_counts = self.service.history_repo.get_stats_by_method(
                 days=days, chat_settings_id=chat_settings_id
             )
+            method_status = self.service.history_repo.get_stats_by_method_and_status(
+                days=days, chat_settings_id=chat_settings_id
+            )
             daily_counts = self.service.history_repo.get_daily_counts(
                 days=days, chat_settings_id=chat_settings_id
             )
@@ -70,6 +73,17 @@ class HistoryDashboardQueries:
             total = sum(status_counts.values())
             posted = status_counts.get("posted", 0)
 
+            # Method-split fields keep Instagram publish health distinct
+            # from Telegram delivery health. Lumping them together (e.g.
+            # the legacy "success_rate" field) made a 958-row Telegram
+            # delivery burst in 2026-05 look like a 1% IG success rate —
+            # see the 2026-05 burst postmortem (#467) for context.
+            ig = method_status.get("instagram_api", {})
+            tg = method_status.get("telegram_manual", {})
+            ig_posted = ig.get("posted", 0)
+            ig_failed = ig.get("failed", 0)
+            ig_attempts = ig_posted + ig_failed
+
             result = {
                 "summary": {
                     "total_posts": total,
@@ -79,8 +93,18 @@ class HistoryDashboardQueries:
                     "failed": status_counts.get("failed", 0),
                     "success_rate": round(posted / total, 2) if total else 0,
                     "avg_per_day": round(total / days, 1),
+                    # Method-split — preferred for new UI; legacy fields
+                    # above kept for backward compatibility.
+                    "ig_posted": ig_posted,
+                    "ig_failed": ig_failed,
+                    "ig_success_rate": (
+                        round(ig_posted / ig_attempts, 2) if ig_attempts else 0
+                    ),
+                    "telegram_skipped": tg.get("skipped", 0),
+                    "telegram_failed": tg.get("failed", 0),
                 },
                 "method_breakdown": method_counts,
+                "method_status_breakdown": method_status,
                 "daily_counts": daily_counts,
                 "hourly_distribution": hourly_dist,
                 "category_breakdown": category_stats,

--- a/tests/src/services/test_dashboard_service.py
+++ b/tests/src/services/test_dashboard_service.py
@@ -303,6 +303,10 @@ class TestGetAnalytics:
             "instagram_api": 60,
             "telegram_manual": 20,
         }
+        service.history_repo.get_stats_by_method_and_status.return_value = {
+            "instagram_api": {"posted": 60},
+            "telegram_manual": {"posted": 20, "skipped": 10, "failed": 5},
+        }
         service.history_repo.get_daily_counts.return_value = [
             {"date": "2026-04-10", "posted": 4, "skipped": 1},
             {"date": "2026-04-11", "posted": 5},
@@ -333,12 +337,58 @@ class TestGetAnalytics:
         assert len(result["category_breakdown"]) == 1
         assert result["days"] == 30
 
+    def test_method_split_summary_fields(self):
+        """Regression for #466.
+
+        The legacy "success_rate" lumped Instagram posts with Telegram
+        delivery attempts: when 595 Telegram cards failed delivery in a
+        burst, the dashboard read "Success Rate: 1%" even though every
+        Instagram post had succeeded. The method-split fields below
+        compute IG success rate against only IG attempts so that
+        Telegram delivery health and Instagram publish health are
+        separately observable.
+        """
+        service = self._setup_analytics_service()
+
+        service.history_repo.get_stats_by_status.return_value = {
+            "posted": 7,
+            "skipped": 8,
+            "failed": 595,
+        }
+        service.history_repo.get_stats_by_method.return_value = {"instagram_api": 7}
+        service.history_repo.get_stats_by_method_and_status.return_value = {
+            "instagram_api": {"posted": 7},
+            "telegram_manual": {"skipped": 8, "failed": 595},
+        }
+        service.history_repo.get_daily_counts.return_value = []
+        service.history_repo.get_hourly_distribution.return_value = []
+        service.history_repo.get_stats_by_category.return_value = []
+
+        result = service.get_analytics(telegram_chat_id=123, days=30)
+        summary = result["summary"]
+
+        # Legacy field — IG and Telegram lumped together
+        assert summary["success_rate"] == round(7 / 610, 2)
+
+        # New method-split fields — IG is 100% successful, Telegram
+        # delivery has a separate 595-count "delivery issues" bucket
+        assert summary["ig_posted"] == 7
+        assert summary["ig_failed"] == 0
+        assert summary["ig_success_rate"] == 1.0
+        assert summary["telegram_skipped"] == 8
+        assert summary["telegram_failed"] == 595
+        # The raw method->status breakdown is also exposed for any
+        # consumer that wants to render its own pivot.
+        assert result["method_status_breakdown"]["instagram_api"]["posted"] == 7
+        assert result["method_status_breakdown"]["telegram_manual"]["failed"] == 595
+
     def test_handles_empty_history(self):
         """get_analytics handles no posting history gracefully."""
         service = self._setup_analytics_service()
 
         service.history_repo.get_stats_by_status.return_value = {}
         service.history_repo.get_stats_by_method.return_value = {}
+        service.history_repo.get_stats_by_method_and_status.return_value = {}
         service.history_repo.get_daily_counts.return_value = []
         service.history_repo.get_hourly_distribution.return_value = []
         service.history_repo.get_stats_by_category.return_value = []
@@ -348,6 +398,9 @@ class TestGetAnalytics:
         assert result["summary"]["total_posts"] == 0
         assert result["summary"]["success_rate"] == 0
         assert result["summary"]["avg_per_day"] == 0
+        assert result["summary"]["ig_posted"] == 0
+        assert result["summary"]["ig_success_rate"] == 0
+        assert result["summary"]["telegram_failed"] == 0
         assert result["daily_counts"] == []
 
     def test_passes_days_and_tenant(self):
@@ -356,6 +409,7 @@ class TestGetAnalytics:
 
         service.history_repo.get_stats_by_status.return_value = {}
         service.history_repo.get_stats_by_method.return_value = {}
+        service.history_repo.get_stats_by_method_and_status.return_value = {}
         service.history_repo.get_daily_counts.return_value = []
         service.history_repo.get_hourly_distribution.return_value = []
         service.history_repo.get_stats_by_category.return_value = []
@@ -366,6 +420,9 @@ class TestGetAnalytics:
             days=7, chat_settings_id="tenant-uuid-1"
         )
         service.history_repo.get_stats_by_method.assert_called_once_with(
+            days=7, chat_settings_id="tenant-uuid-1"
+        )
+        service.history_repo.get_stats_by_method_and_status.assert_called_once_with(
             days=7, chat_settings_id="tenant-uuid-1"
         )
         service.history_repo.get_daily_counts.assert_called_once_with(


### PR DESCRIPTION
## Summary

The Overview page conflated Instagram publish health with Telegram delivery health. After the 2026-05 Telegram delivery burst (#467 postmortem), the dashboard showed:

| KPI shown | What it actually meant |
|---|---|
| Total Posts: 610 | 7 IG posts + 8 Telegram skips + 595 Telegram delivery failures |
| Success Rate: 1% | 7 ÷ 610 — Telegram delivery failures dragging the IG rate down |
| Failed: 595 | Sounded like 595 Instagram posts failed. Zero did. |

The chart compounded it — only `posted` / `skipped` / `rejected` were rendered. The 595 failure days (May 17-19) didn't appear at all, so the visual told a calm story while the KPI screamed.

This PR splits both signals by `posting_method`.

## Changes

### Backend
- **`HistoryRepository.get_stats_by_method_and_status()`** — new method, pivots `posting_history` by (method, status). Existing `get_stats_by_method` only counted successful rows; this counts every row.
- **`get_analytics().summary`** now also returns `ig_posted`, `ig_failed`, `ig_success_rate`, `telegram_skipped`, `telegram_failed`, plus the raw `method_status_breakdown` dict. Legacy fields kept for back-compat (partial-deploy safety).

### Frontend
- **`AnalyticsCards`** — four method-aware cards:
  - **Posts published** — `ig_posted`
  - **Instagram success rate** — `ig_posted / (ig_posted + ig_failed)`. Telegram delivery never enters the denominator.
  - **Cards skipped** — `telegram_skipped`
  - **Delivery issues** — `telegram_failed`, with hover hint when non-zero
  - Falls back to legacy fields if the backend hasn't been updated yet
- **`PostingChart`** — red `failed` bar added on top of the existing stack, so burst days are visible.

### Tests
- New `test_method_split_summary_fields` reproduces the May-burst data shape (7 IG posted, 8 Telegram skipped, 595 Telegram failed) and asserts `ig_success_rate == 1.0` while the legacy `success_rate` stays at the misleading 0.01.
- Updated existing tests to mock the new repo method.

## Test plan

- [x] `pytest tests/src/services/test_dashboard_service.py` — 40 passed
- [x] `ruff check` / `ruff format --check` clean on all touched files
- [x] `next build` clean — no type errors
- [ ] **Live post-deploy**: dashboard shows split KPIs reflecting actual IG vs Telegram health; chart includes red bars on May 17-19

## Closes

#466. Also makes #467's postmortem findings visible (May burst is now a clearly-tagged "Delivery issues" number rather than a misleading 1% Success Rate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)