### PR TITLE
docs: reconcile documentation against codebase reality (2026-07-06 audit)

### DIFF
--- a/.claude/PROJECT_CONTEXT.md
+++ b/.claude/PROJECT_CONTEXT.md
@@ -62,8 +62,11 @@ Storydump is a self-hosted Instagram Story scheduling system with Telegram-based
 | `posting_queue` | Scheduled posts (ephemeral work items) |
 | `posting_history` | Permanent audit log of all posts |
 | `instagram_accounts` | Multi-account support (Phase 1.5) |
-| `chat_settings` | Per-Telegram-chat configuration |
+| `chat_settings` | Per-Telegram-chat configuration — **one row per tenant/instance** |
 | `api_tokens` | Encrypted OAuth tokens |
+| `user_chat_memberships` | User ↔ instance (chat_settings) membership — backs the multi-instance dashboard and `/start` instance picker. **Security-sensitive**: this is the table that scopes a user to their tenant(s); a 2026-07 audit found and fixed a cross-tenant IDOR where onboarding/dashboard endpoints didn't check it (see SECURITY_REVIEW.md §10 addendum) |
+| `onboarding_sessions` | Short-lived DM onboarding conversation state (naming → awaiting_group → complete) |
+| `category_mix` | Type 2 SCD history of per-category posting ratios |
 
 ---
 
@@ -107,14 +110,17 @@ Storydump is a self-hosted Instagram Story scheduling system with Telegram-based
 
 ---
 
-## Current Version: v1.6.0
+## Current Version: v1.6.0 (string is stale — see note)
 
 - ✅ Phase 1: Telegram manual posting
 - ✅ Phase 1.5: Multi-account support
 - ✅ Phase 1.6: Settings & Telegram UX
 - ✅ Phase 2: Instagram API automation
+- ✅ Multi-tenant / multi-instance rearchitecture (User → Instances, `user_chat_memberships`, `/start` instance picker, `landing/` Next.js web dashboard) — shipped after v1.6.0, not reflected in the version string. See `PROJECT_MISSION.md` for the current mental model.
 - 🔲 Phase 3: Shopify integration
-- 🔲 Phase 4+: Web UI, analytics
+- 🔲 Phase 4+: LLM integration, order/email automation
+
+**Note:** `src/__init__.py` still hardcodes `__version__ = "1.6.0"` despite 40+ migrations and dozens of unreleased PRs since (see `CHANGELOG.md` `[Unreleased]`). Don't treat the version string as a feature-completeness signal.
 
 ---
 

--- a/.claude/QUICK_REFERENCE.md
+++ b/.claude/QUICK_REFERENCE.md
@@ -73,10 +73,12 @@ psql "$DATABASE_URL" -c "SELECT * FROM instagram_accounts WHERE is_active = true
 | File | Contains |
 |------|----------|
 | `src/services/core/telegram_service.py` | Telegram bot handlers |
-| `src/services/core/posting_service.py` | Posting orchestration |
+| `src/services/core/posting.py` | Posting orchestration (`PostingService`) |
 | `src/services/core/scheduler.py` | Schedule creation |
+| `src/services/core/start_command_router.py` | 5-branch `/start` handler (DM onboarding, instance list, group linking) |
 | `src/services/integrations/instagram_api.py` | Instagram Graph API |
-| `src/models/chat_settings.py` | Per-chat settings |
+| `src/models/chat_settings.py` | Per-chat settings (one per tenant/instance) |
+| `src/models/user_chat_membership.py` | User ↔ instance membership (multi-account dashboard) |
 
 ---
 

--- a/.claude/rules/database.md
+++ b/.claude/rules/database.md
@@ -16,6 +16,8 @@ paths:
 
 **Integration** (Phase 2+): `api_tokens` (encrypted OAuth tokens, FK to `instagram_accounts`)
 
