### PR TITLE
feat: add api_tokens.auth_method + issuing_app_id (#468 PR 2/4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`api_tokens.auth_method` + `api_tokens.issuing_app_id` columns (#468)** — Credential refactor phase 4. The OAuth-flow discriminator (`instagram_login` / `fb_login` / `manual`) and the issuing Meta App ID move onto the credential row itself so the token becomes self-describing. Today posting code has to JOIN `instagram_accounts` to discover provenance; after the read-switch sub-PR that follows, it'll read directly off the token. Three migrations: 038 adds the columns + partial index, 039 backfills `auth_method` from `instagram_accounts.auth_method` (default `instagram_login` for any unset row), 040 expands the UNIQUE constraint to include `auth_method` so an account can hold both an `instagram_login` token AND an `fb_login` token simultaneously (#380 acceptance criteria). `TokenRepository.create_or_update()` accepts both new kwargs with sensible "preserve existing on omit" semantics so the refresh path doesn't accidentally null them.
+
 ### Fixed
 
 - **Token refresh — `_call_meta_refresh` now sends FB app credentials on the `graph.facebook.com` path (#470)** — Meta exposes two refresh contracts: `graph.instagram.com/refresh_access_token` (IG Login) accepts `grant_type=ig_refresh_token` + `access_token` alone; `graph.facebook.com/.../oauth/access_token` (FB Login / legacy) requires `grant_type=fb_exchange_token`, `client_id`, `client_secret`, and `fb_exchange_token`. The previous implementation always sent IG-flavored params, so any refresh against the FB host failed with Meta error 101 "Missing client_id parameter." Now branches on the resolved URL: IG-host gets the IG payload, FB-host gets credentials. Latent fix — production currently has no `fb_login` tokens to refresh, but the bug would have fired immediately if any tenant connected via Facebook Login.

--- a/scripts/migrations/038_credential_refactor_add_auth_method_to_tokens.sql
+++ b/scripts/migrations/038_credential_refactor_add_auth_method_to_tokens.sql
@@ -1,0 +1,36 @@
+-- Migration: 038_credential_refactor_add_auth_method_to_tokens.sql
+-- Description: Add auth_method + issuing_app_id columns to api_tokens
+-- Created: 2026-06-02
+-- Issue: #468, closes phase 4 of #380
+--
+-- Why this exists
+-- ----------------
+-- The IG host-routing bug fixed in PR #462 (today) revealed that
+-- credential provenance lives on the wrong table. Today the posting
+-- code has to JOIN instagram_accounts to discover which OAuth flow
+-- issued each token; this PR migrates the discriminator onto the
+-- credential row itself so the token becomes self-describing.
+--
+-- After this migration + the dual-write + read-switch + drop-legacy
+-- PRs that follow, instagram_accounts becomes pure identity (username
+-- + display_name + is_active) and api_tokens carries everything about
+-- *the credential*: its OAuth flow (auth_method), its issuing app
+-- (issuing_app_id), and the Meta-side account ID it returned
+-- (meta_account_id, added in migration 035).
+--
+-- Additive only — no behavior changes, no data deleted. Backfill is
+-- in migration 039 so this one is fully reversible.
+
+ALTER TABLE api_tokens
+  ADD COLUMN IF NOT EXISTS auth_method VARCHAR(50),
+  ADD COLUMN IF NOT EXISTS issuing_app_id VARCHAR(100);
+
+-- Partial index so the auth_method lookup is fast for IG tokens
+-- without indexing the NULL google_drive / shopify rows.
+CREATE INDEX IF NOT EXISTS api_tokens_auth_method_idx
+  ON api_tokens (auth_method)
+  WHERE auth_method IS NOT NULL;
+
+INSERT INTO schema_version (version, description, applied_at)
+VALUES (38, 'Add api_tokens.auth_method + issuing_app_id (credential refactor phase 4)', NOW())
+ON CONFLICT DO NOTHING;

--- a/scripts/migrations/039_credential_refactor_backfill_auth_method.sql
+++ b/scripts/migrations/039_credential_refactor_backfill_auth_method.sql
@@ -1,0 +1,35 @@
+-- Migration: 039_credential_refactor_backfill_auth_method.sql
+-- Description: Backfill api_tokens.auth_method from instagram_accounts.auth_method
+-- Created: 2026-06-02
+-- Issue: #468, follows 038
+--
+-- Backfills the new api_tokens.auth_method from the legacy
+-- instagram_accounts.auth_method column. After PR #462 (today's
+-- production cleanup) prod has exactly one Instagram token row, and
+-- that row's account.auth_method is 'instagram_login' — but this
+-- migration is written defensively for any future deployment that
+-- may have legacy fb_login rows or unset values.
+--
+-- Rows that don't join cleanly (no instagram_account_id FK, or the
+-- account row has NULL auth_method) default to 'instagram_login'
+-- because that's the only OAuth flow we still support for new
+-- connections. Legacy fb_login tokens will need to be tagged via
+-- explicit UPDATE if they ever resurface.
+
+UPDATE api_tokens t
+SET auth_method = COALESCE(a.auth_method, 'instagram_login')
+FROM instagram_accounts a
+WHERE t.instagram_account_id = a.id
+  AND t.service_name = 'instagram'
+  AND t.auth_method IS NULL;
+
+-- Catch any orphan IG tokens with no account FK (legacy single-tenant
+-- rows from before instagram_account_id existed). Same default.
+UPDATE api_tokens
+SET auth_method = 'instagram_login'
+WHERE service_name = 'instagram'
+  AND auth_method IS NULL;
+
+INSERT INTO schema_version (version, description, applied_at)
+VALUES (39, 'Backfill api_tokens.auth_method from instagram_accounts', NOW())
+ON CONFLICT DO NOTHING;

