### PR TITLE
Add AGENTS.md with Cursor Cloud dev environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ startup caveats it intentionally does NOT handle.
 - Tests need `ENCRYPTION_KEY` (a Fernet key) in `.env.test`; a generated one is present.
 
 ### Running the services (use the `./venv`)
-- Lint (matches CI): `./venv/bin/ruff check src/ cli/` and `./venv/bin/ruff format --check src/ cli/`.
+- Lint (matches CI): `./venv/bin/ruff check .` and `./venv/bin/ruff format --check .`.
 - Tests: `./venv/bin/pytest` (auto-creates/drops `storydump_test`). ~2240 tests; a handful skip when optional integrations are absent.
 - FastAPI web: `./venv/bin/uvicorn src.api.app:app --host 0.0.0.0 --port 8000` → health at `GET /health`, OpenAPI at `/openapi.json`. Dashboard API under `/api/onboarding/*` requires Telegram WebApp `init_data` (HMAC-signed with `TELEGRAM_BOT_TOKEN`) + an active `UserChatMembership` for the `chat_id`.
 - Next.js landing/dashboard: `npm --prefix landing run dev` → http://localhost:3000 (dashboard BFF proxies to `BACKEND_URL`, the FastAPI service).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,32 @@
+# AGENTS.md
+
+General development guidance lives in `CLAUDE.md` (architecture, safety rules, CLI
+commands, testing). Read it first — its **CRITICAL SAFETY RULES** apply to all agents.
+
+## Cursor Cloud specific instructions
+
+This VM is provisioned for local development of the Python backend (worker + FastAPI
+web + `storydump-cli`) and the Next.js `landing/` site. The update script keeps the
+Python `venv` and `landing/` npm deps fresh; the notes below cover the non-obvious
+startup caveats it intentionally does NOT handle.
+
+### Safety (read `CLAUDE.md` first)
+- NEVER run the worker or any posting path: `python -m src.main`, `storydump-cli process-queue`, `create-schedule`, `reset-queue`, `instagram-auth`. These poll/post to Telegram/Instagram. Inspection commands (`list-*`, `check-health`, `index-media`, `validate-image`) are safe.
+
+### PostgreSQL (must be started each session — not auto-started)
+- Start the local cluster before anything that touches the DB:
+  `sudo pg_ctlcluster 16 main start`
+- Connection (already provisioned, matches `.env`): host `localhost`, db `storydump`, user `storydump_user`, password `storydump` (role has `CREATEDB`+`SUPERUSER` so the pytest suite can create/drop `storydump_test`).
+- If the role/db are ever missing, recreate with `make setup-db` after setting the same creds, then apply `scripts/setup_database.sql` + everything in `scripts/migrations/*.sql` in numeric order.
+
+### Environment files (gitignored — live only on the VM)
+- `.env`, `.env.test`, and `landing/.env.local` are already created and are NOT committed.
+- `src/config/settings.py` requires `TELEGRAM_BOT_TOKEN`, `TELEGRAM_CHANNEL_ID`, `ADMIN_TELEGRAM_CHAT_ID` even for the web service, CLI, and tests. Dummy values are set — only the worker (which we don't run) needs real Telegram credentials.
+- `.env.test` must keep `LOG_LEVEL=DEBUG`; with `WARNING` the logger drops INFO lines and `tests/src/utils/test_logger.py::test_logger_includes_timestamp` fails.
+- Tests need `ENCRYPTION_KEY` (a Fernet key) in `.env.test`; a generated one is present.
+
+### Running the services (use the `./venv`)
+- Lint (matches CI): `./venv/bin/ruff check src/ cli/` and `./venv/bin/ruff format --check src/ cli/`.
+- Tests: `./venv/bin/pytest` (auto-creates/drops `storydump_test`). ~2240 tests; a handful skip when optional integrations are absent.
+- FastAPI web: `./venv/bin/uvicorn src.api.app:app --host 0.0.0.0 --port 8000` → health at `GET /health`, OpenAPI at `/openapi.json`. Dashboard API under `/api/onboarding/*` requires Telegram WebApp `init_data` (HMAC-signed with `TELEGRAM_BOT_TOKEN`) + an active `UserChatMembership` for the `chat_id`.
+- Next.js landing/dashboard: `npm --prefix landing run dev` → http://localhost:3000 (dashboard BFF proxies to `BACKEND_URL`, the FastAPI service).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and documents the development environment for the Storydump monorepo (Python worker/FastAPI web/`storydump-cli` + Next.js `landing/` site) so future Cursor Cloud agents can start fresh and run lint, tests, and the applications.

The only committed change is a new `AGENTS.md`. All environment work (PostgreSQL install + cluster, Python `venv`, npm deps, gitignored `.env` files) lives on the VM / update script and is intentionally not committed.

## What was verified

| Surface | Command | Result |
|---|---|---|
| Lint | `./venv/bin/ruff check src/ cli/` + `ruff format --check` | ✅ All checks passed, 147 files formatted |
| Tests | `./venv/bin/pytest` | ✅ 2242 passed, 8 skipped |
| CLI (hello world) | `storydump-cli index-media media/stories` → `list-media` | ✅ 3 media items indexed into PostgreSQL, 70/30 category mix stored |
| FastAPI web | `uvicorn src.api.app:app --port 8000` | ✅ `GET /health` → 200; authed `/api/onboarding/system-status` → 200 with "Database connection OK" |
| Next.js landing | `npm --prefix landing run dev` | ✅ Homepage renders at :3000 |

## Notes

- Per `CLAUDE.md` safety rules, the worker / posting paths (`python -m src.main`, `process-queue`, etc.) were NOT run. Core functionality is demonstrated via the media-indexing pipeline (CLI → services → repositories → PostgreSQL) and the FastAPI dashboard API.
- The single pre-existing env-sensitive test (`test_logger_includes_timestamp`) requires `LOG_LEVEL=DEBUG` (as CI uses); documented in `AGENTS.md`. No code was modified.

[storydump_landing_site_demo.mp4](https://cursor.com/agents/bc-42870a2d-94bf-43ca-932e-5d5313099eae/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fstorydump_landing_site_demo.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42870a2d-94bf-43ca-932e-5d5313099eae?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42870a2d-94bf-43ca-932e-5d5313099eae&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

