### PR TITLE
feat: catch Meta code 9004 + permanent-reject unsupported media (B1 + B3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **New `MediaUnsupportedError` exception classifies Meta error code 9004** — Previously a 9004 "Only photo or video can be accepted as media type" response (typically: HEIC file masquerading as JPG, or Cloudinary transformation produced output IG can't decode) was classified as a generic `InstagramAPIError`. Now `_check_response_errors` in `instagram_api.py` raises the new `MediaUnsupportedError`, and the autopost handler reacts by creating a **permanent_reject** lock on the underlying media_item so the failing file doesn't keep cycling through retries on every scheduler tick. User sees a clear "couldn't process this file (Meta error 9004) — permanently rejected, won't be scheduled again" message instead of the previous generic error.
+
 ### Fixed
 
 - **Daily posting cap enforced across all 5 posting paths** — `posts_per_day` was only used for interval spacing, not as a hard daily limit. DB evidence showed accounts posting 2x their configured cap. Added a shared `can_post_today()` guard (backed by `HistoryRepository.count_posts_today()` with timezone-aware day boundaries) and wired it into the scheduler, autopost, manual posted callback, `/next` command, and auto-approve paths. Catchup bursts are also capped. On cap hit the queue item stays pending so it retries the next day.

--- a/src/exceptions/__init__.py
+++ b/src/exceptions/__init__.py
@@ -14,6 +14,7 @@ from src.exceptions.instagram import (
     TokenCorruptError,
     TokenRevokedError,
     MediaUploadError,
+    MediaUnsupportedError,
 )
 from src.exceptions.backfill import (
     BackfillError,
@@ -33,6 +34,7 @@ __all__ = [
     "TokenCorruptError",
     "TokenRevokedError",
     "MediaUploadError",
+    "MediaUnsupportedError",
     "BackfillError",
     "BackfillMediaExpiredError",
     "BackfillMediaNotFoundError",

--- a/src/exceptions/instagram.py
+++ b/src/exceptions/instagram.py
@@ -96,6 +96,31 @@ class TokenCorruptError(InstagramAPIError):
         super().__init__(message, **kwargs)
 
 
+class MediaUnsupportedError(InstagramAPIError):
+    """
+    Instagram could not parse the uploaded file (Meta error code 9004).
+
+    Raised when Meta returns "Only photo or video can be accepted as media
+    type." This happens when the Cloudinary URL we serve produces output
+    that Instagram doesn't recognize as a valid image or video — common
+    causes are HEIC files masquerading as JPG, GIFs (IG Stories don't
+    accept), or a Cloudinary transformation failure that served back an
+    error page.
+
+    Unlike TokenCorruptError (credential is broken) or RateLimitError
+    (transient), this means THIS specific media item will fail every time
+    it's posted until the file is fixed. The autopost handler creates a
+    permanent_reject lock so the scheduler doesn't keep cycling through it.
+    """
+
+    def __init__(
+        self,
+        message: str = "Instagram could not parse the uploaded file (Meta code 9004).",
+        **kwargs,
+    ):
+        super().__init__(message, **kwargs)
+
+
 class TokenRevokedError(InstagramAPIError):
     """
     Instagram refresh token has been revoked.

--- a/src/services/core/telegram_autopost.py
+++ b/src/services/core/telegram_autopost.py
@@ -11,6 +11,7 @@ from telegram import InlineKeyboardButton, InlineKeyboardMarkup
 
 from src.exceptions.instagram import (
     InstagramAPIError,
+    MediaUnsupportedError,
     MediaUploadError,
     RateLimitError,
     TokenCorruptError,
@@ -584,8 +585,35 @@ class TelegramAutopostHandler:
             )
 
     async def _handle_autopost_error(self, ctx: AutopostContext, e: Exception) -> None:
-        """Handle auto-post failure: show error message with recovery options."""
+        """Handle auto-post failure: show error message with recovery options.
+
+        For ``MediaUnsupportedError`` (Meta code 9004) we ALSO create a
+        permanent_reject lock on the underlying media_item. The error is
+        deterministic per-file (HEIC content, GIF, etc.), so without the
+        lock the scheduler would keep re-serving the same item and
+        burning through the same failure on every cycle.
+        """
         logger.error(f"Auto-post failed: {e}", exc_info=True)
+
+        if isinstance(e, MediaUnsupportedError):
+            try:
+                self.service.lock_service.create_lock(
+                    str(ctx.media_item.id),
+                    telegram_chat_id=ctx.chat_id,
+                    lock_reason="permanent_reject",
+                    ttl_days=None,  # NULL = permanent (per CLAUDE.md lock model)
+                )
+                logger.warning(
+                    f"Permanent-rejected media {ctx.media_item.file_name} "
+                    f"after Meta 9004: {e}"
+                )
+            except Exception as lock_err:  # noqa: BLE001
+                # Best-effort — don't let the lock failure mask the
+                # original error from the user.
+                logger.error(
+                    f"Failed to create permanent_reject lock for "
+                    f"media {ctx.media_item.id}: {lock_err}"
+                )
 
         user_msg = self._get_user_friendly_error(e)
         caption = (
@@ -624,6 +652,12 @@ class TelegramAutopostHandler:
         """Map internal exceptions to user-friendly error messages."""
         if isinstance(e, MediaUploadError):
             return "Failed to prepare media for Instagram. This is a server issue — please contact the admin."
+        if isinstance(e, MediaUnsupportedError):
+            return (
+                "Instagram couldn't process this file (Meta error 9004). "
+                "It may be a HEIC photo or an unsupported format. This media "
+                "has been permanently rejected and won't be scheduled again."
+            )
         if isinstance(e, RateLimitError):
             return "Instagram rate limit reached. Please try again later."
         if isinstance(e, TokenRevokedError):

--- a/src/services/integrations/instagram_api.py
+++ b/src/services/integrations/instagram_api.py
@@ -18,6 +18,7 @@ from src.utils.encryption import TokenEncryption
 from src.config.settings import settings
 from src.exceptions import (
     InstagramAPIError,
+    MediaUnsupportedError,
     RateLimitError,
     TokenCorruptError,
     TokenExpiredError,
@@ -380,6 +381,19 @@ class InstagramAPIService(BaseService):
             raise TokenExpiredError(
                 f"OAuth error: {error_message}",
                 error_code=str(error_code),
+            )
+
+        # Media format errors — Meta couldn't parse the file we served
+        # from Cloudinary. Caused by HEIC-as-JPG, GIFs (not allowed for
+        # Stories), or a transformation failure that returned non-image
+        # bytes. Distinct from token errors: a retry won't help; the
+        # autopost handler creates a permanent_reject lock for the
+        # underlying media_item so we don't keep cycling on it.
+        if error_code == 9004:
+            raise MediaUnsupportedError(
+                error_message,
+                error_code=str(error_code),
+                error_subcode=error_subcode,
             )
 
         # General API error

--- a/tests/src/services/test_instagram_api.py
+++ b/tests/src/services/test_instagram_api.py
@@ -8,6 +8,7 @@ import httpx
 
 from src.exceptions import (
     InstagramAPIError,
+    MediaUnsupportedError,
     RateLimitError,
     TokenCorruptError,
     TokenExpiredError,
@@ -313,6 +314,30 @@ class TestInstagramAPIService:
 
         with pytest.raises(InstagramAPIError, match="Internal server error"):
             instagram_service._check_response_errors(mock_response)
+
+    def test_check_response_errors_media_unsupported_code_9004(self, instagram_service):
+        """Meta code 9004 ("Only photo or video can be accepted as media
+        type.") classifies as MediaUnsupportedError so the autopost
+        handler can permanent-reject the failing media item instead of
+        letting it cycle through retries forever."""
+        mock_response = Mock()
+        mock_response.status_code = 400
+        mock_response.json.return_value = {
+            "error": {
+                "code": 9004,
+                "message": "Only photo or video can be accepted as media type.",
+            }
+        }
+
+        with pytest.raises(MediaUnsupportedError) as exc_info:
+            instagram_service._check_response_errors(mock_response)
+
+        assert exc_info.value.error_code == "9004"
+        # Must NOT be classified as a generic InstagramAPIError (it IS a
+        # subclass, but isinstance() check in autopost flow requires
+        # MediaUnsupportedError to come first in the chain to trigger
+        # the permanent_reject lock).
+        assert isinstance(exc_info.value, MediaUnsupportedError)
 
     def test_check_response_errors_invalid_json(self, instagram_service):
         """Test InstagramAPIError when response isn't JSON."""

--- a/tests/src/services/test_telegram_autopost.py
+++ b/tests/src/services/test_telegram_autopost.py
@@ -1023,6 +1023,59 @@ class TestHandleAutopostError:
         assert "Instagram rejected" in call_kwargs["caption"]
         assert "Media too large" in call_kwargs["caption"]
 
+    async def test_media_unsupported_creates_permanent_reject_lock(
+        self, mock_autopost_handler, make_autopost_ctx
+    ):
+        """MediaUnsupportedError (Meta 9004) creates a permanent_reject
+        lock on the underlying media_item so the same file doesn't keep
+        cycling through retries on every scheduler tick."""
+        from src.exceptions.instagram import MediaUnsupportedError
+
+        handler = mock_autopost_handler
+        ctx = make_autopost_ctx()
+
+        await handler._handle_autopost_error(
+            ctx,
+            MediaUnsupportedError(
+                "Only photo or video can be accepted as media type.",
+                error_code="9004",
+            ),
+        )
+
+        # Permanent_reject lock created on the media_item
+        handler.service.lock_service.create_lock.assert_called_once()
+        lock_kwargs = handler.service.lock_service.create_lock.call_args.kwargs
+        assert lock_kwargs["lock_reason"] == "permanent_reject"
+        assert lock_kwargs["ttl_days"] is None  # permanent
+        assert lock_kwargs["telegram_chat_id"] == ctx.chat_id
+        # First positional arg is the media_item.id
+        positional = handler.service.lock_service.create_lock.call_args.args
+        assert positional[0] == str(ctx.media_item.id)
+
+        # User-facing message mentions the permanent rejection
+        caption = ctx.query.edit_message_caption.call_args.kwargs["caption"]
+        assert "9004" in caption
+        assert "permanently rejected" in caption.lower()
+
+    async def test_media_unsupported_lock_failure_does_not_mask_error(
+        self, mock_autopost_handler, make_autopost_ctx
+    ):
+        """If the permanent_reject lock creation itself fails, the user
+        still gets the original 9004 error message (best-effort lock
+        must not swallow the underlying failure)."""
+        from src.exceptions.instagram import MediaUnsupportedError
+
+        handler = mock_autopost_handler
+        ctx = make_autopost_ctx()
+        handler.service.lock_service.create_lock.side_effect = RuntimeError("DB down")
+
+        await handler._handle_autopost_error(
+            ctx, MediaUnsupportedError("Only photo or video", error_code="9004")
+        )
+
+        caption = ctx.query.edit_message_caption.call_args.kwargs["caption"]
+        assert "9004" in caption
+
     async def test_logs_failure_interaction(
         self, mock_autopost_handler, make_autopost_ctx
     ):


### PR DESCRIPTION
## Summary

Meta returns code 9004 ("Only photo or video can be accepted as media type") when the URL we serve from Cloudinary produces output IG can't decode — typically a HEIC photo masquerading as JPG, or a transformation that returned non-image bytes. Until this PR:

1. The error surfaced as a generic `InstagramAPIError` ("Instagram rejected the post: …") with no special handling
2. The underlying `media_item` had no lock, so the scheduler would happily re-schedule the same broken file on every tick — burning through the same failure indefinitely

### B1 — new `MediaUnsupportedError` exception

- `src/exceptions/instagram.py` — new class with explanatory docstring covering the three known root causes (HEIC, unsupported format like GIF, transformation failure).
- `src/exceptions/__init__.py` — re-export.
- `src/services/integrations/instagram_api.py:_check_response_errors` — classifies code 9004 BEFORE the generic catch-all.

### B3 — permanent_reject lock on 9004

- `src/services/core/telegram_autopost.py:_handle_autopost_error` — when `isinstance(e, MediaUnsupportedError)`, calls `lock_service.create_lock(..., lock_reason="permanent_reject", ttl_days=None)`. Best-effort: wrapped in try/except so a lock-creation failure doesn't mask the user-facing error.
- `_get_user_friendly_error` gets a specific message for 9004 that mentions both the error code and the permanent-rejection.

## Live evidence

2026-06-04 16:29:17 UTC, file `78847E67-663F-43FB-A35A-F2D330AB91C5.JPG` hit this exact 9004 error. With this PR shipped, the same item would have been locked on its first failure and the user would see a clear "couldn't process this file (Meta 9004) — permanently rejected, won't be scheduled again" toast instead of the previous generic "Instagram rejected the post" message.

## Tests

- `test_check_response_errors_media_unsupported_code_9004` — asserts new exception type + error_code propagation
- `test_media_unsupported_creates_permanent_reject_lock` — asserts lock created with `lock_reason='permanent_reject'`, `ttl_days=None`, and caption mentions 9004
- `test_media_unsupported_lock_failure_does_not_mask_error` — best-effort lock failure mode

## Test plan

- [x] `pytest tests/src/services/test_instagram_api.py tests/src/services/test_telegram_autopost.py` — 89 passed (3 new, no regressions)
- [x] `ruff check` / `ruff format --check` clean on all touched files
- [ ] Live: next time a HEIC or unsupported file hits autopost, error message clearly mentions 9004 and permanent rejection; the media_item gets a permanent_reject lock; no re-cycling

🤖 Generated with [Claude Code](https://claude.com/claude-code)