### PR TITLE
fix(runner): a bounded adopt no longer reports 'no migration file' for files that exist (#755)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A bounded `adopt` reported "no migration file" for files that exist (#755)** — `adopt(..., max_version)` handed the *bounded* migration list to `_load_manifest`, which used it for two checks that ask questions at different scopes. The orphan check ("does every manifest key name a real file?") is a question about the **corpus**; asked against the replay window instead, every manifest entry above the bound was reported as having no migration file while the file sat in the tree, filtered out by the bound. Latent today — the manifest tops out at 049 and 051 carries postconditions rather than an entry — and it fires the moment F.2.2 gives a target migration a manifest entry, taking all four bounded `adopt` call sites with it.
+  - **The severity is the diagnostic, not the crash.** It answers a question nobody asked, confidently: the reader goes looking for missing files, finds them present, and stops believing the tool — at the moment they can least afford it.
+  - **The fix separates the two questions rather than narrowing one.** The probe requirement stays scoped to the **window** (adopt decides nothing about files outside it, and widening it would fail a legacy-lineage adopt because a *target* file has no probe yet — true, and about the wrong files); the orphan check reads the **corpus**. The bound now has one home, `_within`, so a caller holding the whole corpus derives the same window `discover_migrations` would have.
+  - **Chosen over the narrower form suggested on the issue** (filter the orphan list to the bound), which fixes the false report but also silences the check for an entry naming a genuinely absent file on every bounded run. Measured on the case that separates them: manifest names 009, no 009 in the tree, bounded — this fix reports it, the narrower one passes silently. Both forms are otherwise identical across the 17-test adopt suite.
+  - Four mutants killed, none inert, including the original defect and the narrower form.
+
 ### Added
 
 - **F.2.1b — the lineage lane, and the boundary that makes two lineages fit in one directory (#746)** — F.2.2's tables were blocked three independent ways, all of them downstream of one fact: both gate tests replay the whole migrations directory unbounded, so any file numbered 051+ joins both runs automatically with no opt-in. The target schema shares four table names with the legacy one (`users`, `media_items`, `onboarding_sessions`, `category_post_case_mix`), so the first target `CREATE TABLE` dies; and the 3c schema move that clears that collision is itself what breaks parity the other way, emptying `public` of the ~14 legacy tables whose models are still registered on `Base`. This increment lands the move, bounds the legacy lineage, and stands up the lane that replays across the boundary.

--- a/scripts/migration_runner.py
+++ b/scripts/migration_runner.py
@@ -192,8 +192,16 @@ def discover_migrations(migrations_dir, max_version: int | None = None) -> list:
             execution_mode=_execution_mode(no_transaction, statements),
             schema_move=schema_move,
         )
-    versions = sorted(v for v in by_version if max_version is None or v <= max_version)
-    return [by_version[v] for v in versions]
+    return _within([by_version[v] for v in sorted(by_version)], max_version)
+
+
+def _within(migrations, max_version: int | None):
+    """The replay window: files at or below ``max_version``, all of them if
+    unbounded. One home for the bound so a caller that already holds the whole
+    corpus derives the same window `discover_migrations` would have."""
+    if max_version is None:
+        return list(migrations)
+    return [m for m in migrations if m.version <= max_version]
 
 
 def schema_move_migration(migrations_dir):
@@ -482,10 +490,10 @@ class AdoptReport:
     already: list = field(default_factory=list)
 
 
-def _load_manifest(manifest_path, migrations):
+def _load_manifest(manifest_path, window, corpus):
     """The adoption manifest is a reviewed contract.
 
-    Every discovered file is paired with adoption evidence, one of:
+    Every file in the replay window is paired with adoption evidence, one of:
 
     - an explicit ``probe`` entry (SQL returning bool);
     - an explicit ``asserted`` entry (data-only files with no structural
@@ -493,6 +501,21 @@ def _load_manifest(manifest_path, migrations):
       floor trust is never the mechanism);
     - no entry at all, iff the file carries ``runner:postcondition`` lines —
       the probe derives from them, so the predicate has one home.
+
+    **The two checks below ask different questions and take different lists,
+    and conflating them is what made a bounded adopt lie** (#746 review). One
+    list serving both looks harmless until a bound exists:
+
+    - *unpaired* is a **window** question — "does everything I am about to
+      decide on have a probe?" Adopt decides nothing about files outside the
+      window, so demanding evidence for them would fail a legacy-lineage adopt
+      because a *target* file lacks a probe: true, and about the wrong files.
+    - *orphans* is a **corpus** question — "does every manifest key name a
+      real file?" Asked against the window instead, every entry above the
+      bound is reported as having *no migration file* when the file is right
+      there and was merely filtered out. That message sends an operator
+      looking for files that exist, which is worse than no message: it answers
+      a question nobody asked, confidently, mid-incident.
     """
     data = json.loads(Path(manifest_path).read_text())
     required_through = int(data["required_through"])
@@ -520,9 +543,9 @@ def _load_manifest(manifest_path, migrations):
         else:
             entries[version] = ("probe", (entry["probe"],))
 
-    by_version = {m.version: m for m in migrations}
+    in_corpus = {m.version for m in corpus}
     unpaired = []
-    for migration in migrations:
+    for migration in window:
         if migration.version in entries:
             continue
         if migration.postconditions:
@@ -535,7 +558,7 @@ def _load_manifest(manifest_path, migrations):
             " runner:postcondition lines to derive one from: "
             + ", ".join(f"{v:03d}" for v in unpaired)
         )