--- a/scripts/migrations/040_credential_refactor_expand_unique_constraint.sql
+++ b/scripts/migrations/040_credential_refactor_expand_unique_constraint.sql
@@ -1,0 +1,32 @@
+-- Migration: 040_credential_refactor_expand_unique_constraint.sql
+-- Description: Expand api_tokens UNIQUE constraint to include auth_method
+-- Created: 2026-06-02
+-- Issue: #468, #380 acceptance criteria
+--
+-- Today's UNIQUE (service_name, token_type, instagram_account_id)
+-- prevents an account from holding both an instagram_login token AND
+-- an fb_login token simultaneously. Issue #380's acceptance criteria
+-- explicitly call this out: "An account can have a fb_login token
+-- AND an instagram_login token simultaneously."
+--
+-- After this constraint expands to include auth_method, the consumer
+-- services (InstagramAPIService etc.) can pick the right token by
+-- (account, auth_method) without ambiguity. The old constraint name
+-- is preserved logically by the new one — same role, more selective
+-- key.
+--
+-- Safe to run: no existing rows can violate the new constraint
+-- (every IG token had a unique (service, type, account) under the
+-- old rule, so adding auth_method to the tuple cannot create
+-- duplicates).
+
+ALTER TABLE api_tokens
+  DROP CONSTRAINT IF EXISTS unique_service_token_type_account;
+
+ALTER TABLE api_tokens
+  ADD CONSTRAINT unique_credential_per_account
+  UNIQUE (service_name, token_type, instagram_account_id, auth_method);
+
+INSERT INTO schema_version (version, description, applied_at)
+VALUES (40, 'Expand api_tokens UNIQUE to include auth_method', NOW())
+ON CONFLICT DO NOTHING;

--- a/src/models/api_token.py
+++ b/src/models/api_token.py
@@ -48,6 +48,21 @@ class ApiToken(Base):
     # the dual-write migration window; backfilled in phase 3.
     meta_account_id = Column(String(100), nullable=True, index=True)
 