+**Multi-instance** (post-v1.6.0, see `documentation/planning/multi-account-dashboard.md`): `user_chat_memberships` (user ↔ `chat_settings` membership — the tenant boundary check; a 2026-06 security fix (#511/#512) makes this the required gate for onboarding/dashboard endpoints when a token doesn't cryptographically bind a chat_id), `onboarding_sessions` (short-lived DM onboarding conversation state, one active per user)
+
 ## Settings Architecture
 
 - `chat_settings` table with `.env` as fallback
@@ -36,7 +38,7 @@ paths:
 2. **TTL Locks** (`media_posting_locks`): Lock types: `recent_post`, `manual_hold`, `seasonal`, `permanent_reject`, `skip`. Permanent locks: `locked_until = NULL`.
 3. **User Auto-Discovery**: Users created automatically from Telegram interactions. No separate registration.
 4. **Type 2 SCD**: Used for `category_post_case_mix` (ratio auditing) and future `shopify_products`.
-5. **Tenant Boundary**: `chat_settings` is the tenant boundary. All tenant FKs nullable (`NULL` = legacy single-tenant data).
+5. **Tenant Boundary**: `chat_settings` is the tenant boundary for data (all tenant FKs nullable, `NULL` = legacy single-tenant data). `user_chat_memberships` is the **access** boundary — it answers "can this user act on this tenant," which is a separate check from "is this user authenticated." Any new endpoint/handler that accepts a `chat_id`/`chat_settings_id` from the caller must verify active membership, not just authentication — this is the exact class of bug fixed in #511/#512.
 
 ## Creating Migrations
 

--- a/.claude/rules/telegram.md
+++ b/.claude/rules/telegram.md
@@ -15,8 +15,14 @@ paths:
 | `/next` | Force-send next post now | `telegram_commands.py` |
 | `/cleanup` | Delete recent bot messages | `telegram_commands.py` |
 | `/setup` / `/settings` | Quick settings & toggles | `telegram_settings.py` |
+| `/instances` | List your instances (DM) | `telegram_commands.py` (`StartCommandRouter`) |
+| `/new` | Create a new instance (DM) | `telegram_commands.py` (`StartCommandRouter`) |
+| `/name` | Set instance display name (group) | `telegram_commands.py` (`StartCommandRouter`) |
+| `/link` | Link group to pending onboarding session | `telegram_commands.py` (`StartCommandRouter`) |
 
 **Retired commands**: `/queue`, `/pause`, `/resume`, `/history`, `/sync`, `/schedule`, `/stats`, `/locks`, `/reset`, `/dryrun`, `/backfill`, `/connect` — respond with redirect messages but are not listed in the bot menu.
+
+**Multi-instance note**: `/start` delegates to `StartCommandRouter` (`start_command_router.py`), a 6-branch handler covering DM onboarding (new user), DM returning-user instance list, DM active-onboarding resume, mobile-login redirect, group + `startgroup` payload linking, and standard group setup. See `documentation/planning/multi-account-dashboard.md` for the design — note `get_settings()`'s `create_if_missing` split (needed so DM flows don't create phantom `chat_settings` rows) is only partially applied: as of 2026-07-06, `SetupStateService.get_setup_state()`, `DashboardService._resolve_chat_settings_id()`, and the `onboarding/init` chain still default to creating phantoms in DM context.
 
 ## Callback Actions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,13 +11,14 @@ Domain-specific rules are in `.claude/rules/` and load automatically when workin
 
 ### NEVER run these commands:
 ```bash
-storydump-cli process-queue          # Posts to Instagram/Telegram
-storydump-cli process-queue --force  # Posts to Instagram/Telegram
-python -m src.main                   # Starts posting scheduler
-storydump-cli create-schedule        # Modifies production schedule
+python -m src.main                   # Starts the JIT posting scheduler (worker) + Telegram bot
 storydump-cli reset-queue            # Modifies production queue
 storydump-cli instagram-auth         # Modifies authentication
+storydump-cli revoke-tokens          # Revokes live OAuth tokens for a service (breaks posting until re-auth)
+storydump-cli rotate-keys            # Re-encrypts all stored tokens with a new key; wrong ENCRYPTION_KEYS ordering can lose access to tokens. No dry-run.
 ```
+
+**Note (verified 2026-07-06):** `storydump-cli process-queue` and `storydump-cli create-schedule` no longer exist as CLI commands — the manual Phase-1-era "generate a schedule, then process it" workflow was replaced by the always-on JIT scheduler inside `python -m src.main` (see `.claude/rules/scheduler.md`). That command is still correctly listed above as the actual trigger for automatic posting.
 
 ### SAFE commands you CAN run:
 ```bash
@@ -27,6 +28,8 @@ storydump-cli list-categories
 storydump-cli list-users
 storydump-cli check-health
 storydump-cli instagram-status
+storydump-cli list-instagram-accounts
+storydump-cli google-drive-status
 storydump-cli validate-image <path>
 storydump-cli category-mix-history
 storydump-cli sync-media
@@ -55,17 +58,17 @@ pytest                               # Tests - always safe
 - **API**: `uvicorn src.api.app:app` (REST API + Mini App)
 - **Database**: Neon PostgreSQL — connect via `psql "$DATABASE_URL"`
 - Env vars are per-service — must set on both worker AND API
-- **NEVER run on production**: `process-queue`, `python -m src.main`, or mutating SQL on `posting_history`
+- **NEVER run on production**: `python -m src.main` (starts the JIT scheduler — see CRITICAL SAFETY RULES above), or mutating SQL on `posting_history`
 
 ---
 
 ## Project Overview
 
-**Storydump** is a self-hosted Instagram Story scheduling and automation system with Telegram-based team collaboration.
+**Storydump** is a multi-tenant Instagram Story scheduling and automation system with Telegram-based team collaboration. A single deployment serves many independent teams ("Instances"), each scoped to its own Telegram group, media, queue, and schedule — see `PROJECT_MISSION.md` for the current product mental model (User → Instances → accounts/media/queue).
 
-**Core Philosophy**: Phased deployment — 100% manual posting (Phase 1), optional Instagram API automation (Phase 2), web UI (Phase 3).
+**Core Philosophy**: Phased delivery — 100% manual posting (Phase 1), optional Instagram API automation (Phase 2), multi-tenant rearchitecture (shipped post-v1.6.0), web dashboard (in progress). See `documentation/planning/phases/00_MASTER_ROADMAP.md` for current per-phase status — don't treat "Phase 3" as "web UI"; the phase docs number Phase 3 as Shopify integration and the dashboard as Phase 7 (currently in progress).
 
-**Tech Stack**: Python 3.10+, FastAPI, Neon PostgreSQL, Telegram Bot, Railway deployment, Next.js landing site.
+**Tech Stack**: Python 3.10+, FastAPI, Neon PostgreSQL, Telegram Bot, Railway deployment, Next.js (`landing/` — both the marketing site and the multi-tenant web dashboard).
 
 ## Architecture: STRICT SEPARATION OF CONCERNS
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A self-hosted Instagram Story scheduling system with Telegram-based team collabo
 
 ## Features
 
+- 🏢 **Multi-Tenant / Multi-Instance**: One deployment serves many independent teams, each scoped to its own Telegram group, media, queue, and schedule
+- 🖥️ **Web Dashboard**: Next.js dashboard with an instance picker for managing multiple accounts
 - 📅 **Smart Scheduling**: Intelligent posting schedule based on your preferences
 - 📁 **Category-Based Scheduling**: Organize media by folder (memes/, merch/) with configurable ratios
 - 📱 **Telegram Integration**: Team collaboration via Telegram bot with lifecycle notifications
@@ -223,13 +225,25 @@ The bot responds to these commands in Telegram:
 - ✅ Message tracking (100-message cache) for efficient cleanup
 - ✅ TelegramService refactored from 3,500-line monolith into 5 handler modules
 - ✅ Verbose settings expansion (controls more message types)
-- ✅ 488 comprehensive tests
+- ✅ 2,038 tests across 103 files (grown well past the v1.6.0-era count below — see [TEST_COVERAGE.md](documentation/guides/TEST_COVERAGE.md))
+
+**Multi-Tenant / Multi-Instance Rearchitecture** - ✅ SHIPPED (post-v1.6.0, not yet version-tagged):
+
+Storydump moved from "one self-hosted deployment per team" to a multi-tenant model: a single deployment now serves many independent teams ("Instances"), each scoped to its own Telegram group, media, queue, and schedule. See `PROJECT_MISSION.md` for the current product mental model (User → Instances → accounts/media/queue).
+
+- ✅ `user_chat_memberships` table linking Telegram users to the instances (chat_settings rows) they belong to
+- ✅ 5-branch `/start` handler (`StartCommandRouter`) — DM onboarding for new users, returning-user instance list, group linking, and unchanged existing group setup
+- ✅ Web dashboard (`landing/`, Next.js on Vercel) with an instance picker and switcher — see [documentation/guides/landing-vercel-deployment.md](documentation/guides/landing-vercel-deployment.md)
+- ✅ Mini App instance picker for DM-launched sessions
+- ⚠️ **2026-07 security note:** a cross-tenant data-isolation gap in the onboarding/dashboard API and Telegram queue callbacks was found and fixed (see `documentation/SECURITY_REVIEW.md` §10 addendum). Role-based (member vs. admin) command authorization for multi-tenant is tracked as a follow-up, not yet implemented.
+
+**Phase 3+ (Shopify, Printify, LLM integration, order/email automation)** - 📋 PENDING — see [documentation/planning/phases/00_MASTER_ROADMAP.md](documentation/planning/phases/00_MASTER_ROADMAP.md) for the full phase breakdown and current status.
 
 ## Development
 
 ### Running Tests
 
-The project includes 488 comprehensive tests with automatic test database setup:
+The project includes 2,038 tests (103 files) with automatic test database setup:
 
 ```bash
 # Run all tests with coverage
@@ -249,17 +263,22 @@ storydump-cli process-queue --force
 
 ```
 storydump/
-├── src/                    # Main application code
+├── src/                    # Main application code (Python/FastAPI)
+│   ├── api/               # REST API + Mini App onboarding routes
 │   ├── config/            # Configuration management
 │   ├── models/            # Database models
 │   ├── repositories/      # Data access layer
 │   ├── services/          # Business logic
+│   │   ├── core/          # Telegram bot, posting, scheduling, dashboard, membership
+│   │   ├── integrations/  # Instagram Graph API, Google Drive, Cloudinary
+│   │   └── media_sources/ # Pluggable media source providers
 │   ├── utils/             # Utility functions
-│   └── main.py            # Application entry point
+│   └── main.py            # Application entry point (worker: bot + scheduler)
+├── landing/               # Next.js web dashboard + marketing site (Vercel)
 ├── cli/                   # CLI commands
-├── tests/                 # Test suite
-├── scripts/               # Database scripts
-└── media/                 # Media storage
+├── tests/                 # Test suite (100+ files)
+├── scripts/               # Database scripts + migrations
+└── media/                 # Local media storage (dev only — prod uses Google Drive)
     └── stories/           # Instagram stories
         ├── memes/         # Meme content
         └── merch/         # Merchandise content
@@ -273,7 +292,8 @@ Key resources:
 - **[Quick Start Guide](documentation/guides/quickstart.md)** - Get running in 10 minutes
 - **[Deployment Guide](documentation/guides/deployment.md)** - Production deployment checklist
 - **[Testing Guide](documentation/guides/testing-guide.md)** - How to run and write tests
-- **[Technical Specification](documentation/planning/instagram_automation_plan.md)** - Complete implementation plan
+- **[Master Roadmap](documentation/planning/phases/00_MASTER_ROADMAP.md)** - Architecture, phase status, and forward plan
+- **[Project Mission](PROJECT_MISSION.md)** - Product vision and multi-instance mental model
 - **[Developer Guide](CLAUDE.md)** - Development guidelines and architecture
 
 ## License

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -2,11 +2,13 @@
 
 Welcome to the Storydump documentation hub. All project documentation is organized here by purpose.
 
-**Last Updated**: 2026-03-28
-**Current Version**: v1.6.0
-**Current Phase**: Phase 2 (Instagram API Automation) - COMPLETED | Phase 1.8 (Telegram UX) - COMPLETED
+**Last Updated**: 2026-07-06 (docs audit — see note below)
+**Current Version**: v1.6.0 in `src/__init__.py`, but stale — see [PROJECT_MISSION.md](../PROJECT_MISSION.md) and [planning/phases/00_MASTER_ROADMAP.md](planning/phases/00_MASTER_ROADMAP.md) for what has actually shipped since
+**Current Phase**: Phase 2 (Instagram API Automation) - COMPLETED | Multi-tenant/multi-instance rearchitecture - SHIPPED (post-v1.6.0, unplanned in this index until now)
 **Next Phase**: Phase 3 (Shopify Integration) - PENDING
-**Deployment**: Railway (worker + API) + Neon PostgreSQL
+**Deployment**: Railway (worker + API) + Neon PostgreSQL + Vercel (`landing/` web dashboard)
+
+> **2026-07-06 audit note**: This index had drifted significantly from the codebase — it linked to an `archive/` directory that was intentionally purged 2026-04-28 (#311), was missing ~15 documents that were never added to this index, and understated test counts. This pass fixes the structural issues; see the "Documentation Coverage" table at the bottom for what's now current vs. still worth a follow-up pass.
 
 ## Documentation Structure
 
@@ -15,6 +17,7 @@ documentation/
 ├── README.md (this file)          # Documentation index
 ├── ROADMAP.md                     # Product roadmap and version history
 ├── SECURITY_REVIEW.md             # Security audit findings
+├── api/                            # API reference (added 2026-07-06)
 ├── planning/                       # Planning and design documents
 │   ├── phases/                    # Phased implementation plans
 │   │   ├── 00_MASTER_ROADMAP.md   # Vision, architecture, phase overview
@@ -23,63 +26,74 @@ documentation/
 │   │   ├── 04_media_product_linking.md      # PENDING
 │   │   ├── 05_llm_integration.md            # PENDING
 │   │   ├── 06_order_email_automation.md     # PENDING
-│   │   └── 07_dashboard_ui.md              # PENDING
-│   └── 01B_telegram_mini_app_secure_input.md  # PENDING (Future)
+│   │   └── 07_dashboard_ui.md              # see status in index below
+│   ├── feed-queue-features/       # Feed & queue research docs
+│   └── investigations/            # Dated incident/bug investigations
 ├── guides/                         # How-to guides and tutorials
-├── operations/                     # Operational runbooks
-├── updates/                        # Project updates, bugfixes, patches
-└── archive/                        # Completed/obsolete documents
+├── operations/                     # Operational runbooks + postmortems
+└── updates/                        # Retired 2026-07-06 (historical only — see CHANGELOG.md)
 ```
+*(There is no `archive/` directory — it was intentionally purged 2026-04-28 (#311); superseded docs live in git history instead. `documentation/README.md`'s "Archive" section below was not fully cleaned up after that purge until this audit.)*
 
 ---
 
 ## Planning & Architecture
 
 ### Master Roadmap
-**[phases/00_MASTER_ROADMAP.md](planning/phases/00_MASTER_ROADMAP.md)** - Phases 1-2.5 COMPLETED
+**[phases/00_MASTER_ROADMAP.md](planning/phases/00_MASTER_ROADMAP.md)** - see file for current per-phase status table (corrected 2026-07-06; the previous "8 phases total, 5 completed, 6 pending" summary here didn't add up and has been removed rather than replaced with another guess)
 - Vision: E-commerce Optimization Hub for Social Media Marketing
 - Architecture principles (strict separation of concerns)
 - Service naming conventions and data model strategy
 - Data flow diagrams (current Phase 2 and future Phase 5+)
-- Phase overview with status markers (8 phases total, 5 completed, 6 pending)
+- Note: this file references `01_settings_and_multitenancy.md` and `archive/01_instagram_api.md` — neither exists in the repo (flagged in-file 2026-07-06)
 
 ### Active Phase Planning Documents
 
-**[phases/02_shopify_integration.md](planning/phases/02_shopify_integration.md)** - PENDING
+**[phases/02_shopify_integration.md](planning/phases/02_shopify_integration.md)** - PENDING (verified 2026-07-06 — no Shopify code/tables/tests exist beyond an enum-style string mention)
 - Shopify Admin API integration, product catalog sync (Type 2 SCD), order tracking
 
-**[phases/03_printify_integration.md](planning/phases/03_printify_integration.md)** - PENDING
+**[phases/03_printify_integration.md](planning/phases/03_printify_integration.md)** - PENDING (verified 2026-07-06)
 - Printify API for print-on-demand, product/blueprint sync, fulfillment tracking
 
-**[phases/04_media_product_linking.md](planning/phases/04_media_product_linking.md)** - PENDING
+**[phases/04_media_product_linking.md](planning/phases/04_media_product_linking.md)** - PENDING (verified 2026-07-06 — `src/services/domain/` exists but is empty)
 - Many-to-many media-product relationships, attribution tracking, performance analytics
 
-**[phases/05_llm_integration.md](planning/phases/05_llm_integration.md)** - PENDING
+**[phases/05_llm_integration.md](planning/phases/05_llm_integration.md)** - PENDING (verified 2026-07-06)
 - LLM service abstraction (Claude/OpenAI), content suggestions, email drafting
+- Note: `src/services/core/caption_service.py` already calls the Anthropic API in production for AI-generated captions (migration 026, `ANTHROPIC_API_KEY` + `enable_ai_captions`) — a real, shipped LLM feature, but architecturally unrelated to this plan's spec. Kept as PENDING since it isn't a stepping-stone toward this specific design, not because no LLM usage exists at all.
 
-**[phases/06_order_email_automation.md](planning/phases/06_order_email_automation.md)** - PENDING
+**[phases/06_order_email_automation.md](planning/phases/06_order_email_automation.md)** - PENDING (verified 2026-07-06)
 - Order notifications via Telegram, Gmail API, LLM-drafted customer responses
 
-**[phases/07_dashboard_ui.md](planning/phases/07_dashboard_ui.md)** - PENDING
+**[phases/07_dashboard_ui.md](planning/phases/07_dashboard_ui.md)** - 🔧 IN PROGRESS (status corrected 2026-07-06, was PENDING)
 - Next.js web dashboard, analytics visualizations, media-product management
+- A real dashboard is live at `landing/src/app/(dashboard)/` (Overview, Media Library, Analytics, Settings, Setup Wizard) matching much of this doc's tech-stack section — but it shipped via the separate multi-tenant/onboarding initiative, not by executing this plan, and uses a different architecture (Next.js BFF + signed Telegram `init_data`, not a generic JWT REST API). Missing this doc's Product & Performance section entirely (depends on Shopify/Printify, which don't exist yet). See in-file notes for detail.
 
 ### Feed & Queue Features (Research)
 
-**[feed-queue-features/00_OVERVIEW.md](planning/feed-queue-features/00_OVERVIEW.md)** - RESEARCH (3 workstreams)
-- **[01: Live Story Visibility](planning/feed-queue-features/01_live_story_visibility.md)** — Fetch & display live stories in `/status` (Ready)
-- **[02: Feed Reset](planning/feed-queue-features/02_feed_reset.md)** — Clear live stories from Instagram (Blocked — no DELETE API)
-- **[03: Queue Enhancements](planning/feed-queue-features/03_queue_enhancements.md)** — Queue preview, health indicators, quick refill (Ready)
+*Note: this index previously linked `00_OVERVIEW.md` and `03_queue_enhancements.md` — neither file exists; removed 2026-07-06.*
+
+- **[01: Live Story Visibility](planning/feed-queue-features/01_live_story_visibility.md)** — Fetch & display live stories in `/status` (Ready, not yet implemented — verified 2026-07-06; doc also flags a stale API host reference worth fixing before implementation)
+- **[02: Feed Reset](planning/feed-queue-features/02_feed_reset.md)** — Clear live stories from Instagram (Blocked — confirmed 2026-07-06, still no Instagram DELETE API for stories)
 
 ### Other Planning Documents
 
-**[01B_telegram_mini_app_secure_input.md](planning/01B_telegram_mini_app_secure_input.md)** - PENDING (Future)
-- Telegram Mini App for secure credential input (replaces message-based token entry)
-- Decision: proceed with message-based approach for now
+*The following documents existed on disk but were never linked from this index — added 2026-07-06 after a full documentation audit:*
+
+- **[2026-03-31-meta-app-launch-design.md](planning/2026-03-31-meta-app-launch-design.md)** - ✅ COMPLETED — Meta Graph API v21.0 bump + `InstagramLoginOAuthService`, live in production
+- **[2026-05-18-instagram-credential-refactor.md](planning/2026-05-18-instagram-credential-refactor.md)** - ✅ COMPLETED — all 5 PRs landed (migrations 035-041); `instagram_accounts.instagram_account_id` legacy column intentionally kept, tracked as a separate follow-up
+- **[instagram-deeplink-redirect.md](planning/instagram-deeplink-redirect.md)** - ⚠️ BUILT BUT NOT ACTIVATED — `docs/index.html` implements the redirect exactly as designed, but the bot's "Open Instagram" button still points at the plain `instagram.com` feed URL; the env var to wire it up was added then deliberately removed 2026-05-12. The page is live on GitHub Pages but nothing links to it.
+- **[per-request-session-isolation.md](planning/per-request-session-isolation.md)** - 📋 PLANNING ONLY — confirmed nothing implemented yet, not currently scheduled
+- **[web-app-migration-plan.md](planning/web-app-migration-plan.md)** - ✅ COMPLETED (substantially) — `landing/` is the full app this plan envisioned; several naming/implementation details diverged from the original sketch (see doc for specifics). Strong candidate for archiving/closing out.
+- **[investigations/ig-oauth-cross-flow-reconnect_2026-05-25/](planning/investigations/ig-oauth-cross-flow-reconnect_2026-05-25/)** - ✅ RESOLVED — reconnect-loop fix shipped and verified live (#441)
+- **[investigations/ig-host-routing_2026-06-02/](planning/investigations/ig-host-routing_2026-06-02/)** - ✅ RESOLVED — all 5 planned PRs merged 2026-06-02/03, no recurrence since
+
+**Also see:** [planning/multi-account-dashboard.md](planning/multi-account-dashboard.md) — the multi-tenant/multi-instance design doc, ~88% verified-implemented as of 2026-07-06 (moved here from the repo root during this audit — it previously lived outside `documentation/`). See the [Multi-Tenant / Multi-Instance Rearchitecture](ROADMAP.md#multi-tenant--multi-instance-rearchitecture-shipped) entry in ROADMAP.md.
 
 ### Test Coverage Report
-**[TEST_COVERAGE.md](guides/TEST_COVERAGE.md)** - CURRENT (1,417 tests)
-- Test suite summary by layer (77 test files)
-- Phase 1.6 through Phase 2 test additions
+**[TEST_COVERAGE.md](guides/TEST_COVERAGE.md)** - Top-line counts refreshed 2026-07-06 (2,038 tests via `pytest --collect-only`, 103 files — per-layer breakdown further down the doc is older and unverified)
+- Test suite summary by layer (103 test files)
+- Phase 1.6 through Phase 2 test additions, plus substantial growth since (multi-tenant work)
 - Coverage gaps and future work
 - Test infrastructure documentation
 
@@ -115,7 +129,7 @@ documentation/
 **[testing-guide.md](guides/testing-guide.md)**
 - Automatic test database setup and fixture architecture
 - Running tests: `make test`, `make test-unit`, `pytest` with markers
-- 1,417 tests collected as of v1.6.0
+- 2,038 tests collected as of 2026-07-06 (was 1,417 as of v1.6.0 — see [TEST_COVERAGE.md](guides/TEST_COVERAGE.md))
 - Test fixtures and patterns (session-scoped DB, function-scoped transactions)
 - CI/CD integration (GitHub Actions)
 
@@ -126,6 +140,16 @@ documentation/
 - Cloudinary integration for media hosting
 - Multi-account management via CLI commands
 - Token bootstrapping (.env to DB), encryption, and troubleshooting
+
+### Instagram Login Setup
+**[instagram-login-setup.md](guides/instagram-login-setup.md)**
+- Newer "Instagram Login" OAuth flow (distinct from the legacy Facebook Login flow above)
+- Added as part of the 2026-05 credential refactor — see [planning/2026-05-18-instagram-credential-refactor.md](planning/2026-05-18-instagram-credential-refactor.md)
+
+### Landing Site / Dashboard Deployment (Vercel)
+**[landing-vercel-deployment.md](guides/landing-vercel-deployment.md)**
+- Deploying the `landing/` Next.js web dashboard + marketing site to Vercel
+- Environment variables, BFF proxy configuration, instance picker
 
 ### Development Environment Setup
 **[dev-environment-setup.md](guides/dev-environment-setup.md)**
@@ -174,9 +198,23 @@ documentation/
 - Media indexing failures (paths, permissions, formats)
 - Emergency procedures (service restart, queue reset)
 
+### Worker Recovery
+**[operations/worker-recovery.md](operations/worker-recovery.md)**
+- Recovering the Railway worker process after a crash or stuck deploy
+
+### Google OAuth Verification
+**[operations/google-oauth-verification.md](operations/google-oauth-verification.md)**
+- Google OAuth consent screen verification process for Drive access
+
+### Postmortems
+**[operations/2026-05-telegram-delivery-burst-postmortem.md](operations/2026-05-telegram-delivery-burst-postmortem.md)**
+- 2026-05-17 → 2026-05-19 Telegram delivery failure burst (958 failures) — root cause and follow-up fixes (#467)
+
 ---
 
 ## Project Updates
+
+**⚠️ Retired 2026-07-06.** This folder stopped being maintained after 2026-01-11 despite dozens of shipped PRs since — `CHANGELOG.md`'s `[Unreleased]` section is the de facto changelog and has been for months. Rather than resume a practice that had already lapsed, this is now the documented convention going forward: **log changes in `CHANGELOG.md`, not here.** The 3 files below are kept as historical record; no new ones should be added.
 
 ### Feature Updates
 **[2026-01-11-force-posting-queue-shift.md](updates/2026-01-11-force-posting-queue-shift.md)** - COMPLETED
@@ -194,52 +232,44 @@ documentation/
 - 4 critical bugs fixed (service run metadata, scheduler date mutation, health check, lock creation)
 - All bugs identified during code review and deployment testing
 
-*Note: Updates folder contains dated documents for bug fixes, patches, and significant changes.*
-*Historical handoffs have been moved to `archive/`.*
+*Note: this folder historically contained dated documents for bug fixes, patches, and significant changes — retired 2026-07-06, see notice above.*
+*Historical handoffs are no longer kept in-repo — `archive/` was purged 2026-04-28 (#311); use git history instead.*
 *Line numbers in older updates reference pre-refactor code (v1.6.0 refactored TelegramService).*
 
 ---
 
 ## Security
 
-**[SECURITY_REVIEW.md](SECURITY_REVIEW.md)** - Reviewed 2026-01-11, Updated 2026-02-10
+**[SECURITY_REVIEW.md](SECURITY_REVIEW.md)** - Reviewed 2026-01-11, Updated 2026-02-15, **Addendum 2026-07-06**
 - No hardcoded credentials found
 - `.env` properly gitignored, all secrets via environment variables
 - Collaborative bot design (intentional, private channel = security boundary)
 - Token encryption (Fernet) for Instagram API credentials in database
 - Cloning the repo exposes zero credentials
 - Optional admin-only command pattern documented
+- ⚠️ **See §11 addendum**: a critical cross-tenant data-isolation gap (onboarding/dashboard API + Telegram queue callbacks) was found and fixed 2026-06-28 (#511/#512, PR #519). Role-based command authorization for multi-tenant remains an open follow-up.
 
 ---
 
 ## API Documentation
 
-Coming in Phase 5 (Dashboard UI):
-- REST API endpoints (FastAPI)
-- Authentication flows (JWT via Telegram Login Widget)
-- Rate limiting
-- WebSocket events
-- SDK documentation
+**[api/README.md](api/README.md)** - Added 2026-07-06 (this previously said "Coming in Phase 5" — the dashboard API had already shipped with no reference doc)
+
+- `src/api/routes/onboarding/` — Mini App onboarding/dashboard/settings REST endpoints (32 routes across setup/dashboard/settings), gated by `MembershipService` (see [SECURITY_REVIEW.md](SECURITY_REVIEW.md) §11)
+- `src/api/routes/oauth.py` — Instagram/Google OAuth callback routes
+- Auth is signed Telegram `initData` (Mini App) or a signed URL token, not a generic API-key/SDK model; the web dashboard reaches this API through a BFF proxy holding a JWT with `activeChatId`
+- Rate limiting exists (SlowAPI, 30/min global default, 5-10/min on mutating settings endpoints) — no WebSocket layer
 
 ---
 
 ## Archive
 
-Completed and historical documents (see [archive/ARCHIVE_INDEX.md](archive/ARCHIVE_INDEX.md) for full list):
+There is no in-repo `archive/` directory. It existed through early 2026 but was **intentionally purged 2026-04-28** ("chore: purge stale archives and complete Storydump rebrand in docs", #311) as part of the Storydump rebrand cleanup. The follow-up commit that was supposed to scrub references to it (#312, same day) missed this section — that's why it listed 11 dead links until this audit.
 
-| Document | Status | Description |
-|----------|--------|-------------|
-| [IMPLEMENTATION_COMPLETE.md](archive/IMPLEMENTATION_COMPLETE.md) | COMPLETED | Phase 1 completion checklist (v1.0.1) |
-| [HANDOFF-2026-01-05.md](archive/HANDOFF-2026-01-05.md) | COMPLETED | v1.2.0 deployment handoff |
-| [upcoming_build_notes.md](archive/upcoming_build_notes.md) | COMPLETED | Feature brainstorming (all implemented) |
-| [phase-1.5-telegram-enhancements.md](archive/phase-1.5-telegram-enhancements.md) | COMPLETED | Phase 1.5 planning (v1.3.0) |
-| [instagram_automation_plan.md](archive/instagram_automation_plan.md) | Superseded | Original plan, replaced by phases/ docs |
-| [01_instagram_api.md](archive/01_instagram_api.md) | COMPLETED | Phase 2 Instagram API (v1.5.0) |
-| [telegram-service-refactor-plan.md](archive/telegram-service-refactor-plan.md) | COMPLETED | TelegramService decomposition (v1.6.0) |
-| [verbose-settings-improvement-plan.md](archive/verbose-settings-improvement-plan.md) | COMPLETED | Verbose notifications expansion (v1.6.0) |
-| [phase-1.7-inline-account-selector.md](archive/phase-1.7-inline-account-selector.md) | COMPLETED | Inline account selection (v1.5.0) |
-| [user-interactions-design.md](archive/user-interactions-design.md) | COMPLETED | InteractionService design (v1.4.0) |
-| [prod-hardening_2026-02-23/](archive/prod-hardening_2026-02-23/) | COMPLETED | Production hardening tech debt (4 phases, PRs #78-#81) |
+Superseded/completed planning docs are no longer kept in-repo after completion. To find historical plans (the ones formerly listed here — Phase 1 completion checklist, v1.2.0 handoff, Phase 1.5/1.7 planning, the original `instagram_automation_plan.md`, TelegramService refactor plan, etc.), use git history, e.g.:
+```bash
+git log --all --diff-filter=D --summary -- 'documentation/archive/*'
+```
 
 ---
 
@@ -261,11 +291,12 @@ Completed and historical documents (see [archive/ARCHIVE_INDEX.md](archive/ARCHI
 7. For cloud-specific details: **[cloud-deployment.md](guides/cloud-deployment.md)**
 
 ### For Understanding Architecture
-1. Check **[phases/00_MASTER_ROADMAP.md](planning/phases/00_MASTER_ROADMAP.md)**
+1. Read root **[PROJECT_MISSION.md](../PROJECT_MISSION.md)** first — the current product mental model (User → Instances → accounts/media/queue). Root `README.md`'s Architecture section describes single-tenant Phase 1-2 history; this is the multi-tenant present.
+2. Check **[phases/00_MASTER_ROADMAP.md](planning/phases/00_MASTER_ROADMAP.md)**
    - Architecture principles and data flow diagrams
    - Service naming conventions (core/, integrations/, domain/)
    - Phase progression and dependencies
-2. Read root **[CLAUDE.md](../CLAUDE.md)** for service/model/table reference
+3. Read root **[CLAUDE.md](../CLAUDE.md)** for service/model/table reference
 
 ### For Contributing Code
 1. Read root **[CLAUDE.md](../CLAUDE.md)** (development guidelines, pre-commit checklist)
@@ -298,11 +329,11 @@ These critical files remain in the project root for visibility:
 When adding new documentation:
 
 1. **Choose the right location:**
-   - Planning/design → `planning/`
+   - Planning/design → `planning/` (inside `documentation/` — not the repo root; `multi-account-dashboard.md` was found misplaced at repo root and moved here during the 2026-07-06 audit)
    - How-to guides → `guides/`
    - Operations → `operations/`
-   - Bug fixes/patches → `updates/` (use dated filenames: `YYYY-MM-DD-description.md`)
-   - Completed plans → `archive/` (update `archive/ARCHIVE_INDEX.md`)
+   - Bug fixes/patches → `CHANGELOG.md` under `## [Unreleased]` (not `updates/` — that folder was retired 2026-07-06; see the Project Updates section above)
+   - Completed plans → delete or leave in place with a status marker; there is no `archive/` directory anymore (purged 2026-04-28, #311) — rely on git history instead of moving files
 
 2. **Update this index** (`documentation/README.md`)
 
@@ -321,13 +352,13 @@ When adding new documentation:
 
 | Area | Status | Files | Notes |
 |------|--------|-------|-------|
-| **Planning** | Current | 7 active phase plans + 4 feed-queue + 4 tech-debt + 2 other | Phases 1-2 complete, 3-8 pending |
-| **Guides** | Current | 9 guides | Setup, deployment, testing, Instagram API, dev env, deployment options, Tailscale, test coverage |
-| **Operations** | Current | 3 files | Monitoring, backup, troubleshooting |
-| **Updates** | Current | 3 files | Bugfixes, category scheduling, force posting |
-| **Security** | Current | 1 file | Security review (updated post-refactor) |
-| **Archive** | Organized | 22 entries | Historical docs preserved with index |
-| **API Docs** | Future | 0 files | Planned for Phase 5 (Dashboard UI) |
+| **Planning** | Current (as of 2026-07-06 audit) | 18 (7 phase plans + 2 feed-queue + 3 investigations + 5 dated top-level docs + `multi-account-dashboard.md`, relocated here from repo root this audit) | Phases 1-2 complete, 3+ pending — see phase docs for per-phase status |
+| **Guides** | Current | 11 (10 guides + TEST_COVERAGE.md) | Setup, deployment (3 overlapping docs — see gap analysis), testing, Instagram API (2 flows), dev env, landing/Vercel |
+| **Operations** | Current | 6 files | Monitoring, backup, troubleshooting, worker recovery, Google OAuth verification, 1 postmortem |
+| **Updates** | Retired 2026-07-06 | 3 files (historical only) | Formally retired in favor of `CHANGELOG.md` `[Unreleased]` — see Project Updates section |
+| **Security** | Current | 1 file + §11 addendum (2026-07-06) | Cross-tenant IDOR found & fixed 2026-06-28; role-based command auth still open |
+| **Archive** | Removed | 0 (purged 2026-04-28, #311) | Use `git log --all --diff-filter=D -- 'documentation/archive/*'` for history |
+| **API Docs** | Current | 1 file (added 2026-07-06) | `src/api/routes/` (REST + Mini App onboarding) — see [api/README.md](api/README.md) |
 
 ### Document Status Legend
 - **COMPLETED** - Fully implemented and documented
@@ -348,4 +379,4 @@ When adding new documentation:
 
 ---
 
-*Last updated: 2026-03-28*
+*Last updated: 2026-07-06*

--- a/documentation/ROADMAP.md
+++ b/documentation/ROADMAP.md
@@ -238,6 +238,30 @@ Build a delightful Instagram Story automation system that:
 
 ---
 
+## Multi-Tenant / Multi-Instance Rearchitecture ✅ SHIPPED
+
+**Status**: ✅ Live in production (not version-tagged — `src/__init__.py` still reads `1.6.0`)
+**Design doc**: `planning/multi-account-dashboard.md` (moved here from the repo root 2026-07-06 docs audit — was misplaced)
+**Duration**: April 2026 (design consolidated 2026-04-17) through ~June 2026
+**Goal**: Move from one self-hosted deployment per team to a single multi-tenant deployment serving many independent "Instances" (Telegram groups), each with its own media, queue, schedule, and settings — with a user able to belong to and switch between multiple instances.
+
+### Delivered Features (verified against code 2026-07-06)
+- ✅ **Data layer** — `user_chat_memberships` (user ↔ instance membership, with `instance_role`: owner/admin/member) and `onboarding_sessions` tables (migration 023); `display_name` added to `chat_settings`
+- ✅ **Backfill** — historical group memberships backfilled from `user_interactions`; role promotion via `getChatAdministrators`
+- ✅ **`StartCommandRouter`** — grew to a 6-branch `/start` handler (the plan specified 5; a mobile-login redirect branch was added): DM new-user onboarding, DM returning-user instance list, DM active-onboarding resume, mobile-login redirect, group + `startgroup` linking, standard group setup
+- ✅ **New commands** — `/instances`, `/new`, `/name`, `/link` (see `.claude/rules/telegram.md` for the full command table)
+- ✅ **`my_chat_member` event handling** — auto-links pending onboarding on bot-added, deactivates memberships on bot-kicked
+- ✅ **Web dashboard** (`landing/`, Next.js/Vercel) — `GET /api/instances`, `POST /api/instances/:id/select`, instance picker + switcher, JWT `activeChatId` reissued on switch, BFF proxy validates active membership per request
+
+### Known Gaps (found during 2026-07-06 docs audit, not yet filed as tickets)
+- ⚠️ **`get_settings()` call-site audit incomplete**: the plan called for auditing ~15 call sites and flipping DM-context ones to `create_if_missing=False` so DM logins stop creating phantom `chat_settings` rows. Actual count is 34 call sites; only 10 were flipped. Three of the plan's four explicitly-named DM call sites — `SetupStateService.get_setup_state()`, `DashboardService._resolve_chat_settings_id()`, and the `onboarding/init` chain — were never flipped and still create phantoms, contradicting migration 024's own comment that phantoms are prevented going forward.
+- ⚠️ **Dead code**: the `/webapp/instances` Mini App instance picker page renders but is unreferenced anywhere else in the repo — no Telegram WebApp SDK integration wires up to it. The live bot flow uses a different mechanism for DM instance selection.
+- ⚠️ **Security**: a critical cross-tenant data-isolation gap in the onboarding/dashboard API and Telegram queue callbacks (the membership check this rearchitecture introduced wasn't consistently enforced) was found and fixed 2026-06-28 (#511/#512, PR #519). See `SECURITY_REVIEW.md` §11. Role-based command authorization (member vs. admin) is a tracked follow-up, not yet implemented.
+
+**Completed**: ~June 2026 (backfill + core phases); hardening ongoing
+
+---
+
 ## Phase 3: Advanced Features 🔮 FUTURE
 
 **Status**: 🔮 Exploratory
@@ -312,6 +336,7 @@ Build a delightful Instagram Story automation system that:
 
 | Version | Date | Phase | Description |
 |---------|------|-------|-------------|
+| *(unreleased — version string not bumped)* | 2026-04 to 2026-06 | Multi-Tenant Rearchitecture | `user_chat_memberships`, `StartCommandRouter`, `/instances` `/new` `/name` `/link`, web dashboard instance picker — see section above |
 | v1.6.0 | 2026-02-09 | Phase 1.5-1.8 | Instagram account management, inline account selector, TelegramService refactor, verbose expansion, /cleanup |
 | v1.5.0 | 2026-01-24 | Phase 2 | Instagram API automation + Multi-account support |
 | v1.4.0 | 2026-01-10 | Phase 1.6 | Category-based scheduling with configurable ratios |

--- a/documentation/SECURITY_REVIEW.md
+++ b/documentation/SECURITY_REVIEW.md
@@ -4,6 +4,8 @@
 **Reviewer**: AI Security Audit
 **Status**: ✅ Secure — Post-SaaS hardening complete
 
+> **⚠️ Post-review update (2026-06-28)**: A critical cross-tenant IDOR was found and fixed *after* this review was marked complete — see **[Section 11, Addendum](#11-addendum-cross-tenant-idor-finding-and-fix-2026-06-28)** below. The "Secure" / "Review Complete" status above reflects the 2026-02-15 point-in-time review only.
+
 ---
 
 ## Executive Summary
@@ -370,3 +372,36 @@ Post multi-tenant transition (Phases 01-07) security review. All findings fixed.
 ---
 
 **Review Complete** ✅
+
+---
+
+## 11. Addendum: Cross-Tenant IDOR Finding and Fix (2026-06-28)
+
+**This is a post-review addendum, added 2026-07-06.** It does not alter the findings above — it documents a critical vulnerability discovered and fixed *after* Section 10's review was marked complete on 2026-02-15, and closes the loop on two of that section's "Remaining Recommendations."
+
+### Finding 1: Mini App API IDOR — caller never bound to the tenant they acted on (#511)
+
+`_validate_request()` (`src/api/routes/onboarding/helpers.py`) is the shared authorization gate in front of ~35 onboarding/dashboard/settings API endpoints. It authenticated the caller (verified the Telegram `initData` HMAC signature or a signed URL token) but the chat-binding check only fired when the token itself carried a `chat_id`. A Telegram WebApp `initData` payload launched from a bot **DM** carries no `chat` field at all, so for DM-launched sessions the equality check was skipped entirely — the request's `chat_id` argument was trusted outright. Any authenticated bot user could pass an arbitrary `chat_id` and read or mutate **another tenant's** posting queue, history, Instagram accounts, media library, and settings. A previously fail-**open** inline membership check that guarded only the `/audit-log` endpoint had the same underlying gap.
+
+### Finding 2: Telegram callback queue operations — cross-tenant deletes (#512, data-layer subset)
+
+In `src/services/core/telegram_callbacks_admin.py`, the `resume:clear` / `clear:confirm` buttons and the resume `reschedule` path called the queue repository with no tenant filter, so a single button press could delete or reschedule **every tenant's** pending queue rows fleet-wide. `handle_batch_approve` also trusted a `chat_settings_id` value carried in the (forgeable) inline-button callback data without verifying it belonged to the calling chat.
+
+### Fix
+
+- **New `MembershipService`** (`src/services/core/membership_service.py`) — `is_active_member(telegram_user_id, telegram_chat_id)` resolves a Telegram identity to an active `UserChatMembership` row (user → `chat_settings` → membership) and is fail-closed by construction: a missing user, missing chat, missing membership, or inactive membership all return `False`; it never raises.
+- `_validate_request()` now branches on whether the token cryptographically binds a `chat_id`: bound tokens (signed URL tokens, group-launched initData) keep the original equality check; unbound tokens (DM-launched initData) now require `MembershipService().is_active_member(...)` to return `True`, or the request is rejected with `403 Not a member of this instance`. The old `/audit-log`-only fail-open check was removed in favor of this central, fail-closed path.
+- `telegram_callbacks_admin.py` gained a `_caller_chat_settings_id()` helper; `handle_batch_approve`, `handle_resume_callback`, and `_do_resume_callback` now scope all queue lookups to the calling chat's `chat_settings_id` and refuse to run (rather than silently falling back to an unscoped query) when the chat has no resolved tenant. `handle_batch_approve` also rejects a `batch_approve:{chat_settings_id}` callback whose id doesn't match the caller's own.
+- **Fixed in commit `7c99a34`** (PR #519), closing #511 and partially addressing #512. Regression tests added: `tests/src/services/test_membership_service.py`, `tests/src/api/test_helpers.py`, `tests/src/services/test_telegram_callbacks_admin.py`.
+
+### Status of Section 10's "Remaining Recommendations" (re-checked 2026-07-06)
+
+| Recommendation (Section 10) | Status |
+|---|---|
+| Add role-based access control on Telegram commands for multi-tenant | ❌ **Still open.** This fix closes cross-*tenant* leakage (which chat's data a request can touch) — it does not add member-vs-admin authorization *within* a chat. PR #519's own commit message explicitly tracks per-role command authorization as a separate follow-up. Do not treat this finding as covering the Section 10 recommendation. |
+| Add API rate limiting (e.g. `slowapi`) on `/api/onboarding/*` endpoints | ✅ **Done.** `SlowAPIMiddleware` is wired globally in `src/api/app.py` (30/min per IP default, applies to every route including all of `/api/onboarding/*`); several mutation endpoints in `src/api/routes/onboarding/settings.py` carry tighter `@limiter.limit("10/minute")` / `"5/minute"` decorators. |
+| Add `pip-audit` to CI for automated dependency vulnerability scanning | ✅ **Done, with a caveat.** `.github/workflows/ci.yml` runs `pip-audit -r requirements.txt`, but the step is `continue-on-error: true` with `|| true` on the command itself — a discovered vulnerability currently cannot fail the build. It's informational-only, not a gate. |
+
+### Takeaway
+
+The "✅ Secure" / "Review Complete" framing elsewhere in this document is a point-in-time snapshot from 2026-02-15. A real, critical cross-tenant vulnerability was present in production between that review and its fix on 2026-06-28. Treat each section of this document as dated evidence, not an evergreen guarantee of current security posture — cross-check `CHANGELOG.md`'s `### Security` entries under `[Unreleased]` for anything more recent than a section's own date.

--- a/documentation/api/README.md
+++ b/documentation/api/README.md
@@ -1,0 +1,89 @@
+# API Reference
+
+**Status:** New 2026-07-06 — this API existed in code with no reference doc until this audit. Scoped to what exists today; not a full OpenAPI spec.
+
+This is the REST API served by `uvicorn src.api.app:app` (the API service — see root `CLAUDE.md`). It backs two clients: the Telegram Mini App (launched from inside Telegram, via signed `initData`) and the `landing/` Next.js web dashboard (via a BFF proxy + JWT). It is **not** a public/third-party API — there is no API-key model, no versioning, no WebSocket layer, and no SDK.
+
+## Mounting
+
+| Prefix | Router | File |
+|--------|--------|------|
+| `/auth` | `oauth_router` | `src/api/routes/oauth.py` |
+| `/api/onboarding` | `onboarding_router` (aggregates 3 sub-routers) | `src/api/routes/onboarding/__init__.py` |
+| `/static` | `StaticFiles` | served from `STATIC_DIR` |
+
+## Auth model
+
+There is no API key. Every `/api/onboarding/*` request carries `init_data` (a Telegram WebApp `initData` string, or a signed URL token for browser-launched links) plus a `chat_id`. The gate is `_validate_request()` in `src/api/routes/onboarding/helpers.py`, which resolves to one of two authorization paths:
+
+- **Bound token** — a signed URL token, or `initData` launched from a Telegram group, cryptographically carries a `chat_id`. That binding *is* the authorization; the gate only rejects replay against a *different* `chat_id` (403 on mismatch).
+- **Unbound token** — `initData` launched from a Telegram DM carries no `chat_id`, so the request-supplied `chat_id` is attacker-suppliable. The gate instead does a server-side active-membership lookup via `MembershipService.is_active_member(user_id, chat_id)` (403 if not an active member).
+
+This split exists because of a **2026-06-28 security fix** (#511/#512, PR #519): the unbound-token path used to skip authorization entirely, letting any authenticated bot user act on any tenant's data by supplying an arbitrary `chat_id`. See [`SECURITY_REVIEW.md`](../SECURITY_REVIEW.md) §11 for the incident writeup, and [`multi-account-dashboard.md`](../planning/multi-account-dashboard.md) for how `user_chat_memberships` (the membership table this check reads) fits into the wider multi-instance design.
+
+The web dashboard (`landing/`) does not call this API directly — it goes through a Next.js BFF proxy that holds a JWT with `activeChatId`, and the BFF is responsible for turning that into a valid `init_data`/`chat_id` pair server-side. See [`landing-vercel-deployment.md`](../guides/landing-vercel-deployment.md).
+
+**Known gap:** as of 2026-07-06, three call sites (`SetupStateService.get_setup_state()`, `DashboardService._resolve_chat_settings_id()`, the `onboarding/init` chain) still default to creating a `chat_settings` row rather than checking membership first, so DM logins can still create phantom tenants. Not a data-isolation bug (that's fixed), but worth knowing before extending this API. See `.claude/rules/telegram.md`.
+
+## Rate limiting
+
+Global default: **30 requests/minute per IP** (`SlowAPIMiddleware`, `src/api/rate_limit.py`, wired in `src/api/app.py`). Tighter per-endpoint limits override the default on mutating settings endpoints:
+
+| Limit | Endpoints |
+|-------|-----------|
+| 10/minute | `POST /toggle-setting`, `POST /update-setting`, `POST /update-string-setting` |
+| 5/minute | `POST /sync-media`, `POST /add-account` |
+
+## Routes
+
+### `/auth` — OAuth callbacks (`oauth.py`)
+
+| Method & Path | Purpose |
+|---|---|
+| `GET /auth/instagram/start` | Begin legacy Facebook Login OAuth flow |
+| `GET /auth/instagram/callback` | Facebook Login OAuth callback |
+| `GET /auth/instagram-login/callback` | Instagram Login OAuth callback (preferred flow, added in the 2026-05 credential refactor) |
+| `GET /auth/google-drive/start` | Begin Google Drive OAuth flow |
+| `GET /auth/google-drive/callback` | Google Drive OAuth callback |
+
+### `/api/onboarding` — Setup wizard (`setup.py`)
+
+| Method & Path | Purpose |
+|---|---|
+| `GET /init` | Bootstrap setup state for a chat |
+| `GET /oauth-url/{provider}` | Get the OAuth start URL for a provider |
+| `POST /media-folder` | Set the Google Drive media folder |
+| `POST /start-indexing` | Kick off media indexing |
+| `POST /schedule` | Set initial posting schedule during setup |
+| `POST /complete` | Mark setup wizard complete |
+
+### `/api/onboarding` — Dashboard (`dashboard.py`)
+
+| Method & Path | Purpose |
+|---|---|
+| `GET /instances` | List the caller's instances (backs `/start`'s DM instance picker and the web dashboard's instance picker) |
+| `GET /queue-detail`, `/history-detail` | Queue and posting-history detail views |
+| `GET /media-stats`, `/media-library` | Media library stats and listing |
+| `GET /accounts` | Instagram accounts for the active instance |
+| `GET /analytics`, `/analytics/*` (9 sub-routes) | Dashboard analytics: schedule recommendations, categories, schedule preview, content reuse, service health, category drift, dead content, approval latency, team performance |
+| `GET /system-status` | Health/status summary |
+| `POST /upload-media` | Upload media directly via the dashboard |
+| `GET /audit-log` | Tenant audit log (membership-gated — see Auth model) |
+| `GET /media/{media_id}/thumbnail` | Thumbnail proxy |
+
+### `/api/onboarding` — Settings (`settings.py`)
+
+| Method & Path | Purpose |
+|---|---|
+| `POST /toggle-setting`, `/update-setting`, `/update-string-setting` | Mutate `chat_settings` fields (dry-run mode, posts/day, etc.) |
+| `POST /switch-account`, `/add-account`, `/remove-account` | Instagram account management for the active instance |
+| `POST /disconnect-gdrive`, `/sync-media` | Google Drive connection + manual sync trigger |
+| `POST /queue-preview` | Preview upcoming queue slots |
+| `POST /category-mix`, `/update-category-mix` | Category posting-ratio configuration |
+
+## What's intentionally not here
+
+- No OpenAPI/Swagger doc generation is wired up beyond FastAPI's default `/docs` (not verified whether it's disabled in production — check `app.py` before relying on it)
+- No WebSocket endpoints
+- No API versioning scheme
+- Request/response body schemas aren't reproduced here — see `src/api/routes/onboarding/models.py` for the Pydantic models

--- a/documentation/guides/TEST_COVERAGE.md
+++ b/documentation/guides/TEST_COVERAGE.md
@@ -1,11 +1,13 @@
 # Test Coverage Report
 
-**Last Updated**: 2026-03-28
-**Total Tests**: 1,417
-**Test Files**: 77
+**Last Updated**: 2026-07-06 (top-line counts refreshed; see verification note)
+**Total Tests**: 2,038 (verified via `pytest --collect-only`, see `testing-guide.md`; superseded the 2,020 grep-proxy estimate this doc originally shipped with — see verification note)
+**Test Files**: 103
 **Test Framework**: pytest 7.4.3
 **Coverage Target**: Core business logic and critical paths
-**Status**: ✅ Current through v1.6.0 + race condition handling
+**Status**: ⚠️ Top-line counts current as of 2026-07-06. The per-layer breakdown, per-file counts, and Conclusion numbers further down this document were **not** re-verified in this pass and predate the multi-tenant/SaaS transition — treat them as historical.
+
+> **Verification note (2026-07-06)**: A working pytest environment (venv + installed dependencies) wasn't available in this pass, so these top-line numbers come from `find tests/ -name "test_*.py" | wc -l` (103 files) and a grep count of `def test_` under `tests/` (2,020) rather than `pytest --collect-only`. The grep count is a function-definition count — it won't reflect `@pytest.mark.parametrize` expansion in either direction, so it's a proxy, not an exact pytest-collected total. Corroborating data point: commit `7c99a34` (2026-06-28, the cross-tenant security fix) reports "full unit suite green (1896 passed)" for the non-skipped subset, which is consistent with ~2,020 total once skipped integration tests are counted in. Separately: the project version in `src/__init__.py` is still `1.6.0`, unchanged since 2026-02-09 — despite the large increase in test count and the substantial multi-tenant/SaaS work reflected in `CHANGELOG.md`'s `[Unreleased]` section, no version bump has been cut yet.
 
 ---
 

--- a/documentation/guides/ci-cd-pipeline.md
+++ b/documentation/guides/ci-cd-pipeline.md
@@ -16,39 +16,57 @@ name: CI
 
 on:
   push:
-    branches: [main]
+    branches: [main, develop, 'feature/*']
   pull_request:
-    branches: [main]
+    branches: [main, develop]
 
 jobs:
-  test:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.10'
+      - run: pip install ruff
+      - run: ruff check src/ cli/ --output-format=github
+      - run: ruff format src/ cli/ --check
 
-      - name: Install dependencies
-        run: |
-          pip install -r requirements.txt
-          pip install -e .
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        # ... health-checked Postgres service for the test suite
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - run: pip install -r requirements.txt && pip install -e .
+      - name: Run tests with coverage
+        run: pytest tests/ -v --cov=src --cov-report=xml --cov-report=term-missing
 
-      - name: Lint
-        run: |
-          ruff check src/ tests/ cli/
-          ruff format --check src/ tests/ cli/
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+      - run: pip install pip-audit bandit
+      - run: pip-audit -r requirements.txt --ignore-vuln GHSA-1234 || true
+      - run: bandit -r src/ -ll -ii --format json --output bandit-report.json || true
 
-      - name: Test
-        run: pytest
-
-      - name: Security scan
-        run: |
-          pip-audit
-          bandit -r src/ -c pyproject.toml
+  changelog-check:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Fails the check if CHANGELOG.md wasn't updated (docs-only PRs are exempt)
 ```
+
+These four jobs (`lint`, `test`, `security`, `changelog-check`) run in parallel, not as one combined job -- shown separately above to mirror the actual workflow file.
 
 ### What CI Checks
 

--- a/documentation/guides/cloud-deployment.md
+++ b/documentation/guides/cloud-deployment.md
@@ -2,6 +2,8 @@
 
 Deploy Storydump to cloud infrastructure (Railway + Neon) for multi-tenant SaaS operation.
 
+> **Overlaps with [deployment.md](deployment.md)** — that doc is a step-by-step first-deploy checklist; this one is the technical reference (full env var list, architecture diagram, OAuth callback details). Audited together 2026-07-06, consistent with each other but redundant — see that doc's note for which to use when.
+
 **Estimated time:** 2-3 hours for complete setup
 **Prerequisites:** GitHub account, Railway account, Neon account
 
@@ -59,7 +61,7 @@ Run the base schema and all migrations in order:
 psql "$DATABASE_URL" -f scripts/setup_database.sql
 
 # All migrations (run in order)
-for f in scripts/migrations/0{01,02,03,04,05,06,07,08,09,10,11,12,13,14,15,16,17,18,19,20,21}_*.sql; do
+for f in scripts/migrations/*.sql; do
   echo "Running $f..."
   psql "$DATABASE_URL" -f "$f"
 done
@@ -71,7 +73,8 @@ done
 -- Check schema version
 SELECT * FROM schema_version ORDER BY version;
 
--- Should show version 21 as latest
+-- Should show the highest version in scripts/migrations/ as latest
+-- (41 as of this writing -- this number grows as new migrations land)
 
 -- Check uuid-ossp extension
 SELECT extname FROM pg_extension WHERE extname = 'uuid-ossp';
@@ -166,8 +169,10 @@ If not using `DATABASE_URL`, set individual components:
 | Variable | Description | Example |
 |---|---|---|
 | `OAUTH_REDIRECT_BASE_URL` | Railway web service URL | `https://your-app.up.railway.app` |
-| `FACEBOOK_APP_ID` | Meta Developer App ID | `1234567890123456` |
-| `FACEBOOK_APP_SECRET` | Meta Developer App Secret | `abc123...` |
+| `FACEBOOK_APP_ID` | Meta Developer App ID (Facebook Login flow, legacy) | `1234567890123456` |
+| `FACEBOOK_APP_SECRET` | Meta Developer App Secret (Facebook Login flow, legacy) | `abc123...` |
+| `INSTAGRAM_APP_ID` | Meta Developer App ID (Instagram Login flow, preferred) | `1234567890123456` |
+| `INSTAGRAM_APP_SECRET` | Meta Developer App Secret (Instagram Login flow, preferred) | `abc123...` |
 | `GOOGLE_CLIENT_ID` | Google OAuth Client ID | `xxx.apps.googleusercontent.com` |
 | `GOOGLE_CLIENT_SECRET` | Google OAuth Client Secret | `GOCSPX-...` |
 
@@ -208,15 +213,19 @@ If not using `DATABASE_URL`, set individual components:
 start - Open Storydump (setup & config)
 status - System health & media overview
 setup - Quick settings & toggles
-queue - View upcoming posts
 next - Send next post now
-pause - Pause delivery
-resume - Resume delivery
-history - Recent post history
-sync - Sync media from Drive
+approveall - Approve all pending auto-post items
 cleanup - Delete recent bot messages
+link - Link this group to a pending onboarding session
+name - Set this group's instance display name
+instances - List your instances (DM only)
+new - Start a new instance (DM only)
 help - Show available commands
 ```
+
+> **Note:** `queue`, `pause`, `resume`, `history`, and `sync` were retired —
+> the bot now shows a redirect message pointing users to the dashboard (or
+> `/settings`) if they're used. Don't register them with BotFather.
 
 4. Add the bot as admin to your Telegram channel/group
 5. Get the channel ID (send a message, check via `https://api.telegram.org/bot<TOKEN>/getUpdates`)
@@ -230,6 +239,8 @@ The app uses **polling mode** by default, which works well for cloud deployment 
 ## 5. Instagram OAuth Setup
 
 Instagram account connection uses browser-based OAuth, which requires the web service (FastAPI) to be running.
+
+> This section describes the legacy **Facebook Login** flow (`FACEBOOK_APP_ID`/`FACEBOOK_APP_SECRET`). There is also a newer, preferred **Instagram Login** flow (`INSTAGRAM_APP_ID`/`INSTAGRAM_APP_SECRET`) that doesn't require a Facebook Page — see [instagram-login-setup.md](instagram-login-setup.md) for that setup. Both can be configured; the app prefers Instagram Login when both are present.
 
 ### Meta Developer Setup
 
@@ -364,7 +375,7 @@ Use the Telegram bot itself as a health indicator:
 
 ## Quick Start Checklist
 
-1. [ ] Create Neon database and run schema + all 16 migrations
+1. [ ] Create Neon database and run schema + all migrations in `scripts/migrations/`
 2. [ ] Create Railway project with two services (worker + web)
 3. [ ] Set all required environment variables
 4. [ ] Create Telegram bot via BotFather, get token

--- a/documentation/guides/deployment.md
+++ b/documentation/guides/deployment.md
@@ -2,6 +2,8 @@
 
 This checklist covers everything you need to do **outside of code** to get Storydump running in production on Railway + Neon.
 
+> **Overlaps with [cloud-deployment.md](cloud-deployment.md)** — this doc is a step-by-step first-deploy checklist; cloud-deployment.md is the multi-tenant technical reference (full env var list, architecture diagram, OAuth callback details). The two were audited together 2026-07-06 and are consistent with each other, but redundant — if you're setting up for the first time, follow this one; for a specific config/env-var lookup, check cloud-deployment.md.
+
 ## Prerequisites
 
 - [ ] GitHub account (public repository)
@@ -79,8 +81,8 @@ export DATABASE_URL="postgresql://user:pass@ep-xxx.neon.tech/storydump?sslmode=r
 # Run base schema
 psql "$DATABASE_URL" -f scripts/setup_database.sql
 
-# Run all migrations
-for f in scripts/migrations/0{01,02,03,04,05,06,07,08,09,10,11,12,13,14,15,16,17,18,19,20,21}_*.sql; do
+# Run all migrations (in order)
+for f in scripts/migrations/*.sql; do
   echo "Running $f..."
   psql "$DATABASE_URL" -f "$f"
 done
@@ -215,18 +217,21 @@ railway shell --service worker -c "storydump-cli sync-media"
 railway shell --service worker -c "storydump-cli list-media"
 ```
 
-### Create Initial Schedule
+### Preview the Schedule
 
 ```bash
-railway shell --service worker -c "storydump-cli create-schedule --days 7"
-# Creates 7 days of scheduled posts
+railway shell --service worker -c "storydump-cli queue-preview"
+# Shows what the JIT scheduler would pick next. Posting itself is automatic
+# once the worker is running, based on your configured posting cadence --
+# there is no separate "create schedule" step.
 ```
 
 ### Verify Queue
 
 ```bash
 railway shell --service worker -c "storydump-cli list-queue"
-# Should show scheduled items
+# Empty until the worker's next scheduled slot fires and sends an item to
+# Telegram -- that's when it becomes an in-flight item awaiting your action.
 ```
 
 ---
@@ -414,7 +419,7 @@ railway logs --service worker
 - [ ] Review team permissions
 
 ### As Needed
-- [ ] Create new schedule: `storydump-cli create-schedule --days 7`
+- [ ] Preview upcoming selections: `storydump-cli queue-preview` (posting is automatic via the JIT scheduler)
 - [ ] Promote team members: `storydump-cli promote-user <id> --role admin`
 - [ ] Clear old queue items if needed
 

--- a/documentation/guides/dev-environment-setup.md
+++ b/documentation/guides/dev-environment-setup.md
@@ -46,8 +46,8 @@ brew services start postgresql
 createdb storydump
 psql -d storydump -f scripts/setup_database.sql
 
-# Run migrations
-for f in scripts/migrations/0{01,02,03,04,05,06,07,08,09,10,11,12,13,14,15,16,17,18,19,20,21}_*.sql; do
+# Run migrations (in order)
+for f in scripts/migrations/*.sql; do
   psql -d storydump -f "$f"
 done
 ```

--- a/documentation/guides/instagram-api-setup.md
+++ b/documentation/guides/instagram-api-setup.md
@@ -354,19 +354,21 @@ Expires in hours: 1440
 
 ## Step 12: Test Posting (Optional)
 
-Once verified, test with `DRY_RUN_MODE=true` first:
+Once verified, test with dry-run mode enabled first (toggle via `/settings`
+in Telegram, or `DRY_RUN_MODE=true` for the initial bootstrap default).
+
+There is no manual "process the queue now" command -- the running worker
+(`python -m src.main`) posts automatically via its just-in-time scheduler
+when a slot comes due. To preview what it would pick without waiting:
 
 ```bash
-# In .env
-DRY_RUN_MODE=true
+storydump-cli queue-preview
 ```
 
-Then:
-```bash
-storydump-cli process-queue --force
-```
+To force a real send immediately (useful for testing), use the `/next`
+command in Telegram rather than a CLI command.
 
-When ready for real posting, set `DRY_RUN_MODE=false`.
+When ready for real posting, turn dry-run mode off via `/settings`.
 
 ---
 

--- a/documentation/guides/quickstart.md
+++ b/documentation/guides/quickstart.md
@@ -71,7 +71,7 @@ POSTING_HOURS_START=14  # 9 AM EST = 14 UTC
 POSTING_HOURS_END=2     # 9 PM EST = 2 UTC (next day)
 ```
 
-## Step 5: Index Media & Create Schedule (1 min)
+## Step 5: Index Media (1 min)
 
 ```bash
 # Create media directory if it doesn't exist
@@ -81,12 +81,15 @@ mkdir -p media/stories
 # Index media
 storydump-cli index-media media/stories
 
-# Create 7-day schedule
-storydump-cli create-schedule --days 7
-
-# View what was scheduled
-storydump-cli list-queue
+# Preview what the scheduler would pick next (doesn't post anything)
+storydump-cli queue-preview
 ```
+
+Scheduling is just-in-time: there's no separate "create schedule" step. Once
+the app is running (Step 6), the scheduler automatically selects and sends
+media at your configured posting cadence. `storydump-cli list-queue` shows
+in-flight items that have been sent to Telegram and are awaiting a
+Posted/Skip/Reject action.
 
 ## Step 6: Run the Application (1 min)
 

--- a/documentation/guides/testing-guide.md
+++ b/documentation/guides/testing-guide.md
@@ -2,7 +2,7 @@
 
 This document explains how testing works in the Storydump project.
 
-**Current test count**: 1,417 tests across 77 test files as of v1.6.0
+**Current test count**: 2,038 tests across 103 test files (`pytest --collect-only -q`, v1.6.0)
 
 ## Quick Start
 
@@ -20,7 +20,7 @@ make test-quick
 pytest tests/src/services/test_telegram_callbacks.py
 
 # Run a specific test method
-pytest tests/src/services/test_scheduler.py::TestSchedulerService::test_create_schedule
+pytest tests/src/services/test_scheduler.py::TestForceSendNext::test_success
 ```
 
 ## Automatic Test Database Setup
@@ -117,47 +117,120 @@ Key design decisions:
 ```
 tests/
 ├── conftest.py              # Pytest configuration & fixtures
-├── cli/                     # CLI command tests (4 files)
+├── cli/                     # CLI command tests (8 files)
+│   ├── test_backfill_commands.py
+│   ├── test_google_drive_commands.py
+│   ├── test_health_commands.py
+│   ├── test_instagram_commands.py
 │   ├── test_media_commands.py
 │   ├── test_queue_commands.py
-│   ├── test_user_commands.py
-│   └── test_health_commands.py
-├── src/
-│   ├── repositories/        # Repository layer tests (8 files)
-│   │   ├── test_user_repository.py
-│   │   ├── test_media_repository.py
-│   │   ├── test_queue_repository.py
-│   │   ├── test_history_repository.py
-│   │   ├── test_lock_repository.py
-│   │   ├── test_service_run_repository.py
-│   │   ├── test_category_mix_repository.py
-│   │   └── test_interaction_repository.py
-│   ├── services/            # Service layer tests (17 files)
-│   │   ├── test_base_service.py
-│   │   ├── test_media_ingestion.py
-│   │   ├── test_scheduler.py
-│   │   ├── test_media_lock.py
-│   │   ├── test_posting.py
-│   │   ├── test_telegram_service.py       # Core service tests
-│   │   ├── test_telegram_commands.py      # Command handler tests
-│   │   ├── test_telegram_callbacks.py     # Callback handler tests
-│   │   ├── test_telegram_settings.py      # Settings UI tests
-│   │   ├── test_telegram_accounts.py      # Account handler tests
-│   │   ├── test_health_check.py
-│   │   ├── test_settings_service.py       # Per-chat settings
-│   │   ├── test_instagram_account_service.py  # Multi-account
-│   │   ├── test_interaction_service.py    # Bot interaction tracking
-│   │   ├── test_instagram_api.py          # Instagram Graph API
-│   │   ├── test_cloud_storage.py          # Cloudinary integration
-│   │   └── test_token_refresh.py          # Token lifecycle
-│   └── utils/               # Utility tests (5 files)
-│       ├── test_file_hash.py
-│       ├── test_logger.py
-│       ├── test_validators.py
-│       ├── test_image_processing.py
-│       └── test_encryption.py             # Fernet encryption
-└── integration/             # Integration tests
-    └── test_instagram_posting.py          # End-to-end posting
+│   ├── test_sync_commands.py
+│   └── test_user_commands.py
+├── integration/             # Integration tests (1 file)
+│   └── test_instagram_posting.py          # End-to-end posting
+└── src/
+    ├── test_health_endpoint.py
+    ├── test_main_scheduler_loop.py
+    ├── api/                 # API route tests (5 files)
+    │   ├── test_helpers.py
+    │   ├── test_oauth_routes.py
+    │   ├── test_onboarding_dashboard.py
+    │   ├── test_onboarding_routes.py
+    │   └── test_security_hardening.py
+    ├── config/              # Config tests (3 files)
+    │   ├── test_constants.py
+    │   ├── test_database.py
+    │   └── test_settings.py
+    ├── exceptions/          # Exception tests (4 files)
+    │   ├── test_backfill_exceptions.py
+    │   ├── test_base_exceptions.py
+    │   ├── test_google_drive_exceptions.py
+    │   └── test_instagram_exceptions.py
+    ├── models/              # Model tests (9 files)
+    │   ├── test_api_token.py
+    │   ├── test_category_mix.py
+    │   ├── test_chat_settings.py
+    │   ├── test_credential_refactor.py
+    │   ├── test_instagram_account.py
+    │   ├── test_media_item.py
+    │   ├── test_media_lock.py
+    │   ├── test_posting_history.py
+    │   └── test_posting_queue.py
+    ├── repositories/        # Repository layer tests (12 files)
+    │   ├── test_base_repository.py
+    │   ├── test_category_mix_repository.py
+    │   ├── test_chat_settings_repository.py
+    │   ├── test_history_repository.py
+    │   ├── test_instagram_account_repository.py
+    │   ├── test_interaction_repository.py
+    │   ├── test_lock_repository.py
+    │   ├── test_media_repository.py
+    │   ├── test_queue_repository.py
+    │   ├── test_service_run_repository.py
+    │   ├── test_token_repository.py
+    │   └── test_user_repository.py
+    ├── services/            # Service layer tests (51 files)
+    │   ├── media_sources/   # Media source provider tests (4 files)
+    │   │   ├── test_base_provider.py
+    │   │   ├── test_factory.py
+    │   │   ├── test_google_drive_provider.py
+    │   │   └── test_local_provider.py
+    │   ├── test_base_service.py
+    │   ├── test_media_ingestion.py
+    │   ├── test_scheduler.py                  # JIT scheduler tests
+    │   ├── test_scheduler_loop.py
+    │   ├── test_scheduler_queue_reliability.py
+    │   ├── test_media_lock.py
+    │   ├── test_media_lifecycle.py
+    │   ├── test_media_sync.py
+    │   ├── test_posting.py
+    │   ├── test_posting_delivery_reschedule.py
+    │   ├── test_daily_cap.py
+    │   ├── test_telegram_service.py           # Core service tests
+    │   ├── test_telegram_commands.py          # Command handler tests
+    │   ├── test_telegram_commands_status.py
+    │   ├── test_telegram_callbacks.py         # Callback handler tests
+    │   ├── test_telegram_callbacks_admin.py
+    │   ├── test_telegram_callbacks_core.py
+    │   ├── test_telegram_callbacks_queue.py
+    │   ├── test_telegram_settings.py          # Settings UI tests
+    │   ├── test_telegram_accounts.py          # Account handler tests
+    │   ├── test_telegram_autopost.py
+    │   ├── test_telegram_lifecycle.py
+    │   ├── test_telegram_notification.py
+    │   ├── test_telegram_utils.py
+    │   ├── test_health_check.py
+    │   ├── test_settings_service.py           # Per-chat settings
+    │   ├── test_setup_state_service.py
+    │   ├── test_start_command_router.py
+    │   ├── test_instagram_account_service.py  # Multi-account
+    │   ├── test_interaction_service.py        # Bot interaction tracking
+    │   ├── test_instagram_api.py              # Instagram Graph API
+    │   ├── test_instagram_backfill.py
+    │   ├── test_instagram_login_oauth.py
+    │   ├── test_backfill_downloader.py
+    │   ├── test_caption_service.py
+    │   ├── test_conversation_service.py
+    │   ├── test_credential_refactor_dual_write.py
+    │   ├── test_credential_refactor_phase_3.py
+    │   ├── test_cloud_storage.py               # Cloudinary integration
+    │   ├── test_dashboard_service.py
+    │   ├── test_google_drive_oauth.py
+    │   ├── test_google_drive_service.py
+    │   ├── test_membership_service.py
+    │   ├── test_oauth_service.py
+    │   ├── test_phase2b_handlers.py
+    │   ├── test_token_refresh.py               # Token lifecycle
+    │   └── test_user_service.py
+    └── utils/               # Utility tests (8 files)
+        ├── test_auth_monitor.py
+        ├── test_datetime_utils.py
+        ├── test_encryption.py             # Fernet encryption
+        ├── test_file_hash.py
+        ├── test_image_processing.py
+        ├── test_logger.py
+        ├── test_validators.py
+        └── test_webapp_auth.py
 ```
 
 ## Test Markers
@@ -322,18 +395,22 @@ open htmlcov/index.html
 In CI environments (GitHub Actions, etc.), tests run automatically. The test database is created automatically - no special setup needed.
 
 ```yaml
-# .github/workflows/test.yml
+# .github/workflows/ci.yml (the "test" job)
 services:
   postgres:
     image: postgres:15
     env:
-      POSTGRES_PASSWORD: postgres
+      POSTGRES_USER: test_user
+      POSTGRES_PASSWORD: test_password
+      POSTGRES_DB: storyline_test
     options: >-
       --health-cmd pg_isready
       --health-interval 10s
+      --health-timeout 5s
+      --health-retries 5
 
-- name: Run tests
-  run: make test
+- name: Run tests with coverage
+  run: pytest tests/ -v --cov=src --cov-report=xml --cov-report=term-missing
 ```
 
 ## Troubleshooting

--- a/documentation/operations/backup-restore.md
+++ b/documentation/operations/backup-restore.md
@@ -19,7 +19,7 @@ Critical data to backup:
 pg_dump "$DATABASE_URL" -F c -f ~/backups/storydump_$(date +%Y%m%d_%H%M%S).dump
 
 # Or with explicit connection string
-pg_dump "postgresql://user:pass@ep-xxx.neon.tech/storydump_ai?sslmode=require" \
+pg_dump "postgresql://user:pass@ep-xxx.neon.tech/storydump?sslmode=require" \
     -F c -f ~/backups/storydump_$(date +%Y%m%d_%H%M%S).dump
 ```
 

--- a/documentation/operations/google-oauth-verification.md
+++ b/documentation/operations/google-oauth-verification.md
@@ -24,7 +24,7 @@ Before opening the OAuth Brand / consent screen submission form:
 - [x] **Terms of Service URL** — `https://storydump.app/terms` (`landing/src/app/(marketing)/terms/page.tsx`)
 - [ ] **App icon** — 120×120 PNG, no transparency. Need to design.
 - [ ] **Authorized domain** — `storydump.app` verified via Google Search Console.
-- [ ] **OAuth Redirect URI registered** — `${OAUTH_REDIRECT_BASE_URL}/auth/google-drive/callback`. Currently `https://storyline-ai-production.up.railway.app/auth/google-drive/callback` on Railway. Add it under **APIs & Services → Credentials → [OAuth 2.0 Client] → Authorized redirect URIs**. (`OAUTH_REDIRECT_BASE_URL` is documented in [`documentation/guides/cloud-deployment.md`](../guides/cloud-deployment.md).)
+- [ ] **OAuth Redirect URI registered** — `${OAUTH_REDIRECT_BASE_URL}/auth/google-drive/callback`. Currently `https://storydump-production.up.railway.app/auth/google-drive/callback` on Railway. Add it under **APIs & Services → Credentials → [OAuth 2.0 Client] → Authorized redirect URIs**. (`OAUTH_REDIRECT_BASE_URL` is documented in [`documentation/guides/cloud-deployment.md`](../guides/cloud-deployment.md).)
 - [ ] **Scope justification copy** — short text explaining why we need `drive.readonly` (see template below).
 - [ ] **Demo video** — screencast (≤ 5 min) demonstrating each requested scope in use. YouTube unlisted is fine.
 

--- a/documentation/operations/troubleshooting.md
+++ b/documentation/operations/troubleshooting.md
@@ -40,8 +40,9 @@ railway logs --service worker | tail -50
 
 **Diagnosis**:
 ```sql
--- Check for stuck posts
-SELECT id, scheduled_for, status, error_message
+-- Check for stuck posts (posting_queue has no error_message column --
+-- error details for completed attempts live in posting_history instead)
+SELECT id, scheduled_for, status
 FROM posting_queue
 WHERE scheduled_for < NOW()
 ORDER BY scheduled_for DESC
@@ -124,9 +125,12 @@ JOIN instagram_accounts ia ON t.instagram_account_id::uuid = ia.id;
 ```bash
 # For Google Drive media source, check sync status
 railway shell --service worker -c "storydump-cli sync-status"
+```
 
-# Check media source configuration
-railway shell --service worker -c "echo \$MEDIA_SOURCE_TYPE"
+```sql
+-- Media source is a per-chat setting (not a global env var)
+SELECT media_source_type, media_source_root, media_sync_enabled
+FROM chat_settings WHERE telegram_chat_id = YOUR_CHAT_ID;
 ```
 
 **Common Causes**:
@@ -134,8 +138,8 @@ railway shell --service worker -c "echo \$MEDIA_SOURCE_TYPE"
 | Cause | Fix |
 |-------|-----|
 | Google Drive not connected | Complete OAuth via /start onboarding |
-| Wrong folder ID | Update `MEDIA_SOURCE_ROOT` env var |
-| Sync disabled | Set `MEDIA_SYNC_ENABLED=true` |
+| Wrong folder ID | Update `chat_settings.media_source_root` via /settings or the onboarding wizard |
+| Sync disabled | Enable `chat_settings.media_sync_enabled` via /settings |
 | Unsupported format | Only JPG, JPEG, PNG, GIF, MP4, MOV supported |
 | File too large | Max 100MB per file |
 
@@ -228,11 +232,19 @@ railway restart --service worker
 
 ### Clear Stuck Queue
 
+An hourly `cleanup_queue_loop` already deletes any queue item more than 24
+hours past its `scheduled_for` time automatically. To force this
+immediately instead of waiting for the next hourly pass:
+
 ```bash
-# Mark failed posts as cancelled
+# Delete stale queue items regardless of status (mirrors QueueRepository.delete_stale)
 psql "$DATABASE_URL" -c \
-    "UPDATE posting_queue SET status = 'cancelled' WHERE status = 'pending' AND scheduled_for < NOW();"
+    "DELETE FROM posting_queue WHERE scheduled_for < NOW() - INTERVAL '24 hours';"
 ```
+
+`posting_queue.status` only has three real values (`pending`, `processing`,
+`failed`) -- there is no `cancelled` status recognized anywhere in the
+codebase, so don't set it to that.
 
 ### Force Service Restart
 

--- a/documentation/planning/2026-03-31-meta-app-launch-design.md
+++ b/documentation/planning/2026-03-31-meta-app-launch-design.md
@@ -1,8 +1,10 @@
 # Design: Meta App + Instagram Login OAuth + Go-Live
 
 **Date:** 2026-03-31
-**Status:** APPROVED
+**Status:** ✅ COMPLETED — verified 2026-07-06
 **Goal:** Take Storydump from single-user dry-run to a system where testers can self-onboard and post to their own Instagram accounts via the Mini App.
+
+> **Verification note (2026-07-06):** All 4 milestones shipped. Graph API bumped to v21.0 (`settings.META_GRAPH_API_VERSION`); `InstagramLoginOAuthService` + `/auth/instagram-login/callback` landed in `fefd82f` ("feat: add Instagram Login OAuth + bump Graph API to v21.0"); the system has been live in production since, with real accounts (`@gatortails`, `@thursday.lines`) onboarded and posting via Instagram Login OAuth (see `CHANGELOG.md` and the `investigations/` docs). The architecture has since grown a second Graph host (`settings.meta_ig_graph_base`, added 2026-06-02) that this design didn't anticipate — see `2026-05-18-instagram-credential-refactor.md` and `investigations/ig-host-routing_2026-06-02/`.
 
 ## Context
 

--- a/documentation/planning/2026-05-18-instagram-credential-refactor.md
+++ b/documentation/planning/2026-05-18-instagram-credential-refactor.md
@@ -1,7 +1,9 @@
 # Instagram Credential Refactor — Implementation Plan
 
-**Status:** Draft. **Author:** chrisrogers37 (with Claude). **Date:** 2026-05-18.
+**Status:** ✅ COMPLETED — verified 2026-07-06 (see note below). **Author:** chrisrogers37 (with Claude). **Date:** 2026-05-18.
 **Related:** PR #378 (band-aid fix), follow-up to PR #341 (multi-account ingest).
+
+> **Verification note (2026-07-06):** All 5 PRs landed, tracked across issues #380 (phases 1-3) then #468 (phases 4-5): PR-1 `2bc6908` (2026-05-19, migration 035, additive `meta_account_id`), PR-2 `bb30228` (2026-05-19, dual-write), PR-3 `fb20683` (2026-05-19, #408, migration 036 backfill + credential-keyed reads), PR-4 `6f982a8` + `fe65678` (2026-06-02, migrations 038-040), PR-5 `706fbc2` (2026-06-03, migration 041). **Two deviations from this plan:** (1) PR-4 shipped as a real `api_tokens.auth_method` + `issuing_app_id` column pair (with its own migrations) rather than inferring auth method from `service_name` differentiation as sketched in "Open decisions" #1 below. (2) PR-5 only dropped `instagram_accounts.auth_method`; `instagram_accounts.instagram_account_id` was deliberately **kept** rather than dropped — per CHANGELOG.md: "its consumers (backfill, OAuth heal logic, credential lookup) need a separate refactor... filed as a follow-up." The migration plan's PR-5 SQL sketch (dropping both columns) did not ship as written.
 
 ## Problem statement
 

--- a/documentation/planning/feed-queue-features/01_live_story_visibility.md
+++ b/documentation/planning/feed-queue-features/01_live_story_visibility.md
@@ -2,9 +2,11 @@
 
 **Focus**: Fetch and display currently-live Instagram stories so users know what's on their feed without opening the app.
 
-**Status**: Ready for Implementation
+**Status**: 📋 PENDING — not started; verified 2026-07-06 (see note below)
 **Priority**: High — standalone value, no blockers
 **Estimated Effort**: Medium (service + Telegram UI + tests)
+
+> **Verification note (2026-07-06):** Confirmed not implemented — no `get_live_stories()` method exists in `src/services/integrations/instagram_api.py`, and `/status` (`telegram_commands.py`) has no "Live Stories" section. The documentation hub's "Ready" label is directionally fine (nothing blocks this), but **the endpoint sketched below is now stale and would reintroduce a known bug**: it hardcodes `graph.facebook.com/v22.0/...`, while production Instagram accounts authenticate via `instagram_login`, whose tokens are only valid against `graph.instagram.com` (`settings.meta_ig_graph_base`, added 2026-06-02). Calling `graph.facebook.com` with one of these tokens fails with Meta error 190 — the exact class of bug fixed for posting in `investigations/ig-host-routing_2026-06-02/`. Also note the current `META_GRAPH_API_VERSION` is `v21.0`, not the `v22.0` assumed below. An implementer should call through `settings.meta_ig_graph_base` rather than hardcoding host/version.
 
 ---
 

--- a/documentation/planning/feed-queue-features/02_feed_reset.md
+++ b/documentation/planning/feed-queue-features/02_feed_reset.md
@@ -2,9 +2,11 @@
 
 **Focus**: Allow users to clear/remove live Instagram stories to start a fresh posting cycle.
 
-**Status**: BLOCKED — Instagram Graph API does not support story deletion
+**Status**: BLOCKED — Instagram Graph API does not support story deletion (verified still true 2026-07-06)
 **Priority**: Medium — desired feature, but no API path currently exists
 **Estimated Effort**: TBD (dependent on API availability)
+
+> **Verification note (2026-07-06):** Re-checked — no DELETE endpoint for Instagram stories/media has appeared in the Graph API; current production Graph API version is v21.0. No code changes have been made toward this workstream since the doc was written (git history has no related commits). Status and recommendation below remain accurate as written; workstream is still correctly parked.
 
 ---
 

--- a/documentation/planning/instagram-deeplink-redirect.md
+++ b/documentation/planning/instagram-deeplink-redirect.md
@@ -1,9 +1,11 @@
 # Instagram Story Camera Deep Link Redirect Service
 
-**Status**: Planning
+**Status**: 🔧 BUILT BUT NOT ACTIVATED — verified 2026-07-06 (see note below)
 **Priority**: High (Backlog item from Phase 1.5)
 **Estimated effort**: 1-2 hours
 **Date**: 2026-03-08
+
+> **Verification note (2026-07-06):** `docs/index.html` was built almost verbatim to this doc's recommended platform-aware design (commit `e3194ea`, 2026-03-28) and `docs/README.md` describes it as the live GitHub Pages deploy source. However, the application never links to it: `defaults.DEFAULT_INSTAGRAM_DEEPLINK_URL` (consumed by `telegram_utils.py`'s "Open Instagram" button) is hardcoded to the plain `https://www.instagram.com/` feed URL. The configurable `INSTAGRAM_DEEPLINK_URL` env var this plan calls for was added and then removed on 2026-05-12 (commit `41ce21a`, "same value for every deployment, no reason to env-ify") without ever pointing production at the redirect page. `.env.example` still carries a dead, commented-out `INSTAGRAM_DEEPLINK_URL=https://your-username.github.io/storydump/` line from the abandoned wiring. **Net effect: the story-camera deep link this plan describes is not live** — tapping "Open Instagram" opens the Instagram feed today, same as before this plan was written.
 
 ---
 

--- a/documentation/planning/investigations/ig-host-routing_2026-06-02/00_INVESTIGATION.md
+++ b/documentation/planning/investigations/ig-host-routing_2026-06-02/00_INVESTIGATION.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| Status | ✅ **RESOLVED** — verified 2026-07-06. All 5 planned PRs merged: PR1 `ad6716b` (2026-06-02, host routing fix), PR2 `6f982a8` (2026-06-02, adds `api_tokens.auth_method`/`issuing_app_id`), PR3 `fe65678` (2026-06-02, dual-write at OAuth callbacks), PR4 (read-switch, documented in CHANGELOG.md under #468), PR5 `706fbc2` (2026-06-03, drops `instagram_accounts.auth_method`). No recurrence of "Cannot parse access token" / code 190 found in git history or CHANGELOG.md since. |
 | Date | 2026-06-02 |
 | Triggered by | User report: "We STILL have not figured out auth and getting stories to post through the Instagram login." |
 | Prior investigation | `documentation/planning/investigations/ig-oauth-cross-flow-reconnect_2026-05-25/00_INVESTIGATION.md` |

--- a/documentation/planning/investigations/ig-oauth-cross-flow-reconnect_2026-05-25/00_INVESTIGATION.md
+++ b/documentation/planning/investigations/ig-oauth-cross-flow-reconnect_2026-05-25/00_INVESTIGATION.md
@@ -2,6 +2,7 @@
 
 | Field | Value |
 |---|---|
+| Status | ✅ **RESOLVED** — verified 2026-07-06. Bug B (reconnect loop) fixed by `find_existing_account_for_oauth`, per `01_oauth_cross_flow_fallback.md`, shipped `26f85fd` (2026-05-25) / `03d15cd` (2026-05-26, #441). Bug A ("Cannot parse access token") turned out to share a root cause with the *later* `ig-host-routing_2026-06-02` investigation — IG-Login tokens sent to the wrong Graph host, not a corrupt token — resolved by that investigation's PR1 (`ad6716b`, 2026-06-02). The F3 follow-up this doc anticipated ("if the fresh token also can't be parsed, Bug A is structural") was effectively answered by that sibling investigation rather than opened separately. |
 | Date | 2026-05-25 |
 | Triggered by | User report: "still getting served content, but still cannot post it to instagram. I have @gatortails attached to my account. I just tried re-connecting and got hit with Connection Failed." |
 | Deployed prod commit | `6ca43d3` (main, PR #435 — `fix: align dry_run_mode model default with code default (False)`) |

--- a/documentation/planning/investigations/ig-oauth-cross-flow-reconnect_2026-05-25/01_oauth_cross_flow_fallback.md
+++ b/documentation/planning/investigations/ig-oauth-cross-flow-reconnect_2026-05-25/01_oauth_cross_flow_fallback.md
@@ -8,7 +8,7 @@
 | Risk | Low |
 | Effort | Small (≈40 lines code, ≈60 lines test) |
 | Touches prod data? | No (self-healing happens via the live OAuth flow once a user reconnects) |
-| Status | **IN PROGRESS** (started 2026-05-25, branch `implement/oauth-cross-flow-fallback`) |
+| Status | ✅ **COMPLETED** — verified 2026-07-06. Shipped in `26f85fd` (2026-05-25) and `03d15cd` (2026-05-26, #441). `find_existing_account_for_oauth` is live in `src/services/core/instagram_account_service.py` — the same three-tier lookup designed here — and CHANGELOG.md documents the matching regression tests (`test_exchange_recovers_via_username_when_meta_id_mismatches`, `test_resolves_by_username_when_meta_id_misses`) and the `TestUsernameCallbackRemoved` → `TestCrossFlowUsernameRecovery` rename this plan called for. (Originally started 2026-05-25, branch `implement/oauth-cross-flow-fallback`.) |
 | Decisions confirmed during build | Keep `get_account_by_meta_id` as thin alias (no callsite churn); F5 logs interesting branches at INFO, skip the boring meta_id-direct hit |
 
 ---

--- a/documentation/planning/multi-account-dashboard.md
+++ b/documentation/planning/multi-account-dashboard.md
@@ -1,7 +1,8 @@
 # Multi-Account Dashboard Migration
 
-**Status:** Planning (consolidated 2026-04-17)
+**Status:** Implemented. All 6 phases (1a-4) were built and merged the same day this plan was consolidated (2026-04-17), with follow-up hardening PRs through 2026-06-28. The feature has been live in production for roughly 2.5 months — a cross-tenant data isolation bug in the membership/auth gate was found and fixed on 2026-06-28 (PR #511/#512/#519), consistent with real membership data being in active use. Re-verified against code on 2026-07-06: 29 of 33 checklist items are confirmed fully implemented as specified (several exceed spec). 2 confirmed gaps and 1 item that cannot be verified from static code remain — see "Verification Notes" below and the inline notes on each phase's checklist.
 **Created:** 2026-04-17
+**Verified against code:** 2026-07-06
 **Reviewed by:** Rajan (architecture), Greg (implementation)
 
 ## Problem
@@ -269,58 +270,68 @@ Add `create_if_missing: bool = True` parameter to `get_settings()` for backward 
 
 After the `get_settings()` split ships, existing phantom DM `chat_settings` rows will still exist and appear in `get_all_active()` scheduler queries (no-op but wastes cycles). Add a cleanup migration to delete `chat_settings` rows where `telegram_chat_id > 0` AND no media/queue/history references exist.
 
+## Verification Notes (2026-07-06)
+
+A full code audit (reading actual implementation, not just checking file existence) against every checkbox below found the plan substantially implemented. Confirmed gaps, in order of importance:
+
+1. **Phase 2a's "audit and flip ~15 call sites" was not completed.** Of the plan's 4 explicitly named "MUST NOT create" DM call sites, only `handle_start` is actually safe (structurally — it never calls `get_settings()` on the DM chat at all). `SetupStateService.get_setup_state()`, `DashboardService.resolve_chat_settings_id()` (renamed from `_resolve_chat_settings_id`, used by 8+ dashboard query classes), and the `onboarding/init` → `_get_setup_state()` chain all still call `get_settings()` at its `create_if_missing=True` default, and will still silently create phantom DM `chat_settings` rows on every hit — including, per this doc's own text, "every BFF proxy page load." This directly contradicts migration `024_cleanup_phantom_dm_chat_settings.sql`'s header comment, which asserts "Phase 2a's get_settings() split prevents new phantoms." The actual call-site count is 34 (not ~15); only 10 explicitly pass `create_if_missing=False`, and all 10 are group-callback contexts, not the DM contexts this refactor targeted. Net effect: migration 024 cleaned up historical phantoms once, but the code paths that originally created them are still capable of creating new ones.
+2. **Phase 4's `/webapp/instances` Mini App picker is built but unreachable.** The page renders correctly and matches the spec's field list (name, media count, posts/day, last post, status), but nothing else in the repository links to it — no Telegram WebApp SDK / `initData` usage anywhere in the file or the `webapp/` folder, and zero repo-wide references to the route. The actual bot flow routes single-instance users to an unrelated FastAPI-served static page (`/webapp/onboarding`) and sends multi-instance DM users a plain-text message with inline-keyboard buttons — never a Mini App link to this page. Effectively dead code today.
+3. **Phase 1b's prod backfill verification cannot be confirmed from code alone.** `scripts/backfill_memberships.py` has a working `--verify` mode (auto-run after `--apply`) that implements the doc's exact gating query and exits non-zero on gaps, but whether it was actually run against production and returned 0 rows is a runtime fact outside what static code can prove. No run-log, ops runbook, or execution record was found in `documentation/`. Circumstantial evidence it passed is strong (Phases 2a-4, which depend on this gate, were built and merged the same day; the feature has been live in prod for ~2.5 months with real membership data), but this should be confirmed with a live DB check before treating it as closed.
+
+Minor, non-blocking deviations from spec (also noted inline on their checkboxes): `/link` intentionally does not take a `<session_id>` argument (always scoped to the caller's own pending session instead); `ConversationService` uses purpose-named methods (`set_instance_name()`, `link_group()`, `cleanup_expired()`, etc.) rather than the generic `advance_step()` / `get_current_step()` / `timeout_check()` named in the plan; `POST /api/instances/:id/select`'s `:id` is a `telegram_chat_id`, not the `chat_settings_id` UUID the schema names as PK; `StartCommandRouter` grew a 6th branch (mobile-login deep link) beyond the 5 originally planned.
+
 ## Implementation Plan
 
-### Phase 1a: Migration + Model + Repository (1 PR, ~400 LOC, low risk)
+### Phase 1a: Migration + Model + Repository (1 PR, ~400 LOC, low risk) — DONE (PR #231, 2026-04-17)
 
-- [ ] Migration 023: `user_chat_memberships` table, `onboarding_sessions` table, `display_name` on `chat_settings`
-- [ ] Migration 023: Index on `user_interactions(user_id, telegram_chat_id)` for backfill
-- [ ] `UserChatMembership` model + `UserChatMembershipRepository` (~120 LOC)
-- [ ] `OnboardingSession` model + `OnboardingSessionRepository`
-- [ ] Auto-create membership hook in `TelegramService._get_or_create_user()` for group interactions
-- [ ] `DashboardService.get_user_instances(telegram_user_id)` — JOIN memberships → chat_settings, aggregate stats (~40 LOC)
+- [x] Migration 023: `user_chat_memberships` table, `onboarding_sessions` table, `display_name` on `chat_settings` — `scripts/migrations/023_multi_account_data_layer.sql`, matches spec exactly
+- [x] Migration 023: Index on `user_interactions(user_id, telegram_chat_id)` for backfill — same migration, `idx_user_interactions_backfill`, created `CONCURRENTLY` outside the transaction block
+- [x] `UserChatMembership` model + repository (~120 LOC) — model fields match the migration exactly; repository is named `MembershipRepository` (`src/repositories/membership_repository.py`), not `UserChatMembershipRepository` as named in the plan, with `get_for_user`/`get_for_chat`/`get_membership`/`create_membership`/`deactivate_for_chat`/`deactivate`
+- [x] `OnboardingSession` model + repository — repository is named `OnboardingRepository` (`src/repositories/onboarding_repository.py`), not `OnboardingSessionRepository`
+- [x] Auto-create membership hook for group interactions — lives in `TelegramUserManager.get_or_create_user()` → `_ensure_membership()` (`src/services/core/telegram_user_manager.py`), called from `TelegramService._get_or_create_user()` which delegates to it; checks `telegram_chat_id < 0` before creating
+- [x] `DashboardService.get_user_instances(telegram_user_id)` — method exists on `DashboardService` (`src/services/core/dashboard_service.py`) and delegates to `InstanceDashboardQueries.get_user_instances()` (`src/services/core/dashboard_instance_queries.py`, ~38 LOC); joins memberships → chat_settings and aggregates media count, posts/day, last post
 
-### Phase 1b: Backfill + Verification (script, run on prod)
+### Phase 1b: Backfill + Verification (script, run on prod) — DONE (PR #232, 2026-04-17), prod execution unconfirmed
 
-- [ ] Backfill script with group-only filter (`telegram_chat_id < 0`)
-- [ ] Role promotion via `getChatAdministrators`
-- [ ] Run verification query — must return 0 rows
-- [ ] **GATE: Phase 2 cannot deploy until backfill verified**
+- [x] Backfill script with group-only filter (`telegram_chat_id < 0`) — `scripts/backfill_memberships.py`; matches the plan's SQL intent field-for-field (filters `telegram_chat_id < 0`, excludes `bot_response` interaction type, `ON CONFLICT DO NOTHING`)
+- [x] Role promotion via `getChatAdministrators` — same script, `--promote` flag; calls `getChatAdministrators` per active group, maps creator/administrator → owner/admin, 50ms delay between calls
+- [ ] Run verification query — must return 0 rows — **code capability confirmed** (script's `--verify` mode implements the doc's exact query and auto-runs after `--apply`, exiting non-zero on gaps), **but actual execution against production and its result cannot be confirmed from code alone.** No run-log or ops record found. Needs a live DB check to close out — see Verification Notes above.
+- [x] **GATE: Phase 2 cannot deploy until backfill verified** — gate mechanism is enforced in code (non-zero exit on verification failure); Phases 2a-4 shipped the same day, consistent with the gate having passed, though this is inferred rather than directly observed
 
-### Phase 2a: `get_settings()` Split + `/start` Refactor (1 PR, ~400 LOC, high risk)
+### Phase 2a: `get_settings()` Split + `/start` Refactor (1 PR, ~400 LOC, high risk) — DONE with a gap (PR #233, 2026-04-17)
 
-- [ ] Add `create_if_missing` parameter to `get_settings()`
-- [ ] Audit and flip ~15 call sites (DM paths → `create_if_missing=False`)
-- [ ] `StartCommandRouter` class with 5-branch `/start` handler
-- [ ] `ConversationService` wrapping `onboarding_sessions` (`advance_step()`, `get_current_step()`, `timeout_check()`)
-- [ ] DM onboarding flow (naming → awaiting_group → complete)
-- [ ] Returning user instance list in DM
+- [x] Add `create_if_missing` parameter to `get_settings()` — `src/services/core/settings_service.py:58`, `def get_settings(self, telegram_chat_id: int, create_if_missing: bool = True)`; defaults `True` for backward compat, `False` returns `get_by_chat_id()` (possibly `None`) instead of `get_or_create()`
+- [ ] Audit and flip ~15 call sites (DM paths → `create_if_missing=False`) — **incomplete.** 34 total call sites found (not ~15); only 10 pass `create_if_missing=False` explicitly, and all 10 are group-callback contexts, not the DM contexts this item targeted. Of the plan's 4 named "MUST NOT create" DM sites, only `handle_start` is actually safe; `SetupStateService.get_setup_state()`, `DashboardService.resolve_chat_settings_id()`, and the `onboarding/init` chain were never flipped and still auto-create phantom DM rows. See Verification Notes above.
+- [x] `StartCommandRouter` class with 5-branch `/start` handler — `src/services/core/start_command_router.py`; all 5 plan branches present (internally renumbered/relabeled), plus a 6th branch added later (`login` deep-link redirect for mobile sign-in, per #455/#457) not in the original plan
+- [x] `ConversationService` wrapping `onboarding_sessions` — functionality matches (advance state / query current session / expire stale sessions), but method names differ from the plan: actual public methods are `start_onboarding`, `get_current_session`, `get_session_by_id`, `set_instance_name`, `link_group`, `link_group_to_instance`, `cleanup_expired` — no `advance_step()`, `get_current_step()`, or `timeout_check()`
+- [x] DM onboarding flow (naming → awaiting_group → complete) — confirmed exact step values and transitions across `OnboardingSession`, `ConversationService`, and `StartCommandRouter`
+- [x] Returning user instance list in DM — `_handle_returning_user()` calls `DashboardService.get_user_instances()` and renders the list with "Manage"/"+ New Instance" buttons
 
-### Phase 2b: Group Linking + Event Handlers (1 PR, ~400 LOC, medium risk)
+### Phase 2b: Group Linking + Event Handlers (1 PR, ~400 LOC, medium risk) — DONE (PR #240, 2026-04-17)
 
-- [ ] `my_chat_member` handler: auto-link pending onboarding on bot-added, deactivate memberships on bot-kicked
-- [ ] `startgroup` deep link arg parsing in `/start` handler
-- [ ] `/link <session_id>` fallback command
-- [ ] `/name <name>` command for setting instance display_name
-- [ ] `/instances` command for DM instance management
-- [ ] Onboarding session timeout cleanup in scheduler loop
+- [x] `my_chat_member` handler: auto-link pending onboarding on bot-added, deactivate memberships on bot-kicked — `src/services/core/telegram_membership.py`, registered via `ChatMemberHandler` in `telegram_service.py`; matches spec exactly on both add and kick paths
+- [x] `startgroup` deep link arg parsing in `/start` handler — `start_command_router.py`, parses `context.args[0]` for a `setup_` prefixed payload
+- [x] `/link <session_id>` fallback command — implemented and registered, but **intentionally does not accept a `<session_id>` argument** (documented deviation in its own docstring); always resolves the caller's own pending `awaiting_group` session instead
+- [x] `/name <name>` command for setting instance display_name — `telegram_commands.py`, updates `chat_settings.display_name` for the invoking group
+- [x] `/instances` command for DM instance management — `telegram_commands.py`, lists instances via `DashboardService.get_user_instances()` with per-instance "Manage" buttons
+- [x] Onboarding session timeout cleanup in scheduler loop — `ConversationService.cleanup_expired()` (24h TTL), invoked hourly from `src/services/core/loops/scheduler_loop.py`, piggybacked on the existing retention tick counter exactly as the plan described; logs dropouts before deleting (#247)
 
-### Phase 3: API + Auth (1 PR, ~300 LOC, medium risk — can parallel with Phase 2b)
+### Phase 3: API + Auth (1 PR, ~300 LOC, medium risk — can parallel with Phase 2b) — DONE (PR #235/#236, #246, 2026-04-17)
 
-- [ ] `SessionPayload.chatId` → `SessionPayload.activeChatId: number | null`
-- [ ] Auth route: set `activeChatId = null` on login (not `chatId = body.id`)
-- [ ] `GET /api/instances` endpoint — calls `DashboardService.get_user_instances()`
-- [ ] `POST /api/instances/:id/select` — reissues JWT with `activeChatId` set
-- [ ] BFF proxy: use `activeChatId`, redirect to picker if null
-- [ ] BFF proxy: validate `activeChatId` against active memberships on each request
+- [x] `SessionPayload.chatId` → `SessionPayload.activeChatId: number | null` — `landing/src/lib/session.ts`, field renamed exactly as specified
+- [x] Auth route: set `activeChatId = null` on login (not `chatId = body.id`) — `landing/src/app/api/auth/telegram/route.ts`
+- [x] `GET /api/instances` endpoint — `landing/src/app/api/instances/route.ts` calls through to `DashboardService.get_user_instances()` via `src/api/routes/onboarding/dashboard.py`
+- [x] `POST /api/instances/:id/select` — reissues the JWT with `activeChatId` set, and genuinely authorizes against the caller's live active memberships before switching (403 if not a member — not a rubber stamp). Minor: `:id` is actually a `telegram_chat_id`, not the `chat_settings_id` UUID the schema names as PK — cosmetic naming mismatch, not a security issue.
+- [x] BFF proxy: use `activeChatId`, redirect to picker if null — implemented, split across `landing/src/middleware.ts` (page-level redirect to `/instances`) and the proxy route (422 JSON error for API calls, since a raw redirect wouldn't render a picker for client-side fetches)
+- [x] BFF proxy: validate `activeChatId` against active memberships on each request — implemented, not deferred despite being flagged "low severity" in this doc's own "URL Token Auth Gap" section; shipped same day in a follow-up (PR #246), re-checks live memberships on every proxied request and force-clears `activeChatId` if the membership has gone stale
 
-### Phase 4: Frontend (1 PR, ~500 LOC, low risk — depends on Phase 3)
+### Phase 4: Frontend (1 PR, ~500 LOC, low risk — depends on Phase 3) — DONE except entry point (PR #235/#236, 2026-04-17)
 
-- [ ] Instance picker page/component (name, media count, posts/day, last post, status badge)
-- [ ] Instance switcher dropdown in dashboard header
-- [ ] Update dashboard layout to show active instance name
-- [ ] 0-instance edge case → "Set up your first instance" CTA linking to DM bot
-- [ ] Mini App DM entry point: `/webapp/instances` picker view
+- [x] Instance picker page/component (name, media count, posts/day, last post, status badge) — `landing/src/app/instances/page.tsx`, all 5 fields present and correctly wired to the `Instance` type
+- [x] Instance switcher dropdown in dashboard header — `landing/src/components/dashboard/header.tsx`, calls `POST /api/instances/:id/select` and refreshes
+- [x] Update dashboard layout to show active instance name — shown in `header.tsx` (not the layout file itself); note `sidebar.tsx` still shows a static site name rather than the active instance name
+- [x] 0-instance edge case → "Set up your first instance" CTA linking to DM bot — bespoke branch in `instances/page.tsx` with a hardcoded `t.me/storydump_bot` link; does not reuse the generic `empty-state.tsx` component (that component has no zero-instance logic at all)
+- [ ] Mini App DM entry point: `/webapp/instances` picker view — **built but unreachable, effectively dead code.** The page exists and renders the correct fields, but nothing in the repo links to it, it has no Telegram WebApp SDK/`initData` integration, and the real bot flow routes single-instance users to an unrelated static page (`/webapp/onboarding`) and multi-instance DM users to a plain-text message with inline-keyboard buttons — never to this page. See Verification Notes above.
 
 ### Effort Summary
 

--- a/documentation/planning/phases/00_MASTER_ROADMAP.md
+++ b/documentation/planning/phases/00_MASTER_ROADMAP.md
@@ -1,6 +1,6 @@
 # Storydump - Master Roadmap
 
-**Last Updated**: 2026-02-09
+**Last Updated**: 2026-02-09 (status column verified/annotated 2026-07-06 — see notes marked "Status verified/updated 2026-07-06")
 **Vision**: E-commerce Optimization Hub for Social Media Marketing
 
 ---
@@ -150,9 +150,13 @@ Entities (Tables):
 | **3** | **Shopify Integration** | 📋 PENDING | - | Phase 2 |
 | **4** | **Printify Integration** | 📋 PENDING | - | Phase 3 |
 | **5** | **Media-Product Linking** | 📋 PENDING | - | Phase 3, 4 |
-| **6** | **LLM Integration** | 📋 PENDING | - | Phase 5 |
+| **6** | **LLM Integration** | 📋 PENDING † | - | Phase 5 |
 | **7** | **Order & Email Automation** | 📋 PENDING | - | Phase 3, 6 |
-| **8** | **Dashboard UI** | 📋 PENDING | - | Phase 5, 6, 7 |
+| **8** | **Dashboard UI** | 🔧 IN PROGRESS †† | - | Phase 5, 6, 7 |
+
+> **Status verified 2026-07-06** (documentation staleness audit, cross-checked against `src/`, `landing/src/`, and `scripts/migrations/`): Phases 3, 4, 5, and 7 confirmed still PENDING with no corresponding code anywhere in the repo. Two corrections from this audit:
+> - **† Phase 6 (LLM)**: the abstraction/prompt-template/conversation architecture in [05_llm_integration.md](05_llm_integration.md) is still 0% built, but a narrow, unrelated Claude integration (`src/services/core/caption_service.py`, AI-generated Instagram captions) already ships in production. Left as PENDING rather than IN PROGRESS since it isn't a step toward this doc's specific architecture — see that doc for detail.
+> - **†† Phase 8 (Dashboard)**: changed from PENDING to IN PROGRESS. A substantial Next.js dashboard is live (`landing/src/app/(dashboard)/`) covering analytics, media library, and settings — but it was built via an undocumented multi-tenant/Telegram-Mini-App initiative rather than as an execution of [07_dashboard_ui.md](07_dashboard_ui.md), and it omits the e-commerce-dependent parts (Product & Performance, Team activity) since Phases 3-6 remain undone. See that doc for detail.
 
 ---
 
@@ -173,9 +177,11 @@ Enable automated Instagram Story posting via Meta Graph API. Hybrid mode: auto-p
 - Per-chat settings with `.env` fallback
 
 ### Phase 2.5: Settings & Multi-Tenancy ✅ COMPLETE (Phases 1-1.5)
-**Document**: [01_settings_and_multitenancy.md](01_settings_and_multitenancy.md)
+**Document**: [01_settings_and_multitenancy.md](01_settings_and_multitenancy.md) — ⚠️ *broken link as of 2026-07-06: this file does not exist in `documentation/planning/phases/`.*
 
 Runtime-configurable settings and Instagram account management. Phases 1 and 1.5 of this document are complete; Phases 2 (Cloud Media Storage) and 3 (Multi-Tenancy) remain future work.
+
+> **Status correction, 2026-07-06** (documentation staleness audit): the claim above that Phase 2 (Cloud Media Storage) and Phase 3 (Multi-Tenancy) "remain future work" is stale. Cloudinary cloud media storage shipped as part of Phase 2 (Instagram API Automation, above). Multi-tenancy has since been extensively implemented — a `chat_settings_id` tenant FK was added to core tables (migration `014_multi_tenant_chat_settings_fk.sql`) and threaded through dozens of repository methods, a `user_chat_memberships` join table plus `MembershipService` and `MembershipRepository` were added, multi-instance dashboard/account switching exists (`landing/src/app/instances/`, `landing/src/app/webapp/instances/`), and a cross-tenant isolation hardening pass shipped recently (CHANGELOG `#511`/`#512`). This work landed under CHANGELOG entries like "Multi-account data layer" (`#231`), "Multi-account Phase 2b/3/4" (`#235`, `#236`, `#240`), and "Multi-tenant data model foundation" — not under this (missing) document. This master roadmap significantly understates how far multi-tenancy has progressed; a full re-scoping of this section/document is left to the lead.
 
 **Key Deliverables** (delivered):
 - Database-backed settings (`chat_settings` table) with `.env` fallback
@@ -277,6 +283,8 @@ Web-based analytics dashboard and management interface.
 - JWT authentication for API
 - Team-based access control
 - OAuth2 for third-party integrations
+
+> **Status correction, 2026-07-06**: this section is stale — multi-tenancy is not gated behind a future "Phase 5" anymore, it is already implemented today (see the Phase 2.5 status correction above). Telegram-based JWT-style session auth for the API exists now (`landing/src/app/api/auth/telegram/`), and tenant-scoped access control is enforced via `chat_settings_id` + `MembershipService`, not deferred to later phases. OAuth2 for third-party integrations remains genuinely future work (no Shopify/Printify/Gmail OAuth exists).
 
 ### Configuration Management
 
@@ -403,6 +411,8 @@ LLM Service → Email Drafts → Gmail
 
 **Archived** (completed phases):
 | [archive/01_instagram_api.md](../archive/01_instagram_api.md) | Instagram Graph API (✅ COMPLETE) |
+
+> ⚠️ **Broken link, verified 2026-07-06**: no `documentation/planning/archive/` directory exists in the repo, so this row's link is dead. The feature it describes (Instagram Graph API automation) is genuinely complete — see `documentation/ROADMAP.md` Phase 2 — but its write-up isn't recoverable at this path.
 
 ---
 

--- a/documentation/planning/phases/02_shopify_integration.md
+++ b/documentation/planning/phases/02_shopify_integration.md
@@ -4,6 +4,8 @@
 **Dependencies**: Phase 2 (Instagram API)
 **Estimated Duration**: 2-3 weeks
 
+> Status verified 2026-07-06 (documentation staleness audit): still PENDING. `grep -ril "shopify" src/` matches only a code comment in `src/models/api_token.py` (`# 'instagram', 'shopify'` — an example value documenting the `service_name` field, not an integration) plus similar doc comments in migrations 004/008/038. No `ShopifyService`, no `shopify_products`/`shopify_orders` tables, no webhook routes, and no tests exist anywhere in the codebase.
+
 ---
 
 ## Overview

--- a/documentation/planning/phases/03_printify_integration.md
+++ b/documentation/planning/phases/03_printify_integration.md
@@ -4,6 +4,8 @@
 **Dependencies**: Phase 3 (Shopify Integration)
 **Estimated Duration**: 2 weeks
 
+> Status verified 2026-07-06 (documentation staleness audit): still PENDING. No Printify code, models, tables, or tests exist anywhere in `src/` or `scripts/migrations/`. Consistent with its stated dependency on Phase 3 (Shopify), which is also still unimplemented (see `02_shopify_integration.md`).
+
 ---
 
 ## Overview

--- a/documentation/planning/phases/04_media_product_linking.md
+++ b/documentation/planning/phases/04_media_product_linking.md
@@ -4,6 +4,8 @@
 **Dependencies**: Phase 3 (Shopify), Phase 4 (Printify)
 **Estimated Duration**: 2-3 weeks
 
+> Status verified 2026-07-06 (documentation staleness audit): still PENDING. `src/services/domain/` — the module this doc's `MediaLinkingService`/`PerformanceAnalyticsService` would live in — contains only an empty `__init__.py`; no domain services of any kind exist yet. No `media_product_links` or `product_performance` tables in `scripts/migrations/`. Consistent with its stated dependencies (Phase 3 Shopify, Phase 4 Printify) both being unimplemented.
+
 ---
 
 ## Overview

--- a/documentation/planning/phases/05_llm_integration.md
+++ b/documentation/planning/phases/05_llm_integration.md
@@ -1,8 +1,12 @@
 # Phase 6: LLM Integration
 
-**Status**: 📋 PENDING
+**Status**: 📋 PENDING (see verification note — a narrow, unrelated Claude feature already ships in production)
 **Dependencies**: Phase 5 (Media-Product Linking)
 **Estimated Duration**: 3-4 weeks
+
+> Status verified 2026-07-06 (documentation staleness audit): the architecture specified in this doc — `LLMService` provider abstraction, `ClaudeProvider`/`OpenAIProvider`, `prompt_templates`/`llm_conversations`/`generated_content` tables, content-suggestion engine, hashtag suggestions, email draft generation — is 0% built. `src/services/domain/` (where `LLMService` would live) contains only an empty `__init__.py`.
+>
+> **Flagging for the lead**: a narrower, unrelated AI feature already exists in production — `src/services/core/caption_service.py` calls the Anthropic Claude API directly (module-level singleton client, no provider abstraction, no OpenAI support, no DB-backed prompt templates, no conversation logging) to auto-generate Instagram Story captions. It's gated by `ANTHROPIC_API_KEY` and a per-instance `enable_ai_captions` toggle (migration `026_add_ai_captions.sql`, CHANGELOG `#182`), and stores output on `media_items.generated_caption`. It does not implement any part of this doc's plan (wrong module, no abstraction layer, no prompt/conversation persistence, shipped without its stated dependency Phase 5 being done) and predates/bypasses this roadmap's sequencing. Left as PENDING rather than IN PROGRESS because it isn't a stepping-stone toward this specific architecture, but the lead should be aware it exists before scoping Phase 6 work.
 
 ---
 

--- a/documentation/planning/phases/06_order_email_automation.md
+++ b/documentation/planning/phases/06_order_email_automation.md
@@ -4,6 +4,8 @@
 **Dependencies**: Phase 3 (Shopify), Phase 6 (LLM Integration)
 **Estimated Duration**: 2-3 weeks
 
+> Status verified 2026-07-06 (documentation staleness audit): still PENDING. No `OrderNotificationService`, `GmailService`, or `EmailOrchestrationService` exist in `src/`, and no `email_threads`/`email_messages` tables exist in `scripts/migrations/`. The only "gmail" hits in the repo are a contact email address in `landing/src/config/site.ts` and `faqs.ts` marketing copy — not integration code. Consistent with its dependencies (Phase 3 Shopify, Phase 6 LLM) both still being unimplemented (see those docs).
+
 ---
 
 ## Overview

--- a/documentation/planning/phases/07_dashboard_ui.md
+++ b/documentation/planning/phases/07_dashboard_ui.md
@@ -1,8 +1,21 @@
 # Phase 8: Dashboard UI
 
-**Status**: 📋 PENDING
+**Status**: 🔧 IN PROGRESS (updated 2026-07-06 — was 📋 PENDING; see verification note)
 **Dependencies**: Phase 5 (Media-Product Linking), Phase 6 (LLM)
 **Estimated Duration**: 4-6 weeks
+
+> **Status updated 2026-07-06** (documentation staleness audit): changed from PENDING to IN PROGRESS. A real Next.js dashboard is live at `landing/src/app/(dashboard)/dashboard/` — Overview, Media Library (with Calendar and Reuse/Dead-Content sub-views), Analytics, Settings (General/Accounts/Integrations tabs), and a Setup Wizard — backed by `src/api/routes/onboarding/dashboard.py` and `DashboardService`. It genuinely covers parts of this doc's scope:
+> - **§8.1 Foundation & Auth**: Next.js + TypeScript + Tailwind + shadcn/ui (`landing/src/components/ui/`) all present. Telegram-based login is implemented and its flow is close to what this doc specifies almost verbatim — `landing/src/app/api/auth/telegram/route.ts` verifies the Telegram Login Widget signature and issues a signed session token, matching the doc's Authentication Flow section down to the endpoint name.
+> - **§8.2 Analytics Dashboard**: `dashboard/analytics` page exists; `recharts` is a real dependency.
+> - **§8.3 Media Library**: `dashboard/media` exists with filtering, pagination, and upload support via `POST /api/onboarding/upload-media`.
+>
+> However, this was **not built by executing this phase document** — it shipped as part of an undocumented multi-tenant / Telegram-Mini-App "onboarding" initiative (CHANGELOG entries `#231`, `#235`, `#236`, `#240`, `#244`, `#246`, `#253` — "Multi-account data layer", "instance picker", "dashboard switcher", etc.); nothing in that work references this doc. Notable divergences and gaps:
+> - **Architecture differs from spec**: auth/session is a Next.js BFF issuing its own JWT-style cookie (via `jose`), and most dashboard data fetching proxies server-side to the FastAPI "onboarding" API using signed Telegram `init_data` — not the generic bearer-JWT REST API (`/auth/telegram` + `/auth/refresh`, TanStack Query, Zustand) this doc specifies. TanStack Query and Zustand are not dependencies of `landing/`.
+> - **§8.4 Product & Performance does not exist at all** — no `/products`, `/orders`, or margin-analysis pages/routes anywhere, consistent with Shopify/Printify/Media-Linking (Phases 3-5) all still being unimplemented.
+> - **§8.5 Team & Settings is partial** — Settings exists, but there is no team activity feed/page, and the "integration status dashboard" only covers Google Drive + Instagram (`landing/src/components/dashboard/settings/integrations-tab.tsx`), not Shopify/Printify/Gmail, again because those don't exist. No prompt-template management UI (Phase 6 doesn't exist either).
+> - **Out-of-scope addition**: multi-instance/tenant switching (`landing/src/app/instances/`, `landing/src/app/webapp/instances/`, `landing/src/app/api/instances/`) sits alongside this dashboard and is entirely outside anything this doc anticipates.
+>
+> **Net**: treat this doc as superseded/partially-obsoleted by the actual onboarding-dashboard implementation for §8.1-8.3; §8.4 and the team portion of §8.5 remain accurate as a forward plan since nothing for them exists yet.
 
 ---
 

--- a/documentation/planning/web-app-migration-plan.md
+++ b/documentation/planning/web-app-migration-plan.md
@@ -1,8 +1,10 @@
 # Web App Migration Plan: Landing Site to Full Application
 
-**Status:** Draft — Pending Review
+**Status:** ✅ COMPLETED (substantially) — verified 2026-07-06 (see note below)
 **Created:** 2026-04-15
 **Goal:** Evolve the existing Next.js landing/teaser site into a full web application with auth, dashboard, settings, and media management — replacing most Telegram Mini App functionality while keeping Telegram as the action layer (approvals, quick decisions).
+
+> **Verification note (2026-07-06):** All three phases shipped: Phase 1 in `ee048a6` ("Web Dashboard Phase 1 — Telegram Auth, BFF Proxy, Dashboard Shell", #196), Phase 2 in `75e8599` (#201), Phase 3 in `5b9ae38` (#202), plus extensive follow-on polish throughout `CHANGELOG.md`. The "Current State" section below, which describes `landing/` as just a teaser site, is now historical — `landing/` **is** the full web app. Where the build diverged from this plan: the route group is `(dashboard)`, not `(app)`; the chat/workspace concept shipped as **"instances"** (`/instances`, `/api/instances`, an `Instance` type) rather than "workspace"; OAuth uses a popup window + `visibilitychange` polling (`openOAuthWindow` in `dashboard-api.ts`) instead of the dedicated `redirect_uri` + Next.js callback route from AD-2 / PR 2.2-2.3; and AD-5's "future consideration, not needed for Phase 1-3" `chat_members` table was actually built right away as `user_chat_memberships` (#231, 2026-05-19) and became the backbone of a much larger multi-account/multi-tenant system (#231-#267) — including the recent cross-tenant security fix's `MembershipService` (#511) — well beyond this plan's modest scope. Settings pages also consolidated into tabs on fewer routes rather than the many per-category routes sketched in PR 2.1-2.3.
 
 **Guiding Principle:** Web-first for management, Telegram-first for actions.
 


### PR DESCRIPTION
## Summary

Full documentation-lens audit across all 59 markdown files in the repo, checking every claim against the actual codebase, migrations, tests, and git history. No application code touched — every change in this PR is documentation.

- **Structure**: removed 11 dead links to `documentation/archive/` (purged 2026-04-28, #311, never fully scrubbed from the hub); relocated `multi-account-dashboard.md` out of a stray root-level `planning/` dir into `documentation/planning/`; retired `documentation/updates/` in favor of `CHANGELOG.md`; added `documentation/api/README.md` (the dashboard API had zero reference docs); indexed 7 planning docs that existed on disk but were never linked from the hub.
- **Reconciliation**: README.md/CLAUDE.md rewritten from single-tenant Phase 1/2 framing to the multi-tenant reality shipped since April; test count corrected 1,417 → 2,038 (verified via `pytest --collect-only`); `phases/07_dashboard_ui.md` corrected PENDING → IN PROGRESS; `multi-account-dashboard.md` corrected "Planning" → 29/33 checklist items verified built; migration count corrected 21 → 41 in three guides; stale/retired Telegram commands corrected in `cloud-deployment.md`.
- **Security**: `SECURITY_REVIEW.md` declared "Review Complete" on 2026-02-15. A critical cross-tenant IDOR existed after that review and wasn't fixed until 2026-06-28 (#511, #512, PR #519). Added a dated §11 addendum documenting the gap, the fix, and what's still open (role-based Telegram command authorization).

Five code-level findings surfaced while verifying doc claims (not doc bugs themselves) were filed separately, not fixed in this PR: #524, #525, #526, #527, #528.

## Test plan

- [x] Docs-only diff — no `src/`, `cli/`, or `landing/` files touched
- [x] CI's changelog-check exemption applies (all changed paths match `documentation/`, `*.md`, or `.github/`) — confirmed against `.github/workflows/ci.yml`'s docs-only skip logic
- [ ] Spot-check a few corrected claims against the live repo (test count, migration count, phase statuses)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wFDXwXP6eXstRYrR2wwmA