### PR TITLE
test(#874): the indexing route test exercises the real sync — no-op replaced, red-under-revert demonstrated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **#874: the #873 route test now exercises the real `sync()` — or rather, its replacement does; the no-op is gone.** The predecessor asserted `sync`'s call arguments into a wholesale mock of the very service #872's bug lived in, so reverting the bug left it green — a test named for behavior it never exercised, reading as protection. The replacement runs the route against the REAL `MediaSyncService` (the service suite's own stubbed-`__init__` idiom supplies the mock floor one layer BELOW the defect, never above it) and asserts the boundary-resolved tenant at the repository seam. Demonstrated, not asserted: with the #872 discard reverted locally the test fails at exactly that assertion (`Expected: ('local', 'cs-test-1') / Actual: ('local', None)`), then greens with the fix restored — the evidence the wholesale-mock version structurally could not produce, and the check mutation testing cannot substitute for (a test with no coupling to the mutated layer never moves).
+
+### Fixed
+
 - **#872: `MediaSyncService.sync()` no longer discards its own `chat_settings_id` — "Sync Media Now" and onboarding indexing work again.** The tuple-unpack from `_resolve_source_config` rebound the parameter, so the tenant every route explicitly passed was silently replaced by the resolver's owner — `None` whenever source overrides were given, which is exactly how the routes call. Under the fail-closed repositories an explicit `None` scope raises, so every dashboard/onboarding sync 500'd. Pre-existing shape (present at the F.3 base; found by review on #866). The durable half is the test: the new service-level test asserts the property at the repository seam — the explicitly-passed tenant is the id every media mutation runs under, in the exact argument shape the routes use — and the route test now asserts `sync`'s call **arguments**, not merely its invocation, because a wholesale service mock sat exactly on top of the discard and made "2864 passed" structurally silent about it.
 
 ### Changed

--- a/tests/src/api/test_onboarding_routes.py
+++ b/tests/src/api/test_onboarding_routes.py
@@ -1,9 +1,10 @@
 """Tests for onboarding Mini App API endpoints."""
 
 import pytest
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 from tests.src.api.conftest import TENANT_ID, CHAT_ID, mock_validate, service_ctx
+from src.services.core.media_sync import MediaSyncService
 
 
 def _default_setup_state(**overrides):
@@ -436,26 +437,39 @@ class TestOnboardingMediaFolder:
 class TestOnboardingStartIndexing:
     """Test POST /api/onboarding/start-indexing."""
 
-    def test_indexing_runs_sync(self, client):
-        """Start indexing triggers MediaSyncService.sync() with chat config."""
-        mock_sync_result = Mock(
-            new=42, updated=0, unchanged=0, deactivated=0, errors=0, total_processed=42
-        )
+    def test_indexing_flows_the_tenant_through_the_real_sync(self, client):
+        """#874: the REAL ``sync()`` runs under this route — nothing mocks it
+        away — and the boundary's resolved tenant is asserted where it lands,
+        at the repository seam. The predecessor asserted call arguments into a
+        wholesale mock of the service, which stayed green with the #872 bug
+        reverted; this one goes red there (None reaches the seam), which is
+        the only evidence that separates a real test from that one. The mock
+        floor is the service suite's own idiom (stubbed ``__init__`` with
+        mocked repos), one layer BELOW the defect's layer, never above it."""
+        media_repo = Mock()
+        media_repo.get_active_by_source_type.return_value = []
+
+        def _stub_init(self):
+            self.media_repo = media_repo
+            self.set_result_summary = Mock()
+            self.track_execution = MagicMock()
+            self.track_execution.return_value.__enter__ = Mock(return_value="run-1")
+            self.track_execution.return_value.__exit__ = Mock(return_value=False)
+            self.close = Mock()
+
+        provider = Mock()
+        provider.is_configured.return_value = True
+        provider.list_files.return_value = []
 
         with (
             mock_validate(),
             patch("src.api.routes.onboarding.setup.SettingsService") as MockSettings,
-            patch("src.api.routes.onboarding.setup.MediaSyncService") as MockSync,
+            patch("src.services.core.media_sync.MediaSourceFactory") as MockFactory,
+            patch.object(MediaSyncService, "__init__", _stub_init),
         ):
-            # First SettingsService context: get_media_source_config
             settings_svc = service_ctx(MockSettings)
-            settings_svc.get_media_source_config.return_value = (
-                "google_drive",
-                "abc123",
-            )
-            # Second SettingsService context reuses same mock
-            sync_svc = service_ctx(MockSync)
-            sync_svc.sync.return_value = mock_sync_result
+            settings_svc.get_media_source_config.return_value = ("local", "/media")
+            MockFactory.create.return_value = provider
 
             response = client.post(
                 "/api/onboarding/start-indexing",
@@ -465,19 +479,12 @@ class TestOnboardingStartIndexing:
         assert response.status_code == 200
         data = response.json()
         assert data["indexed"] is True
-        assert data["new"] == 42
-        assert data["total_processed"] == 42
+        assert data["new"] == 0
         settings_svc.set_onboarding_step.assert_called_once_with(CHAT_ID, "indexing")
-        # Call ARGUMENTS, not just invocation (#872): this mock sits exactly
-        # on top of where sync() discarded its tenant — an invocation-only
-        # assertion was structurally silent about that.
-        sync_svc.sync.assert_called_once_with(
-            source_type="google_drive",
-            source_root="abc123",
-            triggered_by="onboarding",
-            telegram_chat_id=CHAT_ID,
-            chat_settings_id=TENANT_ID,
-        )
+        # The seam assertion — #872's property, entered through the route:
+        # the tenant the boundary resolved is the scope the real sync
+        # actually queried under.
+        media_repo.get_active_by_source_type.assert_called_once_with("local", TENANT_ID)
 
     def test_indexing_without_folder_returns_400(self, client):
         """Start indexing without a configured folder returns 400."""


### PR DESCRIPTION
Fixes #874. The judgment call the dispatch asked for, and why it went to **(a) exercise the real path** rather than delete:

## The decision

The no-op asserted `sync`'s call arguments into a wholesale mock of the service the #872 bug lived in — dead for that bug by construction (rajan's revert-stayed-green run is the proof). But deleting it would leave the route→service **seam** wholly unguarded: nothing would pin that the route's call shape agrees with the real signature and that the boundary-resolved tenant actually flows through, and that seam is exactly what the queued `Depends` refactor (#869) will churn. The F.1 lesson on this codebase is that call-shape bugs ship through thousands of green mock-based tests. So (a) — **if** the fixture stayed light.

It did: the replacement uses the service suite's own idiom (stubbed `__init__` supplying mocked repos + a patched `MediaSourceFactory`) threaded through the HTTP client — the mock floor sits one layer **below** the defect's layer, never above it. No new harness machinery; four patches, same as the no-op had. Had it needed more, this PR would be a deletion, per the dispatch.

## The demonstration (not an assertion)

Per the dispatch's standard — the #872 discard reverted locally, then restored:

```
=== new route test under the reverted bug ===
E   AssertionError: expected call not found.
E   Expected: get_active_by_source_type('local', 'cs-test-1')
E   Actual:   get_active_by_source_type('local', None)
```

Red **at the seam assertion, for the right reason** — the reverted rebinding sends `None` to the repository scope and the failure message names the property. Fix restored: green (73/73 across the route + media-sync suites). This is the evidence the wholesale-mock version structurally could not produce, and the check mutation testing cannot substitute for: with zero coupling to the mutated layer, the revert *is* the mutation and a no-op test never moves.

## Scope notes

- `test_sync_media_success` (settings route, added in #866) has the same wholesale-mock shape — argument assertions into a `MediaSyncService` mock. Alive for route-side regressions, dead for service-internal ones. Left alone deliberately: it is the AST-ratchet's population, not this instance's, and converting it here would be scope creep on a task ari sized as small.
- On the ratchet's home (asked for a view, not the work): storydump-local first, in the `scripts/` ratchet family beside `telegram_ratchet.py`/`fc8_gate.py` — the committed-predicate-as-code + equality-pinned-baseline pattern is already built there, and all five instances of the class surfaced in this repo. Promote the predicate to clauDNA once it has survived contact. The predicate design (argument assertions into a wholesale mock of the module a test claims to guard) is the hard part and deserves its own small spec round before code.

## Verification

- Full suite: **2905 passed, 8 skipped; 15 failed — all pre-existing** in L.0's `tests/src/services/target/test_unit_of_work.py`, reproduced identically on the pristine tree with this diff stashed (my change touches one route-test file + CHANGELOG). Presumably env-dependent local-vs-CI (#870 merged green); flagged in the report for routing, not chased here.
- Red-under-revert demonstrated above; restore re-verified.
- `ruff check` + `format`: clean. CI (3.10) is the arbiter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