-    orphans = sorted(set(entries) - set(by_version))
+    orphans = sorted(set(entries) - in_corpus)
     if orphans:
         raise MigrationRunnerError(
             "adoption manifest names versions with no migration file: "
@@ -558,8 +581,9 @@ def adopt(
     about. The legacy ``schema_version`` table is never read; its known
     010/034 gaps are exactly the hazard this replaces.
     """
-    migrations = discover_migrations(migrations_dir, max_version)
-    required_through, entries = _load_manifest(manifest_path, migrations)
+    corpus = discover_migrations(migrations_dir)
+    migrations = _within(corpus, max_version)
+    required_through, entries = _load_manifest(manifest_path, migrations, corpus)
     report = AdoptReport()
     conn = _connect(dsn)
     try:

--- a/tests/scripts/test_migration_runner_adopt.py
+++ b/tests/scripts/test_migration_runner_adopt.py
@@ -187,6 +187,77 @@ class TestAdoptHardFailures:
             adopt(scratch_db, tmp_path, manifest)
 
 
+class TestAdoptUnderALineageBound:
+    """`max_version` selects a replay WINDOW out of a corpus that holds two
+    lineages (#746). The manifest is not windowed — it describes the whole
+    corpus — and the two manifest checks therefore ask questions at different
+    scopes. Answering both from the bounded list is what made adopt lie (#755).
+    """
+
+    def test_a_file_above_the_bound_is_not_reported_as_missing(
+        self, scratch_db, three_file_tree
+    ):
+        """THE REGRESSION. Bounded, the manifest's 002 and 003 were reported as
+        `no migration file` — while both files sat in the tree, filtered out by
+        the bound. An operator reads that and goes looking for files that are
+        already there, which costs more than no diagnostic: they find the files
+        present and stop believing the tool, mid-incident.
+        """
+        manifest = three_entry_manifest(three_file_tree)
+        execute(scratch_db, "CREATE TABLE adopted_one (id INT)")
+
+        report = adopt(scratch_db, three_file_tree, manifest, 1)
+
+        assert [m.version for m in report.adopted] == [1]
+        assert [m.version for m in report.pending] == []
+
+    def test_a_manifest_entry_with_no_file_is_still_reported_when_bounded(
+        self, scratch_db, tmp_path
+    ):
+        """The half a narrower fix loses. Silencing the orphan check *at* the
+        bound also silences it for an entry naming a file that genuinely does
+        not exist — the check stops asking its own question on every bounded
+        run. Pointing it at the corpus instead keeps the question intact and
+        makes the answer true: 009 is absent from the tree, bound or no bound.
+        """
+        write_migration(tmp_path, 1, "CREATE TABLE adopted_one (id INT);")
+        write_migration(tmp_path, 2, "CREATE TABLE adopted_two (id INT);")
+        manifest = write_manifest(
+            tmp_path,
+            1,
+            [
+                {"version": 1, "probe": probe_table("adopted_one")},
+                {"version": 9, "probe": "SELECT true"},
+            ],
+        )
+
+        with pytest.raises(MigrationRunnerError, match="009"):
+            adopt(scratch_db, tmp_path, manifest, 1)
+
+    def test_the_probe_requirement_stays_scoped_to_the_window(
+        self, scratch_db, three_file_tree
+    ):
+        """The other direction, and why the corpus is not simply handed to both
+        checks. "Every file needs adoption evidence" is a question about what
+        adopt is deciding on — it decides nothing above the bound. Widened to
+        the corpus, a legacy-lineage adopt would fail because a TARGET file has
+        no probe yet: true, and about the wrong files.
+
+        The contrast is in one test because the two calls differ in exactly one
+        argument.
+        """
+        manifest = write_manifest(
+            three_file_tree, 1, [{"version": 1, "probe": probe_table("adopted_one")}]
+        )
+        execute(scratch_db, "CREATE TABLE adopted_one (id INT)")
+
+        report = adopt(scratch_db, three_file_tree, manifest, 1)
+        assert [m.version for m in report.adopted] == [1]
+
+        with pytest.raises(MigrationRunnerError, match="002"):
+            adopt(scratch_db, three_file_tree, manifest)
+
+
 class TestAdoptTrustsProbesNotSchemaVersion:
     def test_legacy_schema_version_rows_are_ignored(self, scratch_db, three_file_tree):
         """The legacy self-stamp table contradicts the probes (its known


### PR DESCRIPTION
Closes #755.

mason found it reviewing #754 and rated it `minor` — correctly, it is latent today. ari overrode that to blocking on the grounds that it is **a lying diagnostic**, and I agree with the override: the failure mode is a reader going to look for files that are already there, while debugging a schema problem.

## The defect, reproduced before touching anything

```
files on disk: ['001_m.sql', '002_m.sql', '003_m.sql']
  bound=None: ok
  bound=1:    RAISED -> adoption manifest names versions with no migration file: 002, 003
```

Both files exist. They were filtered out by the bound. `#754` introduced the bounded path, so this is its debt to pay.

## The actual cause: one list, two questions, different scopes

`_load_manifest` received the **bounded** list and used it for both of its checks. They are not the same question:

| check | asks | correct scope |
|---|---|---|
| *unpaired* | "does everything I am about to decide on have a probe?" | the **window** — adopt decides nothing outside it |
| *orphans* | "does every manifest key name a real file?" | the **corpus** — the manifest describes the whole tree |

So the fix gives each check the list its own question needs, rather than narrowing one of them. The bound now has a single home (`_within`), so a caller holding the whole corpus derives exactly the window `discover_migrations` would have.

### Why not simply hand the corpus to both — measured, not assumed

That is the tempting one-line version, and it trades the lie for a coupling:

```
full corpus to both: RAISED -> migrations with neither an adoption-manifest entry
                               nor runner:postcondition lines to derive one from: 004
^ TRUE, but it fires on a LEGACY-lineage adopt because a TARGET file lacks a probe.
```

A legacy adopt would start failing on F.2.2's hygiene. Right answer, wrong files.

## Deviating from the fix specified on the issue — with the case that separates them

#755 suggests filtering the orphan list to the bound:

```python
orphans = sorted(v for v in set(entries) - set(by_version)
                 if max_version is None or v <= max_version)
```

That fixes the reported defect. It also silences the orphan check, on every bounded run, for an entry naming a file that **genuinely does not exist** — the check stops asking its own question rather than answering it correctly.

Measured on the one case that separates the two forms — manifest names `009`, no `009` in the tree, bounded:

| | this PR | the suggested form |
|---|---|---|
| manifest names 002/003, files **exist**, bounded | ok | ok |
| manifest names 009, file **absent**, bounded | **RAISED: 009** | ok — silently |
| unbounded, file absent | RAISED | RAISED |

I wired the suggested form's **literal expression** into the tree and ran the suite: **16 of 17 pass**, failing only the new discriminating test. It breaks nothing pre-existing — my first attempt at encoding it was unfaithful and would have overstated the difference, so this table is from the exact code in the issue.

Both forms are correct for the reported bug. This one keeps a check that the other retires.

> **If you are here to simplify this, read this line first.** The two-list signature
> looks like ceremony that a one-line filter would replace. It is not. Filtering the
> orphan list to the bound **trades a lying diagnostic for a silent blind spot**: the
> check stops reporting a manifest entry that names a genuinely absent file, on every
> bounded call, forever. That trade was considered and rejected deliberately (ari,
> reviewing #757), and `test_a_manifest_entry_with_no_file_is_still_reported_when_bounded`
> exists precisely to go red if someone makes it. Do not delete that test to make the
> simplification pass — it is the reason the shape is what it is.

## Verification

**Adopt suite: 14 → 17 passed.** Green on three separate isolated runs.

Four mutants, four killed, none inert:

| mutant | killed by |
|---|---|
| orphan check reads the window again (the #755 bug) | `test_a_file_above_the_bound_is_not_reported_as_missing` |
| the narrower suggested form | `test_a_manifest_entry_with_no_file_is_still_reported_when_bounded` |
| probe requirement widened to the corpus | `test_the_probe_requirement_stays_scoped_to_the_window` |
| orphan check deleted outright | the above + the pre-existing `test_manifest_entry_without_file_fails` |

### Coverage bound, stated plainly

**I could not get a clean local run of the full `tests/scripts/` suite, and it is the host rather than this branch.** Error counts across four consecutive runs: 2, 12, 4, 9 — different sets each time, all connection-loss and fixture-teardown shaped, landing in `test_lineage_lane.py` and `test_window_bootstrap.py`, neither of which this branch touches. What I found:

- **Another bot is running pytest against the same PostgreSQL instance** from a separate storydump checkout, concurrently. Postgres itself has not restarted (up since 08-08), so this is contention, not a crash.
- **The root `tests/conftest.py` creates, `pg_terminate_backend`s and drops a fixed-name database** (`storydump_test`, from settings). Two checkouts on one host collide on that name by construction — each session's teardown destroys the other's database.
- **`roleless_db` leaks the seven cluster-scoped service roles whenever a test errors mid-fixture.** Because they are cluster-scoped they outlive the run and poison the next one, so one failure begets the next. I found 5-of-7 and 7-of-7 leftover role sets plus orphaned scratch databases between runs, and purging them changed the results.
- Host load average 8+, ~500MB free of 16GB.

I am **not** claiming the fixed-name collision is the mechanism behind every failure — my failures were on randomly-named scratch databases that path does not touch, and I would rather report the measurement than a mechanism I have not pinned down.

What I can stand behind: the surface this PR changes passes cleanly and repeatedly in isolation, `tests/test_deploy_guardrails.py` passes (4), and CI — isolated container, dedicated postgres service — is the authority for the rest.

**CI has since come back green on all seven checks.** `Test` SUCCESS at 2m2s, and confirmed it actually ran rather than short-circuiting: **15 steps**, including `Initialize containers` (the `postgres:15` service) and `Run tests with coverage`. That settles it — the local instability was the host, not this branch.

The role-leak and shared-database-name findings are now filed as #758, with the blast radius and the false-PASS analysis.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
