### PR TITLE
fix(telegram): answer autopost callback immediately so the button stops spinning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Telegram "Auto Post" button no longer spins after timeout** — `handle_autopost` did not call `query.answer()` until the full Cloudinary upload + Meta publish completed (often >30s), past Telegram's callback-answer deadline. Result: the button's loading spinner ran indefinitely, the bot logged `Could not answer callback query (may be stale)`, and the user couldn't tell if their click registered. Now answers immediately with `⏳ Posting…` after the cheap lock-held check (which keeps its specific `⏳ Already processing…` message for duplicate clicks).
+
 ### Removed
 
 - **`instagram_accounts.auth_method` legacy column dropped (#468 PR 5)** — Final sub-PR of the credential refactor. After PR 4 the application reads provenance off `api_tokens.auth_method` exclusively; PRs 2-4 made the account-side column write-only, and this PR removes both the writes (in `instagram_account_service.update_account_token` and `instagram_account_repository.create`) and the column itself (migration 041). `instagram_accounts` is one step closer to pure-identity. The `instagram_accounts.instagram_account_id` legacy column remains — its consumers (backfill, OAuth heal logic, credential lookup) need a separate refactor to read from `api_tokens.meta_account_id` instead, filed as a follow-up.

--- a/src/services/core/telegram_autopost.py
+++ b/src/services/core/telegram_autopost.py
@@ -101,6 +101,17 @@ class TelegramAutopostHandler:
             await query.answer("⏳ Already processing...", show_alert=False)
             return
 
+        # Acknowledge the click IMMEDIATELY so the button stops spinning.
+        # Telegram requires answer_callback_query within ~30s of the click,
+        # but the Cloudinary upload + Meta publish below can take longer
+        # than that. Without this early answer the user sees a stale
+        # spinner and the bot logs "Could not answer callback query (may
+        # be stale)". The dupe-click branch above has its own answer.
+        try:
+            await query.answer("⏳ Posting…", show_alert=False)
+        except Exception as e:  # noqa: BLE001 — best-effort ack
+            logger.debug(f"Could not pre-answer autopost callback {queue_id}: {e}")
+
         cancel_flag = self.service.get_cancel_flag(queue_id)
         cancel_flag.clear()
 

--- a/tests/src/services/test_telegram_autopost.py
+++ b/tests/src/services/test_telegram_autopost.py
@@ -341,6 +341,37 @@ class TestAutopostEarlyFeedback:
         # Keyboard should be removed before claim_for_processing
         mock_query.edit_message_reply_markup.assert_called_once()
 
+    async def test_autopost_answers_callback_before_slow_work(
+        self, mock_autopost_handler
+    ):
+        """handle_autopost calls query.answer('Posting…') BEFORE any slow I/O.
+
+        Telegram requires answer_callback_query within ~30s of the click,
+        but Cloudinary upload + Meta publish can exceed that. Without an
+        early ack the spinner runs indefinitely and the bot logs
+        'Could not answer callback query (may be stale)'.
+        """
+        handler = mock_autopost_handler
+        service = handler.service
+        queue_id = str(uuid4())
+
+        # claim returns None so no background task is spawned (fast path)
+        service.queue_repo.claim_for_processing.return_value = None
+        service.queue_repo.get_by_id.return_value = None
+        service.history_repo.get_by_queue_item_id.return_value = None
+
+        mock_user = Mock()
+        mock_query = AsyncMock()
+
+        await handler.handle_autopost(queue_id, mock_user, mock_query)
+
+        # Early-answer must have fired with the "Posting…" text
+        mock_query.answer.assert_called_once()
+        answer_call = mock_query.answer.call_args
+        assert "Posting" in str(answer_call), (
+            f"Expected 'Posting' in answer call, got: {answer_call}"
+        )
+
 
 @pytest.mark.unit
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

The "Auto Post to Instagram" button looked unresponsive — clicking it kept the loading spinner running until the full work completed (often >30s, past Telegram's callback-answer deadline). The bot logged `Could not answer callback query (may be stale)`. Observed live at 2026-06-04 16:29:14-16 when three rapid clicks all hit this state.

This PR adds an immediate `query.answer("⏳ Posting…")` ack as the second line of `handle_autopost` (after the cheap lock-held check, which keeps its specific `"⏳ Already processing..."` message for dupe clicks).

## Changes

- `src/services/core/telegram_autopost.py:handle_autopost` — adds the early answer in the fresh-click path. Wrapped in try/except + `logger.debug` so a Telegram hiccup on the ack doesn't block the real post work.
- `tests/src/services/test_telegram_autopost.py:test_autopost_answers_callback_before_slow_work` — new test asserts the ack fires on the fast path before `claim_for_processing` returns None.

## Test plan

- [x] `pytest tests/src/services/test_telegram_autopost.py` — 42 passed (1 new, no regressions)
- [x] `ruff check` / `ruff format --check` clean
- [ ] Live click-test post-deploy: spinner clears immediately, toast shows "⏳ Posting…"

🤖 Generated with [Claude Code](https://claude.com/claude-code)