### PR TITLE
fix: add pool monitoring to callback path for latency diagnosis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Pool monitoring on callback path** — `log_pool_status()` now fires on every inline button callback in `_handle_callback`, surfacing connection pool utilization (checked-out, overflow, utilization %) in real-time logs. Aids diagnosis of callback latency spikes correlated with pool exhaustion or Neon cold starts.
 - **`api_tokens.auth_method` + `api_tokens.issuing_app_id` columns (#468)** — Credential refactor phase 4. The OAuth-flow discriminator (`instagram_login` / `fb_login` / `manual`) and the issuing Meta App ID move onto the credential row itself so the token becomes self-describing. Today posting code has to JOIN `instagram_accounts` to discover provenance; after the read-switch sub-PR that follows, it'll read directly off the token. Three migrations: 038 adds the columns + partial index, 039 backfills `auth_method` from `instagram_accounts.auth_method` (default `instagram_login` for any unset row), 040 expands the UNIQUE constraint to include `auth_method` so an account can hold both an `instagram_login` token AND an `fb_login` token simultaneously (#380 acceptance criteria). `TokenRepository.create_or_update()` accepts both new kwargs with sensible "preserve existing on omit" semantics so the refresh path doesn't accidentally null them.
 
 ### Fixed

--- a/src/services/core/telegram_service.py
+++ b/src/services/core/telegram_service.py
@@ -376,9 +376,12 @@ class TelegramService(BaseService):
         1. Dictionary lookup for standard (data, user, query) handlers
         2. Special-case method for handlers with non-standard signatures or sub-routing
         """
+        from src.utils.resilience import log_pool_status
+
         query = update.callback_query
         try:
             logger.info(f"📞 Callback received: {query.data}")
+            log_pool_status()
 
             try:
                 await query.answer()


### PR DESCRIPTION
## Summary

- Adds `log_pool_status()` call at the top of `_handle_callback` in `telegram_service.py` so every inline button press logs connection pool utilization (checked-out, overflow, utilization %).

## Infrastructure investigation findings

### Railway deploys

Railway CLI not authenticated on the Pi, so couldn't pull deploy logs directly. However: `railway.toml` has `drainingSeconds = 60`. During a deploy, the old worker drains for up to 60 seconds before SIGKILL. During this window, the old worker has already stopped its polling loop (so it won't pick up new callbacks), but the new worker hasn't started yet. Any callback pressed during this 60s window gets no handler — Telegram's 30s callback timeout fires, the user sees nothing.

**This is the most likely cause of the reported latency/non-processing.** If deploys happened during active use, callbacks would silently fail for up to 60 seconds.

### Neon DB connection pool

Queried `pg_stat_activity` on production Neon:

| State | Count |
|-------|-------|
| idle | 7 |
| active | 1 (my query) |
| idle in transaction | 1 |

Pool limits: `pool_size=10, max_overflow=20, pool_timeout=30`. Only 9/30 connections in use — **pool exhaustion is NOT the current bottleneck.**

However: one connection has been `idle in transaction` for 74+ minutes, holding a `SELECT FROM posting_queue WHERE status = 'processing'`. This is a leaked transaction from the scheduler loop. Not blocking callbacks right now, but could accumulate under load.

Neon max_connections = 901. Branch state = ready (not cold-starting).

### Pool monitoring (this PR)

`log_pool_status()` from `src/utils/resilience.py` now fires on every callback. It logs at:
- DEBUG when utilization < 70%
- INFO when 70-90%
- WARNING when >= 90% (near exhaustion)

This will surface whether any future callback latency correlates with pool pressure.

## Test plan

- [ ] Deploy, trigger a callback button, verify `DB pool status:` appears in Railway logs
- [ ] Check Railway deploy history for timing overlap with the original latency reports
- [ ] Monitor the idle-in-transaction leak — if it grows, investigate the scheduler loop's session handling