### PR TITLE
feat: hourly posting_queue auto-prune loop (A1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **New `MediaUnsupportedError` exception classifies Meta error code 9004** — Previously a 9004 "Only photo or video can be accepted as media type" response (typically: HEIC file masquerading as JPG, or Cloudinary transformation produced output IG can't decode) was classified as a generic `InstagramAPIError`. Now `_check_response_errors` in `instagram_api.py` raises the new `MediaUnsupportedError`, and the autopost handler reacts by creating a **permanent_reject** lock on the underlying media_item so the failing file doesn't keep cycling through retries on every scheduler tick. User sees a clear "couldn't process this file (Meta error 9004) — permanently rejected, won't be scheduled again" message instead of the previous generic error.
+- **Hourly `posting_queue` auto-prune loop** — New `cleanup_queue_loop` mirrors the existing `cleanup_locks_loop` shape. Runs hourly, calls a new `QueueRepository.delete_stale(hours=24)` to remove any queue item whose `scheduled_for` is more than 24 hours past. Prevents the May 17 → 19 outage style of accumulation that left 954 stale rows in `posting_queue` until manual cleanup on 2026-06-02. Distinct from the existing `delete_stale_pending(max_age_minutes=10)` which targets short-window JIT scheduler hygiene; this catches the long-tail.
 
 ### Fixed
 

--- a/src/main.py
+++ b/src/main.py
@@ -18,6 +18,7 @@ from src.services.core.loops.lifecycle import (
 from src.services.core.loops.scheduler_loop import run_scheduler_loop
 from src.services.core.loops.lock_cleanup_loop import cleanup_locks_loop
 from src.services.core.loops.cloud_cleanup_loop import cleanup_cloud_storage_loop
+from src.services.core.loops.queue_cleanup_loop import cleanup_queue_loop
 from src.services.core.loops.transaction_cleanup_loop import transaction_cleanup_loop
 from src.services.core.loops.media_sync_loop import media_sync_loop
 from src.utils.logger import logger
@@ -107,12 +108,14 @@ async def main_async():
     from src.services.core.telegram_service import TelegramService
     from src.services.core.media_lock import MediaLockService
     from src.services.core.media_sync import MediaSyncService
+    from src.repositories.queue_repository import QueueRepository
 
     scheduler_service = SchedulerService()
     posting_service = PostingService()
     telegram_service = TelegramService()
     lock_service = MediaLockService()
     settings_service = SettingsService()
+    queue_repo = QueueRepository()
 
     # Media sync runs unconditionally — the loop iterates per-chat and skips
     # chats with media_sync_enabled=False. No env gate.
@@ -150,6 +153,9 @@ async def main_async():
         ),
         asyncio.create_task(
             guarded("lock_cleanup", lambda: cleanup_locks_loop(lock_service), bot=bot)
+        ),
+        asyncio.create_task(
+            guarded("queue_cleanup", lambda: cleanup_queue_loop(queue_repo), bot=bot)
         ),
         asyncio.create_task(telegram_service.start_polling()),
     ]

--- a/src/repositories/queue_repository.py
+++ b/src/repositories/queue_repository.py
@@ -251,6 +251,49 @@ class QueueRepository(BaseRepository):
             return True
         return False
 
+    def delete_stale(self, hours: int = 24) -> int:
+        """Delete queue items whose scheduled_for is older than ``hours`` ago.
+
+        Broad sweeper for the long-tail case where queue items accumulate
+        during an upstream outage (Instagram API down, scheduler stuck,
+        etc.) and never get processed. Distinct from
+        ``delete_stale_pending(max_age_minutes=10)`` which is the JIT
+        scheduler's short-window hygiene; this catches the day-scale
+        accumulation that caused the 2026-05-17 → 19 burst (954 rows
+        had to be manually deleted on 2026-06-02).
+
+        Runs hourly via ``cleanup_queue_loop``. Deletes regardless of
+        status — by the time an item is >24h past its scheduled_for it
+        will never be relevant again, whether it's pending, processing,
+        or failed.
+
+        Args:
+            hours: Age threshold in hours (default: 24).
+
+        Returns:
+            Number of items deleted.
+        """
+        cutoff = datetime.utcnow() - timedelta(hours=hours)
+        stale = (
+            self.db.query(PostingQueue)
+            .filter(PostingQueue.scheduled_for < cutoff)
+            .all()
+        )
+
+        count = len(stale)
+        if not count:
+            return 0
+
+        oldest = min(i.scheduled_for for i in stale)
+        for item in stale:
+            self.db.delete(item)
+        self.db.commit()
+        logger.info(
+            f"Deleted {count} queue items older than {hours}h "
+            f"(oldest scheduled_for: {oldest})"
+        )
+        return count
+
     def delete_stale_pending(self, max_age_minutes: int = 10) -> int:
         """Delete pending items that were never sent to Telegram.
 

--- a/src/services/core/loops/heartbeat.py
+++ b/src/services/core/loops/heartbeat.py
@@ -12,6 +12,7 @@ LOOP_EXPECTED_INTERVALS: dict[str, int] = {
     "scheduler": 60,
     "lock_cleanup": 3600,
     "cloud_cleanup": 3600,
+    "queue_cleanup": 3600,
     "media_sync": 300,
     "transaction_cleanup": 60,
 }

--- a/src/services/core/loops/queue_cleanup_loop.py
+++ b/src/services/core/loops/queue_cleanup_loop.py
@@ -1,0 +1,32 @@
+"""Queue cleanup loop — prunes stale posting_queue rows hourly.
+
+Distinct from the existing ``delete_stale_pending(max_age_minutes=10)`` JIT
+cleanup which targets short-window scheduler hygiene. This loop catches
+the long-tail case where items pile up during an upstream outage and
+never get processed (see the 2026-05-17 → 19 burst: 954 items
+accumulated over 17 days before manual cleanup). Without this loop a
+similar incident would silently bloat the table again.
+"""
+
+import asyncio
+
+from src.services.core.loops.heartbeat import record_heartbeat
+from src.repositories.queue_repository import QueueRepository
+from src.utils.logger import logger
+
+
+async def cleanup_queue_loop(queue_repo: QueueRepository) -> None:
+    """Run cleanup loop - remove queue items older than 24h every hour."""
+    logger.info("Starting queue cleanup loop...")
+
+    while True:
+        record_heartbeat("queue_cleanup")
+        try:
+            await asyncio.sleep(3600)
+            count = queue_repo.delete_stale(hours=24)
+
+            if count > 0:
+                logger.info(f"Cleaned up {count} stale queue items (>24h old)")
+
+        except Exception as e:
+            logger.error(f"Error in queue cleanup loop: {e}", exc_info=True)

--- a/tests/src/repositories/test_queue_repository.py
+++ b/tests/src/repositories/test_queue_repository.py
@@ -95,6 +95,42 @@ class TestQueueRepository:
         # commit called once by get_by_id's end_read_transaction (no write commit)
         mock_db.commit.assert_called_once()
 
+    def test_delete_stale_removes_old_items_regardless_of_status(
+        self, queue_repo, mock_db
+    ):
+        """delete_stale(hours=24) wipes anything past the cutoff.
+
+        Regression context: 2026-05-17 → 19 outage left 954 stale rows
+        in posting_queue, eventually deleted manually on 2026-06-02.
+        This loop runs hourly to prevent the same buildup.
+        """
+        stale_item_a = MagicMock()
+        stale_item_a.scheduled_for = datetime.utcnow() - timedelta(days=10)
+        stale_item_b = MagicMock()
+        stale_item_b.scheduled_for = datetime.utcnow() - timedelta(days=2)
+        mock_db.query.return_value.filter.return_value.all.return_value = [
+            stale_item_a,
+            stale_item_b,
+        ]
+
+        count = queue_repo.delete_stale(hours=24)
+
+        assert count == 2
+        assert mock_db.delete.call_count == 2
+        mock_db.delete.assert_any_call(stale_item_a)
+        mock_db.delete.assert_any_call(stale_item_b)
+        mock_db.commit.assert_called_once()
+
+    def test_delete_stale_no_op_when_no_stale_items(self, queue_repo, mock_db):
+        """No commit fired when there's nothing to delete (cheap idle tick)."""
+        mock_db.query.return_value.filter.return_value.all.return_value = []
+
+        count = queue_repo.delete_stale(hours=24)
+
+        assert count == 0
+        mock_db.delete.assert_not_called()
+        mock_db.commit.assert_not_called()
+
     def test_delete_queue_item(self, queue_repo, mock_db):
         """Test deleting a queue item."""
         mock_item = MagicMock()

--- a/tests/src/test_main_scheduler_loop.py
+++ b/tests/src/test_main_scheduler_loop.py
@@ -839,6 +839,7 @@ class TestLoopLiveness:
             "scheduler",
             "lock_cleanup",
             "cloud_cleanup",
+            "queue_cleanup",
             "media_sync",
             "transaction_cleanup",
         }