+    # Which OAuth flow / Meta app issued this token. Values today:
+    # 'instagram_login' (graph.instagram.com), 'fb_login' (legacy,
+    # graph.facebook.com), 'manual' (admin-pasted). Lives here rather
+    # than on instagram_accounts because it's a property of the
+    # credential, not the identity — an account can hold tokens from
+    # multiple flows simultaneously (per #380 acceptance criteria).
+    # Nullable during the dual-write migration window (#468); backfilled
+    # by migration 039.
+    auth_method = Column(String(50), nullable=True, index=True)
+
+    # Which Meta App ID issued this token (explicit, not env-derived
+    # at use time). Eliminates env-var drift as a failure mode and
+    # gives an audit trail of which app produced which credential.
+    issuing_app_id = Column(String(100), nullable=True)
+
     # Per-tenant scoping (used by Google Drive OAuth tokens)
     chat_settings_id = Column(
         UUID(as_uuid=True),
@@ -81,12 +96,19 @@ class ApiToken(Base):
     instagram_account = relationship("InstagramAccount", back_populates="tokens")
 
     __table_args__ = (
-        # One token per service per account (allows multiple IG accounts with separate tokens)
+        # One token per (service, type, account, auth_method) — the
+        # auth_method dimension lets a single account hold both an
+        # instagram_login token AND an fb_login token simultaneously
+        # (#380 acceptance criteria). Constraint name matches
+        # migration 040 (`unique_credential_per_account`); the old
+        # `unique_service_token_type_account` is dropped by that
+        # migration.
         UniqueConstraint(
             "service_name",
             "token_type",
             "instagram_account_id",
-            name="unique_service_token_type_account",
+            "auth_method",
+            name="unique_credential_per_account",
         ),
     )
 

--- a/src/repositories/token_repository.py
+++ b/src/repositories/token_repository.py
@@ -148,6 +148,8 @@ class TokenRepository(BaseRepository):
         metadata: Optional[dict] = None,
         instagram_account_id: Optional[str] = None,
         meta_account_id: Optional[str] = None,
+        auth_method: Optional[str] = None,
+        issuing_app_id: Optional[str] = None,
     ) -> ApiToken:
         """
         Create or update a token (UPSERT pattern).
@@ -168,6 +170,12 @@ class TokenRepository(BaseRepository):
             instagram_account_id: UUID of Instagram account (for multi-account support)
             meta_account_id: Meta-side identifier that issued this token
                 (Business Account ID for FB Login, User ID for IG Login)
+            auth_method: OAuth flow that issued this token
+                ('instagram_login', 'fb_login', 'manual'). Lives on the
+                credential rather than the account so the token is
+                self-describing (#468).
+            issuing_app_id: Meta App ID that issued this token; stored
+                explicitly to eliminate env-var drift as a failure mode.
 
         Returns:
             Created or updated ApiToken
@@ -200,6 +208,10 @@ class TokenRepository(BaseRepository):
                 existing.token_metadata = metadata
             if meta_account_id is not None:
                 existing.meta_account_id = meta_account_id
+            if auth_method is not None:
+                existing.auth_method = auth_method
+            if issuing_app_id is not None:
+                existing.issuing_app_id = issuing_app_id
             self.db.commit()
             self.db.refresh(existing)
             return existing
@@ -215,6 +227,8 @@ class TokenRepository(BaseRepository):
                 token_metadata=metadata,
                 instagram_account_id=instagram_account_id,
                 meta_account_id=meta_account_id,
+                auth_method=auth_method,
+                issuing_app_id=issuing_app_id,
             )
             self.db.add(token)
             self.db.commit()

--- a/tests/src/models/test_api_token.py
+++ b/tests/src/models/test_api_token.py
@@ -37,6 +37,33 @@ class TestApiTokenModel:
     def test_instagram_account_id_nullable(self):
         assert ApiToken.instagram_account_id.nullable is True
 
+    def test_auth_method_column_exists_and_nullable(self):
+        # Added in credential refactor phase 4 (#468). Nullable during
+        # the dual-write window; backfilled by migration 039.
+        assert ApiToken.auth_method.nullable is True
+        assert ApiToken.auth_method.type.length == 50
+
+    def test_issuing_app_id_column_exists_and_nullable(self):
+        assert ApiToken.issuing_app_id.nullable is True
+        assert ApiToken.issuing_app_id.type.length == 100
+
+    def test_unique_constraint_includes_auth_method(self):
+        # The UNIQUE tuple expanded to include auth_method so an
+        # account can hold both an instagram_login token and an
+        # fb_login token simultaneously (#380 acceptance criteria).
+        from sqlalchemy import UniqueConstraint
+
+        uniques = [
+            c for c in ApiToken.__table_args__ if isinstance(c, UniqueConstraint)
+        ]
+        assert len(uniques) == 1
+        cols = [c.name for c in uniques[0].columns]
+        assert "auth_method" in cols
+        assert "instagram_account_id" in cols
+        assert "service_name" in cols
+        assert "token_type" in cols
+        assert uniques[0].name == "unique_credential_per_account"
+
     def test_repr_with_expiry(self):
         token = ApiToken(
             service_name="instagram",

--- a/tests/src/repositories/test_token_repository.py
+++ b/tests/src/repositories/test_token_repository.py
@@ -144,6 +144,72 @@ class TestTokenRepository:
         assert existing_token.token_value == "new_encrypted"
         mock_db.commit.assert_called()
 
+    def test_create_or_update_persists_auth_method_and_issuing_app_id(
+        self, token_repo, mock_db
+    ):
+        """New tokens carry auth_method + issuing_app_id (#468)."""
+        mock_db.query.return_value.filter.return_value.filter.return_value.first.return_value = None
+
+        token_repo.create_or_update(
+            service_name="instagram",
+            token_type="access_token",
+            token_value="encrypted",
+            issued_at=datetime.utcnow(),
+            instagram_account_id="acct-uuid",
+            meta_account_id="26060527550287223",
+            auth_method="instagram_login",
+            issuing_app_id="ig_app_456",
+        )
+
+        added = mock_db.add.call_args[0][0]
+        assert added.auth_method == "instagram_login"
+        assert added.issuing_app_id == "ig_app_456"
+
+    def test_create_or_update_updates_auth_method_when_provided(
+        self, token_repo, mock_db
+    ):
+        """Existing tokens get auth_method/issuing_app_id updated on
+        re-issue but preserved when the caller omits them (matches the
+        meta_account_id pattern — refresh paths don't need to know)."""
+        existing = Mock(spec=ApiToken)
+        existing.token_value = "old"
+        existing.auth_method = "fb_login"
+        existing.issuing_app_id = "old_app"
+        mock_db.query.return_value.filter.return_value.filter.return_value.first.return_value = existing
+
+        token_repo.create_or_update(
+            service_name="instagram",
+            token_type="access_token",
+            token_value="new",
+            auth_method="instagram_login",
+            issuing_app_id="new_app",
+        )
+
+        assert existing.auth_method == "instagram_login"
+        assert existing.issuing_app_id == "new_app"
+
+    def test_create_or_update_preserves_auth_method_when_omitted(
+        self, token_repo, mock_db
+    ):
+        """Refresh path doesn't pass auth_method/issuing_app_id; the
+        existing row's values must be preserved rather than nulled."""
+        existing = Mock(spec=ApiToken)
+        existing.token_value = "old"
+        existing.auth_method = "instagram_login"
+        existing.issuing_app_id = "ig_app_456"
+        mock_db.query.return_value.filter.return_value.filter.return_value.first.return_value = existing
+
+        token_repo.create_or_update(
+            service_name="instagram",
+            token_type="access_token",
+            token_value="new",
+        )
+
+        # Existing fields untouched — only the auth-related fields
+        # need to be guarded against accidental nulling.
+        assert existing.auth_method == "instagram_login"
+        assert existing.issuing_app_id == "ig_app_456"
+
     def test_update_last_refreshed(self, token_repo, mock_db):
         """Test updating last_refreshed_at timestamp."""
         mock_token = Mock(spec=ApiToken)


### PR DESCRIPTION
## Summary

**PR 2 of 4** for #468 (credential refactor phase 4-5, finishes #380).

Credential provenance moves from \`instagram_accounts\` onto the token row itself so the credential becomes self-describing. Today posting code has to JOIN \`instagram_accounts\` to discover which OAuth flow issued each token; the read-switch sub-PR (PR 4) makes the token self-describing.

Additive only — no behavior changes ship with this PR. Subsequent PRs in the sequence:
- **PR 3**: dual-write at the 5 OAuth/token-write sites
- **PR 4**: switch reads to consult the token, not the account
- **PR 5**: drop \`instagram_accounts.auth_method\` and \`instagram_account_id\` legacy columns

## Migrations

| # | What | Reversible |
|---|---|---|
| **038** | ADD COLUMN \`auth_method\` VARCHAR(50), \`issuing_app_id\` VARCHAR(100); CREATE INDEX on \`auth_method\` (partial, NULL-skipping) | ✓ |
| **039** | Backfill \`auth_method\` from \`instagram_accounts.auth_method\`; default \`instagram_login\` for any unset row | ✓ |
| **040** | DROP CONSTRAINT \`unique_service_token_type_account\`; ADD CONSTRAINT \`unique_credential_per_account\` UNIQUE (service_name, token_type, instagram_account_id, **auth_method**) | ✓ (re-add old) |

The expanded UNIQUE lets a single account hold both an \`instagram_login\` token AND an \`fb_login\` token simultaneously — required by #380 acceptance criteria.

## Code

- \`ApiToken\` model: two new columns + updated UniqueConstraint name + cols
- \`TokenRepository.create_or_update()\`: accepts \`auth_method\` and \`issuing_app_id\` kwargs. Uses "preserve existing on omit" semantics so the refresh path doesn't null them when refreshing.

## Tests

- **Model**: 3 new tests for column nullability + UNIQUE constraint shape
- **Repo**: 3 new tests:
  - new rows persist both fields
  - existing rows get updated when provided
  - existing rows **preserve** values when the caller omits (matches \`meta_account_id\` pattern)

## Deployment notes

1. **Merge** → CI green
2. **Apply migrations** on prod Neon in order: 038 → 039 → 040
3. Verify with \`SELECT auth_method, COUNT(*) FROM api_tokens WHERE service_name='instagram' GROUP BY auth_method\` — every IG row should have \`auth_method\` populated (probably all \`instagram_login\` after today's cleanup)
4. **Then ship PR 3** (dual-write at OAuth callbacks)

## Test plan

- [x] \`pytest tests/src/models/test_api_token.py tests/src/repositories/test_token_repository.py\` — 40 passed
- [x] \`ruff check\` / \`ruff format --check\` clean on all touched files
- [ ] Apply migrations 038/039/040 on prod Neon post-merge
- [ ] Verify backfill: \`SELECT COUNT(*) FROM api_tokens WHERE service_name='instagram' AND auth_method IS NULL\` → 0

## Related

#468 (parent), #380 (closed by this 4-PR sequence's PR 5), #462 (PR 1, shipped earlier today — set up the host-routing fix that motivates this refactor)

🤖 Generated with [Claude Code](https://claude.com/claude-code)