### PR TITLE
docs(m1): restate M1-02's two chat-conservation postconditions so neither assumes rule W (#790)

### DIFF
--- a/documentation/planning/2026-08-17-m1-transform-spec/README.md
+++ b/documentation/planning/2026-08-17-m1-transform-spec/README.md
@@ -127,6 +127,15 @@ SELECT count(*) AS chats,
 
 Nothing states how many workspaces the transform mints. §4.2 is written against a **minting rule W** = "one workspace per `chat_settings` row, `workspace_id := chat_settings.id`" — labeled as Fork D's obvious reading, **not** a ruling. At **`chats = 1` total** — the first count of §3.3's query, deliberately not `group_chats` — every candidate shape degenerates to the same transform, so §4.2's mapping stands regardless. The distinction is live, not theoretical: `.claude/rules/database.md` gives each Telegram chat its own settings row, so `chats > 1, group_chats = 1` is an ordinary state — and there a single DM-rooted row makes W mint two workspaces where a collapse shape mints one, so D does **not** collapse even though C does. If `chats` returns > 1, W is D's ruling to make (product owner — merging minted workspaces afterwards is `06` §4 clone-and-retire per account, on live data).
 
+**Restated 2026-08-21 — M1-02's postconditions no longer assume W.** The master identity used to
+be counted in workspaces, which is rule W's shape, and it stops balancing under a collapse:
+evaluated against the shipped target schema at production's two-chat shape it returns **`False`**.
+It is now a **partition over legacy chats** — every chat becomes a binding, a recorded drop, or a
+quarantine entry — which holds under either ruling without editing a character. §6's M1-02 block
+carries the lines and the reasoning. **This does not decide D**, and under a separate-workspace
+ruling the file needs more than a postcondition change: the shipped schema fails that shape for
+two independent reasons that are not about counting, both named in §6.
+
 **Addendum this spec surfaces (C-adjacent, for the C ruling to also cover; confirmed as a genuine menu addition in the #827 review):** `user_interactions` has **no tenant column at all** — only a raw, nullable `telegram_chat_id`. M1-09 resolves it via `legacy.chat_settings.telegram_chat_id`; rows with NULL or unresolvable chat ids have no workspace under any C option as written. Same class, one table further out; named here so the C ruling can say whether it covers them (until then they are a §5.2 feed). Also profiled: `chat_settings` rows with `telegram_chat_id > 0` (a DM-rooted tenant would be product-shaped — Fork D's territory, and the reason D's collapse keys on `chats`, not `group_chats`).
 
 ### 3.5 Fork E — live `recent` locks have no account (surfaced by this spec; menu, no pick)
@@ -398,13 +407,79 @@ Per file, the verbatim `-- runner:postcondition` lines (each a single-boolean SE
 
 **M1-02** (workspaces + members + bindings; owner invariant is *also* enforced by the deferred triggers at this file's commit — these make the arithmetic visible)
 ```
--- runner:postcondition SELECT (SELECT count(*) FROM workspaces) + (SELECT count(*) FROM <quarantine: rung-4 chats>) = (SELECT count(*) FROM legacy.chat_settings)   -- the master identity, M1-08's shape-general form (A1: term = 0; A2: term > 0 and the file completes green; A3: the halt). #827 Finding 3: the earlier hard-zero arm was the A1 instance only
--- runner:postcondition SELECT (SELECT count(*) FROM channel_bindings WHERE channel='telegram_group') = (SELECT count(*) FROM workspaces)   -- bindings track MINTED workspaces, so this holds under every A shape
+-- runner:postcondition SELECT NOT EXISTS (SELECT cs.telegram_chat_id::text FROM legacy.chat_settings cs EXCEPT (SELECT b.external_ref FROM channel_bindings b UNION SELECT d.external_ref FROM <recorded chat drops> d UNION SELECT q.external_ref FROM <quarantine: rung-4 chats> q))   -- THE MASTER IDENTITY, restated as a PARTITION over legacy chats: every chat becomes a binding, a recorded drop, or a quarantine entry. See "why this is no longer counted in workspaces" below
+-- runner:postcondition SELECT NOT EXISTS (SELECT b.external_ref FROM channel_bindings b EXCEPT SELECT cs.telegram_chat_id::text FROM legacy.chat_settings cs)   -- the other direction: no binding is invented. Without it the partition above is one-sided and a dropped chat cancels against a spurious binding
+-- runner:postcondition SELECT NOT EXISTS (SELECT 1 FROM workspaces w WHERE NOT EXISTS (SELECT 1 FROM channel_bindings b WHERE b.workspace_id = w.id))   -- replaces the bindings-1:1-to-workspaces check; see below for why that one had to go
 -- runner:postcondition SELECT NOT EXISTS (SELECT 1 FROM workspaces w WHERE NOT EXISTS (SELECT 1 FROM workspace_members m WHERE m.workspace_id = w.id AND m.role='owner'))
 -- runner:postcondition SELECT (SELECT count(*) FROM workspace_members) = (SELECT count(*) FROM legacy.user_chat_memberships WHERE is_active IS TRUE)   -- + deferred-chat term under A2 (a deferred chat defers its members with it)
 -- runner:postcondition SELECT (SELECT count(*) FROM audit_events WHERE actor_kind='migration' AND entity_kind='member' AND detail->>'transform_log'='membership_dropped_inactive') = (SELECT count(*) FROM legacy.user_chat_memberships WHERE is_active IS NOT TRUE)   -- + deferred-chat term under A2
 -- runner:postcondition SELECT (SELECT count(*) FROM workspaces WHERE tz='UTC' AND id IN (SELECT id FROM legacy.chat_settings WHERE posting_timezone IS NOT NULL AND fn_safe_tz(posting_timezone) <> posting_timezone)) = (SELECT count(*) FROM audit_events WHERE detail->>'transform_log'='tz_discarded')   -- both sides defer together under A2; holds under every A shape
 ```
+
+**Why the master identity is no longer counted in workspaces** (restated 2026-08-21; mason
+raised both of these against Fork D, and neither had been printed).
+
+The earlier form was `workspaces + rung-4 quarantine = legacy chat count`. It assumed one
+workspace per legacy chat — minting rule W, which §3.4 has always labelled Fork D's obvious
+reading rather than a ruling. **Under a collapse shape it stops balancing**: production has
+two legacy chats and one of them is a DM that mints no workspace of its own, so the identity
+reads `1 + 0 = 2`. Measured, not argued — evaluated against the shipped target schema with
+that shape built: **`False`**.
+
+What is actually conserved is not workspaces. **Every legacy chat becomes exactly one of
+three things: a binding, a recorded drop, or a quarantine entry.** That is a partition, and
+stating it as one is what the three lines above do.
+
+**The form is fork-independent, which is why it is written now rather than after the ruling.**
+It holds under a collapse shape (two bindings on one workspace, or one binding plus one
+recorded drop) and under separate-workspace minting (two bindings on two workspaces) without
+changing a character. Only the values it evaluates to depend on the ruling. **Under a
+separate-workspace ruling this postcondition is still not sufficient on its own** — the
+shipped schema fails that shape for reasons that are not about counting (a DM chat with zero
+memberships cannot satisfy `ct_workspaces_owner_at_insert`, and its history rows point at
+media owned by the other workspace, which the composite tenant FK makes inexpressible). That
+is a DDL question and it is deliberately not answered here.
+
+**It is a partition rather than a re-balanced count, and that is load-bearing.** A count
+identity balances whenever two errors cancel. Measured: drop the DM chat silently and mint one
+binding for a chat that does not exist in legacy, and the count form returns **`True`** while
+the set form returns **`False`**. A count that can be satisfied by two mistakes is not a
+conservation check.
+
+**Why the bindings check had to be replaced, and why it is the more dangerous of the two.**
+`count(bindings WHERE channel='telegram_group') = count(workspaces)` does **not fail** under a
+collapse shape — measured, it returns **`True`**. `ck_bindings_channel` admits `telegram_dm`
+as well, so a DM binding carried onto the group workspace is simply invisible to a predicate
+filtered on `telegram_group`. The check goes on passing while no longer conserving what it was
+written to conserve. A postcondition that breaks announces itself; one that goes quiet does
+not. Chat-to-binding conservation now lives in the partition above, and what remains here is
+the property that genuinely holds under every shape: **no minted workspace is binding-less**.
+
+**The rung-4 term stays, and stating why matters more than the line itself.** Under a collapse
+shape the DM mints no workspace, so on *this corpus* the owner-less-workspace failure does not
+arise. **That is a fact about this corpus and not about the design.** The ladder still has four
+rungs, rung 4 still has no adjudication procedure (Fork A), and production exercises neither
+rung 1 nor rung 2 — `m1_preflight` prints exactly that on every run. A chat with memberships
+that are all inactive still resolves to rung 4 under any Fork D shape. The term is therefore
+kept rather than dropped, and what keeps that honest is a test rather than this paragraph:
+`test_m1_ladder.py::TestEachRungIsReachedAndTakesPrecedence::test_rung4_quarantine_when_every_membership_is_inactive`
+seeds a chat whose every membership is inactive and asserts it still resolves to rung 4. It is
+marked `integration`, and CI runs `pytest tests/` with no marker filter, so it executes on every
+run regardless of which way Fork D is ruled.
+
+**A third line in this block is exposed to the same fork and is NOT restated here, because it
+is latent rather than live.** `count(workspace_members) = count(active legacy memberships)`
+assumes the two sides cannot collide. Under a collapse they can: `workspace_members` is keyed
+`(workspace_id, user_id)`, so a user holding a membership in *both* collapsed chats would
+produce one target row from two legacy rows and the count would come up short — a genuine
+failure, and one that reads as a miscount rather than as a collapse consequence.
+
+**Measured on production (read-only, 2026-08-21): zero users hold a membership in more than one
+chat.** One chat carries all three memberships; the DM carries none. So the identity holds at
+`3 = 3` under either ruling and there is nothing to fix today. It is named because the
+condition protecting it is a property of the *data*, not of the mapping — a second chat
+gaining a shared member before the window would make it live, and the same query re-run at
+window prep is what would catch that.
 
 **M1-03**
 ```

--- a/documentation/planning/2026-08-17-m1-transform-spec/README.md
+++ b/documentation/planning/2026-08-17-m1-transform-spec/README.md
@@ -408,7 +408,8 @@ Per file, the verbatim `-- runner:postcondition` lines (each a single-boolean SE
 **M1-02** (workspaces + members + bindings; owner invariant is *also* enforced by the deferred triggers at this file's commit — these make the arithmetic visible)
 ```
 -- runner:postcondition SELECT NOT EXISTS (SELECT cs.telegram_chat_id::text FROM legacy.chat_settings cs EXCEPT (SELECT b.external_ref FROM channel_bindings b UNION SELECT d.external_ref FROM <recorded chat drops> d UNION SELECT q.external_ref FROM <quarantine: rung-4 chats> q))   -- THE MASTER IDENTITY, restated as a PARTITION over legacy chats: every chat becomes a binding, a recorded drop, or a quarantine entry. See "why this is no longer counted in workspaces" below
--- runner:postcondition SELECT NOT EXISTS (SELECT b.external_ref FROM channel_bindings b EXCEPT SELECT cs.telegram_chat_id::text FROM legacy.chat_settings cs)   -- the other direction: no binding is invented. Without it the partition above is one-sided and a dropped chat cancels against a spurious binding
+-- runner:postcondition SELECT NOT EXISTS (SELECT ref FROM (SELECT b.external_ref AS ref FROM channel_bindings b UNION ALL SELECT d.external_ref FROM <recorded chat drops> d UNION ALL SELECT q.external_ref FROM <quarantine: rung-4 chats> q) buckets EXCEPT SELECT cs.telegram_chat_id::text FROM legacy.chat_settings cs)   -- NOTHING INVENTED: no bucket names a chat legacy never had. Covers all three buckets, not just bindings -- a drop recorded for a nonexistent chat is as wrong as a binding minted for one
+-- runner:postcondition SELECT NOT EXISTS (SELECT ref FROM (SELECT b.external_ref AS ref FROM channel_bindings b UNION ALL SELECT d.external_ref FROM <recorded chat drops> d UNION ALL SELECT q.external_ref FROM <quarantine: rung-4 chats> q) buckets GROUP BY ref HAVING count(*) > 1)   -- DISJOINT: no chat lands in two buckets. UNION ALL is load-bearing here -- UNION would dedupe the duplicate away and the check would pass on exactly what it exists to catch
 -- runner:postcondition SELECT NOT EXISTS (SELECT 1 FROM workspaces w WHERE NOT EXISTS (SELECT 1 FROM channel_bindings b WHERE b.workspace_id = w.id))   -- replaces the bindings-1:1-to-workspaces check; see below for why that one had to go
 -- runner:postcondition SELECT NOT EXISTS (SELECT 1 FROM workspaces w WHERE NOT EXISTS (SELECT 1 FROM workspace_members m WHERE m.workspace_id = w.id AND m.role='owner'))
 -- runner:postcondition SELECT (SELECT count(*) FROM workspace_members) = (SELECT count(*) FROM legacy.user_chat_memberships WHERE is_active IS TRUE)   -- + deferred-chat term under A2 (a deferred chat defers its members with it)
@@ -427,8 +428,23 @@ reads `1 + 0 = 2`. Measured, not argued — evaluated against the shipped target
 that shape built: **`False`**.
 
 What is actually conserved is not workspaces. **Every legacy chat becomes exactly one of
-three things: a binding, a recorded drop, or a quarantine entry.** That is a partition, and
-stating it as one is what the three lines above do.
+three things: a binding, a recorded drop, or a quarantine entry.**
+
+**Saying "partition" is a claim with three parts, and the first version of this section only
+made one of them.** A partition is exhaustive *and* disjoint *and* introduces nothing from
+outside the source set. The set-difference over legacy chats proves only the first. Both gaps
+were reachable — measured against the same modelled buckets:
+
+| defect | exhaustiveness alone | with the two lines added |
+|---|---|---|
+| a chat recorded as **both** a binding and a drop | **passes** | caught by the disjointness line |
+| a **drop recorded for a chat legacy never had** | **passes** | caught by the nothing-invented line |
+
+The earlier reverse-direction check was scoped to bindings, so the second row escaped it
+entirely: a phantom drop is exactly as wrong as a phantom binding and was not being looked
+for. `UNION ALL` rather than `UNION` in both lines is not stylistic — `UNION` would dedupe a
+double-bucketed chat away and the disjointness check would pass on the one thing it exists to
+catch.
 
 **The form is fork-independent, which is why it is written now rather than after the ruling.**
 It holds under a collapse shape (two bindings on one workspace, or one binding plus one


### PR DESCRIPTION
> **Replaces #953, which was branched off the unmerged #651-track branch by mistake and therefore carried #951's commit as well.** That made its diff `+637/-2` across three files instead of this one (`+93/-2`, a single file, after the `fa2066c` correction below), and — worse than the mis-labelling — merging it would have brought #951's content in without #951's own review. This branch is cut from `main` at `ae04fcd`; two-dot and three-dot diffs match, so the base is current and the scope is exactly the one file.
>
> **Where the two restatements actually live: this file, `documentation/planning/2026-08-17-m1-transform-spec/README.md` §6's M1-02 block.** The `tests/scripts/test_legacy_uniqueness_behaviour.py` that appeared in #953's file list is #654's uniqueness-behaviour gate (PR #951) and is unrelated to the bindings postcondition — it was dragged in by the branching error, not by this change.

---

Restates M1-02's two chat-conservation postconditions so neither assumes minting rule W. **Docs only. No ruling is assumed and nothing here decides Fork D.**

Both raised by mason against Fork D; neither had been printed. Both are the cheap-now / expensive-mid-window class — one-line-class rewrites while nothing is running, a stall if hit with the window open.

## 1. The master identity stops balancing

**Was:** `workspaces + rung-4 quarantine = legacy chat count`. That is rule W's shape — one workspace per legacy chat — which §3.4 has always labelled Fork D's *obvious reading*, not a ruling.

Under a collapse it does not balance: production has two legacy chats and one is a DM that mints no workspace of its own, so it reads `1 + 0 = 2`. **Evaluated against the shipped target schema with that shape built: `False`.** Measured, not argued.

**What is actually conserved is not workspaces.** Every legacy chat becomes exactly one of: a **binding**, a **recorded drop**, or a **quarantine entry**. That is a partition, and it is now stated as one.

### Written as a set equality, not a re-balanced count

A count identity balances whenever two errors cancel. Measured — drop the DM chat silently *and* mint one binding for a chat that does not exist in legacy:

| form | result |
|---|---|
| count form (`bindings + drops = chats`) | **`True`** — the two mistakes cancel |
| set form (partition) | **`False`** |

A count that can be satisfied by two mistakes is not a conservation check. The reverse direction is a separate line, because without it the partition is one-sided.

## 2. The bindings check — and it is the more dangerous of the two

**Was:** `count(bindings WHERE channel='telegram_group') = count(workspaces)`.

**It does not fail under a collapse. Measured, it returns `True`.** `ck_bindings_channel` admits `telegram_dm` as well, so a DM binding carried onto the group workspace is simply invisible to a predicate filtered on `telegram_group`. The check goes on passing while no longer conserving what it was written to conserve.

**A postcondition that breaks announces itself; one that goes quiet does not.** Chat-to-binding conservation moves into the partition above, and what remains here is the property that genuinely holds under every shape: **no minted workspace is binding-less**.

## Why this lands before the ruling

**The new form is fork-independent by construction.** It holds under a collapse (two bindings on one workspace, or one binding plus one recorded drop) and under separate-workspace minting (two bindings on two workspaces) **without editing a character**. Only the values it evaluates to depend on the answer — so writing it now assumes nothing.

**Under a separate-workspace ruling the file still needs more than a postcondition change**, and that part is deliberately *not* written here: the shipped schema fails that shape for two independent reasons that are not about counting — a DM chat with zero memberships cannot satisfy `ct_workspaces_owner_at_insert`, and its history rows point at media owned by the other workspace, which the composite tenant FK makes inexpressible. That is a DDL question and it is mason's hand-back, live only if the ruling comes back SEPARATE.

## The rung-4 hazard is not removed, and the wording is deliberate

Under a collapse the DM mints no workspace, so the owner-less-workspace failure does not arise **on this corpus**. **That is a fact about this corpus, not about the design.** The ladder still has four rungs, rung 4 still has no adjudication procedure (Fork A), and production exercises neither rung 1 nor rung 2 — `m1_preflight` prints exactly that on every run. A chat whose memberships are *all inactive* still resolves to rung 4 under any Fork D shape.

So the quarantine term is **kept**, not dropped. And what keeps that honest is a test rather than this paragraph: `test_m1_ladder.py::…::test_rung4_quarantine_when_every_membership_is_inactive`, `integration`-marked, and CI runs `pytest tests/` with no marker filter so it executes on every run regardless of the ruling.

## Flagged, not restated — a third line with the same exposure

`count(workspace_members) = count(active legacy memberships)` assumes the two sides cannot collide. Under a collapse they can: `workspace_members` is keyed `(workspace_id, user_id)`, so a user holding a membership in *both* collapsed chats yields one target row from two legacy rows and the count comes up short — failing in a way that reads as a miscount rather than as a collapse consequence.

**Measured on production (read-only, 2026-08-21): zero users hold a membership in more than one chat.** One chat carries all three memberships; the DM carries none. The identity holds at `3 = 3` under either ruling.

It is **named rather than restated** because it is latent, and because what protects it is a property of the **data**, not of the mapping — a second chat gaining a shared member before the window would make it live, and re-running that query at window prep is what catches it.


## Correction pushed as `fa2066c` — I called it a partition and it was a cover

ari named the property to attack: *a partition is only fork-independent if the buckets are exhaustive **and mutually exclusive** under both rulings.* I tested my own claim instead of restating it, and **the exclusivity half was the half I had not written.**

A partition is exhaustive **and** disjoint **and** introduces nothing from outside the source set. The set-difference over legacy chats proves only the first. Both remaining gaps were reachable — measured against the same modelled buckets:

| defect | with exhaustiveness alone | after `fa2066c` |
|---|---|---|
| a chat recorded as **both** a binding and a drop | **passes** | caught by the disjointness line |
| a **drop recorded for a chat legacy never had** | **passes** | caught by the nothing-invented line |

The earlier reverse-direction check was scoped to **bindings only**, so the second escaped it entirely — a phantom drop is exactly as wrong as a phantom binding and nothing was looking for it.

Two lines added: nothing-invented widened from bindings to all three buckets, plus a disjointness check. **`UNION ALL` rather than `UNION` in both is load-bearing** — `UNION` would dedupe a double-bucketed chat away and the disjointness check would pass on the one thing it exists to catch.

Verified across three cases: clean `t|t`, two-buckets `f|t`, phantom-drop `t|f`.

**This does not rescue the fork-independence claim by itself** — whether the three buckets are exhaustive and disjoint *under both rulings* is still the right thing for a reviewer to attack, and it is a question about the shape rather than about the SQL. What changed is that the SQL now actually asserts what the prose claimed.

---
## Verification

Every claim above marked *measured* was evaluated against the shipped target schema on a real replayed database, with the SAME shape constructed (one workspace, two bindings, two legacy chats):

- master identity as written → `False`
- bindings 1:1 as written → `True` (the quiet failure)
- proposed partition → `True`
- count-vs-set discriminator on a cancelling error → count `True`, set `False`
- both set-operator statements parse and behave (checked separately, since `EXCEPT` with a parenthesised `UNION` is easy to get wrong)

Refs: #790 · #943 (the measurements) · mason's `2026-08-21-leftover-rulings-batch-for-chris.md` q3/3b · astrid's build-path §7 row 6