### PR DESCRIPTION
## Summary

Adds an hourly cleanup loop that deletes any \`posting_queue\` row whose \`scheduled_for\` is more than 24h in the past. Prevents the kind of accumulation that caused the May 17 → 19 outage to leave **954 stale rows** in the table until manual cleanup on 2026-06-02.

## Why a new loop instead of extending the existing one

There's already a \`delete_stale_pending(max_age_minutes=10)\` method — that's the JIT scheduler's hygiene for \`pending\` items orphaned by crashes within a 10-minute window. This is the long-tail counterpart: items that survived past their scheduled time (regardless of status) because nothing else cleaned them up. Different cutoff, different intent, different status filter — kept as a separate method to avoid overloading the meaning of either.

## Changes

| File | Change |
|---|---|
| \`src/services/core/loops/queue_cleanup_loop.py\` (NEW, 32 lines) | Mirrors \`lock_cleanup_loop\` shape exactly: \`while True / sleep 3600 / call cleanup / log on count > 0\`. \`record_heartbeat("queue_cleanup")\` so the health server can detect a stuck loop. |
| \`src/repositories/queue_repository.py\` | New \`delete_stale(hours=24)\` method. Logs the count and oldest \`scheduled_for\` when something gets deleted. |
| \`src/main.py\` | Instantiate \`QueueRepository\`, add the new loop to the \`tasks\` list under the same \`guarded(...)\` wrapper as the other cleanup loops. |
| Tests | 2 new cases: deletes stale items regardless of status, no-op when none stale. |

## Test plan

- [x] \`pytest tests/src/repositories/test_queue_repository.py\` — 31 passed
- [x] \`ruff check\` / \`ruff format --check\` clean
- [x] \`python -c "import src.main"\` — no import errors
- [ ] Live post-deploy: monitor \`posting_queue\` row count over 24h. After the first hourly tick with stale items present, expect a \`"Cleaned up N stale queue items (>24h old)"\` log line and a drop in row count.

🤖 Generated with [Claude Code](https://claude.com/claude-code)